### PR TITLE
Say what OpenBot is, and point at the page about it

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Give an agent a computer of its own: a browser, a filesystem and the tools you grant it, with every action decided before it happens and recorded after.**
 
-[**Quick start**](#quick-start) · [**Main surfaces**](#main-surfaces) · [**Features**](#features) · [**Bring your own agent**](#bring-your-own-agent) · [**Architecture**](#architecture) · [**Docs**](docs/README.md)
+[**copilotkit.ai/openbot**](https://copilotkit.ai/openbot) · [**Quick start**](#quick-start) · [**Features**](#features) · [**Bring your own agent**](#bring-your-own-agent) · [**Architecture**](#architecture) · [**Docs**](docs/README.md)
 
 [![CI](https://github.com/CopilotKit/openbot/actions/workflows/ci.yml/badge.svg)](https://github.com/CopilotKit/openbot/actions/workflows/ci.yml)
 [![security](https://github.com/CopilotKit/openbot/actions/workflows/security_zizmor.yml/badge.svg)](https://github.com/CopilotKit/openbot/actions/workflows/security_zizmor.yml)
@@ -31,6 +31,20 @@ keep the boundaries where they belong.
 > **Alpha, and under active development.** OpenBot is early. Expect rough edges and bugs, and expect things to move. Issues and pull requests are welcome.
 
 > **Runs on your machine.** Everything below is written for a laptop. Out of the box OpenBot runs with `OPENBOT_DEV_NO_AUTH`, which skips signing in and admits every request as one administrator. [Google sign-in](#sign-in-with-google) can be wired up instead.
+
+## What it is
+
+An agent platform that runs inside your own infrastructure. Docker Compose brings up every part of it, the data sits in your PostgreSQL, and the model is yours to choose: no model ships in the box, and an administrator supplies the credential, which is encrypted at rest and never logged.
+
+Three teammates ship in the example package, and they are configuration rather than code: **General Assistant** for everyday work, **Knowledge** for company questions, **Risk Analyst** for risk and compliance. Add your own by editing `agents.yaml` or from `/agents` in the UI.
+
+Anything a Bot does to a computer, a file, an MCP server or a component goes through one gateway that decides and records it. That is the difference between an agent that can use your tools and an agent you can let near them.
+
+More at [copilotkit.ai/openbot](https://copilotkit.ai/openbot).
+
+## Built on AG-UI
+
+A Bot is any endpoint speaking [AG-UI](https://github.com/ag-ui-protocol/ag-ui), the open protocol for agent-to-user interaction, so OpenBot is not tied to a framework and neither are you. Agents built with LangGraph, Mastra, CrewAI, Pydantic AI, Google ADK or written by hand all arrive the same way, and the governance rides the protocol rather than the framework.
 
 ## Requirements
 
@@ -237,6 +251,7 @@ Use `bash scripts/start.sh` for the whole stack. Use `bun run dev` only when you
 
 ## Documentation
 
+- [copilotkit.ai/openbot](https://copilotkit.ai/openbot)
 - [docs/README.md](docs/README.md)
 - [docs/architecture.md](docs/architecture.md)
 - [docs/configuration.md](docs/configuration.md)


### PR DESCRIPTION
Follow-on to #6, which merged before this landed.

Adds two sections the README was missing and links [copilotkit.ai/openbot](https://copilotkit.ai/openbot) from the header nav and the documentation list.

**What it is**: runs in your own infrastructure, your PostgreSQL, no bundled model and an admin-supplied credential that is encrypted and never logged. Names the three teammates that actually ship (General Assistant, Knowledge, Risk Analyst) as configuration rather than code.

**Built on AG-UI**: a Bot is any AG-UI endpoint, which is why agents nobody here wrote work with it, and why the governance rides the protocol rather than a framework.

Taken from the launch page and filtered against the code. Left out: the knowledge/citations story (retrieval is an in-memory map whose search ignores the question, and no embedder is called), Helm (no chart), six agent roles (three ship), conversations-in-Postgres (they are in Intelligence), and gateway-with-allowlist (the shipped default permits every host).