### PR TITLE
Lead with what is scarce, not with the mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # OpenBot
 
-**Give an agent a computer of its own: a browser, a filesystem and the tools you grant it, with every action decided before it happens and recorded after.**
+**AI teammates you can hand real work to, and actually trust with the access.** Each gets a computer of its own: a real browser with its own logins, its own files, and only the tools you grant. Every action decided before it happens and recorded after.
 
 [**copilotkit.ai/openbot**](https://copilotkit.ai/openbot) · [**Quick start**](#quick-start) · [**Features**](#features) · [**Bring your own agent**](#bring-your-own-agent) · [**Architecture**](#architecture) · [**Docs**](docs/README.md)
 
@@ -17,11 +17,11 @@ https://github.com/user-attachments/assets/535ef7ee-1631-4a69-b839-564c56cf90b4
 
 <div align="center">
 
-Bots are teammates you hand real work to. They sign in to apps and websites and
-use them the way you do, on a computer that stays theirs between sessions. Name
-one, give it a role, grant it access as it earns it, and talk to it in a
-channel. Bring any AG-UI agent, run the whole thing on your own machine, and
-keep the boundaries where they belong.
+Bring any AG-UI agent, written on a framework or by hand, and it arrives as a
+teammate with a channel of its own. Watch it work on its own screen, take the
+wheel when it reaches something it should not do alone, then hand it back. It
+answers with components rather than only prose, and the whole thing runs on
+your own machine.
 
 </div>
 


### PR DESCRIPTION
Replaces the bolded opening line, which was the weakest of the three places we describe OpenBot: it opened with an instruction ("Give an agent…"), spent its middle on a parts list, and said neither what the thing is nor why anyone should care. The GitHub About and the centred paragraph below both did that better.

**Before**
> Give an agent a computer of its own: a browser, a filesystem and the tools you grant it, with every action decided before it happens and recorded after.

**After**
> **AI teammates you can hand real work to, and actually trust with the access.** Each gets a computer of its own: a real browser with its own logins, its own files, and only the tools you grant. Every action decided before it happens and recorded after.

Everyone ships agents now, so "AI teammates" alone stops nobody. What is actually scarce is an agent you would hand real credentials to, so that goes in the first eight words and the mechanism follows as the reason it is safe.

Also reworks the centred paragraph. It opened with "Bots are teammates you hand real work to" and mentioned "a computer that stays theirs between sessions", which is the same claim as the new opening with only a video in between. It now carries what the opening cannot: bring any AG-UI agent, watch it work, take the wheel, components, runs on your own machine.

Every claim is one I have verified in the code.

**Note on #9:** that PR moves the architecture diagram out of this same region and uses the centred paragraph as context. No overlapping line is changed by both, but whichever lands second may want a quick rebase.