### PR TITLE
Require a maintainer's approval to merge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Who has to approve a change before it can reach main.
+#
+# This repository is public and its collaborator list is inherited from the
+# organisation, so a great many people can open and push branches. Merging is
+# deliberately narrower: `main` requires an approving review from an owner
+# listed here.
+#
+# Widening this list widens who can approve. Add people who know the codebase
+# well enough to say no.
+
+*  @davidmckayv @guidovizoso
+
+# Workflows are the supply chain. A change here runs with the repository's
+# credentials, so engineering reviews it alongside the owners above.
+/.github/workflows/  @CopilotKit/engineering @davidmckayv @guidovizoso


### PR DESCRIPTION
Adds `.github/CODEOWNERS` so the protection rule on `main` has owners to require an approval from.

The repository inherits ~30 collaborators from the organisation, around a dozen with write or admin. With `main` currently requiring 0 approving reviews, any of them could merge their own change with no internal review. That is fine for a private repository two people are building in a weekend, and wrong for a public one.

Merging this first, then raising the branch rule to require one code-owner approval, avoids locking the change out of its own gate.