### PR TITLE
Add Tyler and Mike as owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,10 @@
 # request and comment on one, which is the point of a public repository, and
 # can neither approve nor land it.
 #
+# Nobody can approve their own pull request, so this list needs enough people
+# that work does not stall when one of them is away.
+#
 # Adding a name here grants both powers. Add people who know this codebase well
 # enough to say no.
 
-*  @davidmckayv @guidovizoso
+*  @davidmckayv @guidovizoso @tylerslaton @MikeRyanDev


### PR DESCRIPTION
Adds `@tylerslaton` and `@MikeRyanDev` alongside `@davidmckayv` and `@guidovizoso`, and widens the merge restriction on `main` to match. All four are already admins on the repository.

Note for anyone copying from CopilotKit's CODEOWNERS: `@mme` there is Markus Ecker, not Mike Ryan. Mike is `@MikeRyanDev`.