### PR TITLE
Let somebody talk to a Bot that is already working

### DIFF
--- a/app/src/components/channels/channel-chat.tsx
+++ b/app/src/components/channels/channel-chat.tsx
@@ -336,6 +336,13 @@ export function ChannelChat({
           copilotkit.stopAgent({ agent });
         }}
         pending={agent.isRunning}
+        /*
+         * A channel outlives its turns, so it is the screen where waiting is worth offering. A
+         * correction typed mid-answer is held here, in this tab, and runs as one follow-up turn the
+         * moment this one is over — including when it is over because somebody pressed the button
+         * above.
+         */
+        queueWhileBusy
       />
     </ConversationProvider>
   );

--- a/app/src/components/channels/channel-chat.tsx
+++ b/app/src/components/channels/channel-chat.tsx
@@ -141,6 +141,33 @@ export function ChannelChat({
   const [runError, setRunError] = useState<string | null>(null);
   const awaitingReply = useRef(false);
 
+  /*
+   * TWO DIFFERENT FACTS ABOUT ONE TURN, AND NEITHER OF THEM IS `agent.isRunning`.
+   *
+   * `turnsInFlight` counts what a person would call the Bot having the turn: from the moment `say`
+   * is entered until the whole thing has come back, browser actions in the middle included. It is
+   * what decides whether the next thing typed is sent or parked, and what tells the queue its wait
+   * is over.
+   *
+   * `runsInFlight` counts what Stop can actually reach: the run `copilotkit.runAgent` opens, and
+   * nothing before it. A turn can be in flight for a second and a half before that, while `say`
+   * waits for the runtime agent, and a Stop drawn in that window aborts a controller nobody has
+   * made yet.
+   *
+   * `agent.isRunning` looks like both and is neither. It reports the run on the wire, and a turn
+   * that touches the browser is several runs in a row: the Bot asks for a click, the run ENDS so
+   * the browser can answer it, and another run starts carrying the answer. The agent reports itself
+   * idle in every one of those gaps — the truth about the wire and a lie about the turn. OpenBot
+   * registers every computer tool as a frontend tool, so the gaps open on ordinary work rather than
+   * on some edge case, and anything keyed on the turn ending fires in the middle of one instead.
+   *
+   * Counters rather than booleans because nothing stops a second turn being started from a
+   * component button while the first is still going, and two overlapping turns must not have the
+   * first one to finish declare the conversation idle.
+   */
+  const [turnsInFlight, setTurnsInFlight] = useState(0);
+  const [runsInFlight, setRunsInFlight] = useState(0);
+
   /**
    * Tell the roster what was just said. Failures here must not block the conversation.
    */
@@ -159,12 +186,10 @@ export function ChannelChat({
   reportRef.current = report;
 
   /**
-   * Send a user turn through the channel, including activity reporting and history repair.
+   * Everything `say` does once it has something worth sending, split out so the counter it is
+   * wrapped in covers every way out of here, a throw included.
    */
-  const say = async (text: string, skillInstructions: string[] = []) => {
-    const trimmed = text.trim();
-    if (!trimmed) return;
-
+  const deliver = async (trimmed: string, skillInstructions: string[]) => {
     // Wait briefly for the runtime agent instance before adding the message.
     if (!isReadyRef.current) {
       await Promise.race([
@@ -211,7 +236,32 @@ export function ChannelChat({
       agent.setMessages(repaired as typeof agent.messages);
     }
 
-    await copilotkit.runAgent({ agent });
+    setRunsInFlight((count) => count + 1);
+    try {
+      await copilotkit.runAgent({ agent });
+    } finally {
+      setRunsInFlight((count) => count - 1);
+    }
+  };
+
+  /**
+   * Send a user turn through the channel, including activity reporting and history repair.
+   *
+   * Every user turn in this channel goes through here — what the composer sends, the seed from the
+   * compose screen, and a button inside a rendered component. That is what makes the counter worth
+   * keeping here rather than in the view: the view sees only the turns it started itself, and a
+   * queue that drains on the wrong one of those posts a correction into the middle of an answer.
+   */
+  const say = async (text: string, skillInstructions: string[] = []) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+
+    setTurnsInFlight((count) => count + 1);
+    try {
+      await deliver(trimmed, skillInstructions);
+    } finally {
+      setTurnsInFlight((count) => count - 1);
+    }
   };
 
   useEffect(() => {
@@ -335,7 +385,13 @@ export function ChannelChat({
           awaitingReply.current = false;
           copilotkit.stopAgent({ agent });
         }}
-        pending={agent.isRunning}
+        /*
+         * The turn, not the run. A browser action ends one run and starts another, and telling the
+         * conversation it is idle in between is what would drain a parked correction into the
+         * middle of an answer: a second turn racing the first on one thread, with a fabricated
+         * result stitched over a tool call that is still executing.
+         */
+        pending={agent.isRunning || turnsInFlight > 0}
         /*
          * A channel outlives its turns, so it is the screen where waiting is worth offering. A
          * correction typed mid-answer is held here, in this tab, and runs as one follow-up turn the
@@ -343,6 +399,12 @@ export function ChannelChat({
          * above.
          */
         queueWhileBusy
+        /*
+         * The run, not the turn. Stop reaches a run through the core's abort controller, and that
+         * controller does not exist until `say` has finished waiting for the runtime agent — so
+         * this is the one place the narrower fact is the honest one to draw a button from.
+         */
+        stoppable={agent.isRunning || runsInFlight > 0}
       />
     </ConversationProvider>
   );

--- a/app/src/components/channels/chat-transcript.tsx
+++ b/app/src/components/channels/chat-transcript.tsx
@@ -128,6 +128,13 @@ function Queued({
           <span role="status">Queued</span>
           {onRemove ? (
             <button
+              /*
+               * The sentence it deletes, in the name. Three parked corrections put three buttons
+               * called "Remove" in a row, and somebody reading by name alone is told what they can
+               * do and nothing about which one it would happen to. The visible word stays short
+               * because the bubble it sits under is the answer for everybody who can see it.
+               */
+              aria-label={`Remove queued message: ${text}`}
               className="ml-2 underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
               onClick={onRemove}
               type="button"
@@ -154,6 +161,14 @@ function Queued({
  * of the answer still streaming above it. It does fire when the bottom-most queued line is taken
  * back, which is a scroll nobody asked for and which lands on the end of the conversation anyway,
  * and it stays quiet on a drain, when the id goes to null.
+ *
+ * IT COSTS THE ANCHOR, AND THAT IS THE PRICE OF THE SCROLL RATHER THAN A SIDE EFFECT OF IT.
+ * `scrollToEnd` drops whatever turn the scroller was holding its position against and starts
+ * following the bottom instead, so the rest of that answer streams past under the reader rather
+ * than staying put beneath the question. Somebody who has just typed at the bottom of the
+ * conversation has asked to be at the bottom of the conversation, so following it is the reading
+ * they chose; but they chose it for the whole turn and not only for the moment, and the button
+ * back to the anchored view is the scroller's own, not ours to restore.
  *
  * Rendering nothing and living inside the provider is what buys access to the scroller at all; the
  * alternative is threading a ref out through three components with no other reason to know a

--- a/app/src/components/channels/chat-transcript.tsx
+++ b/app/src/components/channels/chat-transcript.tsx
@@ -7,7 +7,11 @@ import { Streamdown } from "streamdown";
 import { markdownComponents } from "@/lib/markdown";
 import { EASE_OUT, ENTRANCE_SECONDS } from "@/lib/motion";
 import { Bubble, BubbleContent } from "@/components/ui/bubble";
-import { MessageContent, Message as MessageRow } from "@/components/ui/message";
+import {
+  MessageContent,
+  MessageFooter,
+  Message as MessageRow,
+} from "@/components/ui/message";
 import {
   MessageScroller,
   MessageScrollerButton,
@@ -15,8 +19,10 @@ import {
   MessageScrollerItem,
   MessageScrollerProvider,
   MessageScrollerViewport,
+  useMessageScroller,
 } from "@/components/ui/message-scroller";
 import { toVisibleChatItems } from "./chat-messages";
+import type { QueuedMessage } from "./composer";
 import { ToolLine } from "./tool-line";
 import { ToolRenderBoundary } from "./tool-boundary";
 
@@ -25,7 +31,17 @@ type ChatTranscriptProps = {
   /** Comma-separated `/` command names, used to tell a skill chip from a leading slash. */
   commandNames?: string;
   messages: ReadonlyArray<Readonly<Message>>;
+  /**
+   * Typed while the Bot had the turn, and waiting for it to finish. Empty on a screen that does not
+   * offer queueing at all.
+   */
+  queued?: readonly QueuedMessage[];
+  /** Take one back before it runs. Without it a queued line is shown but cannot be undone. */
+  onRemoveQueued?: (id: string) => void;
 };
+
+/** One shared empty array, so a screen without a queue does not hand down a new one per render. */
+const EMPTY_QUEUE: readonly QueuedMessage[] = [];
 
 /**
  * Split a person's message into the skill they invoked and the rest of what they typed.
@@ -73,6 +89,87 @@ function Thinking() {
       Thinking
     </p>
   );
+}
+
+/**
+ * Something the person said while the Bot was working, waiting its turn.
+ *
+ * IT IS DRAWN AS THEIR MESSAGE, NOT AS A NOTICE ABOUT ONE. The whole point of letting somebody type
+ * mid-turn is that they can see their words landed, and a status line saying "1 message queued"
+ * does not do that — they would still be wondering whether the sentence they typed is the sentence
+ * that will run. So it is the same bubble, in the same column, with the same wrapping, and only two
+ * things say it has not run yet: it is faded, and it says so underneath.
+ *
+ * The footer carries the taking-back too, because that is where the reader's eye already is once
+ * they have decided this was a mistake, and because a control on the bubble itself would have to
+ * hover over the words it is offering to delete.
+ */
+function Queued({
+  text,
+  onRemove,
+}: {
+  text: string;
+  onRemove?: (() => void) | undefined;
+}) {
+  return (
+    <MessageRow align="end">
+      <MessageContent>
+        <Bubble align="end" className="opacity-60" variant="muted">
+          <BubbleContent>
+            {/* Shown exactly as typed, for the same reason a sent message is. */}
+            <span className="whitespace-pre-wrap">{text}</span>
+          </BubbleContent>
+        </Bubble>
+        <MessageFooter>
+          {/*
+           * `status` rather than `alert`, matching the thinking line: a person who has just chosen
+           * to queue something is not being interrupted by the news that it is queued.
+           */}
+          <span role="status">Queued</span>
+          {onRemove ? (
+            <button
+              className="ml-2 underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+              onClick={onRemove}
+              type="button"
+            >
+              Remove
+            </button>
+          ) : null}
+        </MessageFooter>
+      </MessageContent>
+    </MessageRow>
+  );
+}
+
+/**
+ * Put the newest queued message where the person who just typed it can see it.
+ *
+ * WITHOUT THIS THE AFFORDANCE IS INVISIBLE EXACTLY WHEN IT MATTERS. The scroller holds its anchor on
+ * the turn being answered rather than following the bottom, so during a long streamed answer the
+ * transcript sits a screen or so above the end — and a line appended below it lands off screen.
+ * Measured at the point somebody would actually use this: eighty-odd pixels under the fold, with
+ * the composer emptying at the same moment. They would have watched their correction vanish.
+ *
+ * Keyed on the newest queued id rather than on the list, so it does not fire again for every chunk
+ * of the answer still streaming above it. It does fire when the bottom-most queued line is taken
+ * back, which is a scroll nobody asked for and which lands on the end of the conversation anyway,
+ * and it stays quiet on a drain, when the id goes to null.
+ *
+ * Rendering nothing and living inside the provider is what buys access to the scroller at all; the
+ * alternative is threading a ref out through three components with no other reason to know a
+ * scroller exists.
+ */
+function ScrollNewestQueuedIntoView({ newest }: { newest: string | null }) {
+  const { scrollToEnd } = useMessageScroller();
+
+  useEffect(() => {
+    if (newest === null) {
+      return;
+    }
+    scrollToEnd();
+  }, [newest, scrollToEnd]);
+
+  return null;
 }
 
 /**
@@ -341,6 +438,8 @@ export function ChatTranscript({
   busy = false,
   commandNames = "",
   messages,
+  onRemoveQueued,
+  queued = EMPTY_QUEUE,
 }: ChatTranscriptProps) {
   /*
    * NOT MEMOISED, AND THAT IS DELIBERATE. `useMemo` keyed on `messages` looks obviously right and
@@ -436,9 +535,26 @@ export function ChatTranscript({
              * the scroller to measure and anchor something that exists for a second and a half.
              */}
             {waitingOnFirstToken ? <Thinking /> : null}
+            {/*
+             * Below the thinking line, and outside the item list for the same reason it is: these
+             * are not yet turns. They have ids of their own, but they are this tab's ids and not the
+             * thread's, so handing them to the scroller would ask it to anchor on something that is
+             * about to be replaced by a message with a different id — and the replacement is the
+             * one worth scrolling to.
+             */}
+            {queued.map((message) => (
+              <Queued
+                key={message.id}
+                onRemove={
+                  onRemoveQueued ? () => onRemoveQueued(message.id) : undefined
+                }
+                text={message.text}
+              />
+            ))}
           </MessageScrollerContent>
         </MessageScrollerViewport>
         <MessageScrollerButton />
+        <ScrollNewestQueuedIntoView newest={queued.at(-1)?.id ?? null} />
       </MessageScroller>
     </MessageScrollerProvider>
   );

--- a/app/src/components/channels/composer/composer.tsx
+++ b/app/src/components/channels/composer/composer.tsx
@@ -43,6 +43,20 @@ export type ComposerProps = {
    * structured data instead of something it would have to re-parse out of the text.
    */
   onSubmit?: (draft: ComposerDraft) => void | Promise<void>;
+  /**
+   * Park this message until the turn in flight is over, instead of refusing the keystroke.
+   *
+   * Its presence is what lets a person type at a Bot that is already working. Without it the
+   * composer goes on refusing mid-turn sends, which is still the right answer for a screen that has
+   * nowhere to put a parked message — the compose screen creates the channel on send and then
+   * navigates away, so anything parked there would be dropped on unmount, and a message that
+   * silently disappears is worse than a send button that visibly will not go.
+   *
+   * Called instead of `onSubmit`, not as well as it, and it does not return a promise: parking is
+   * a state change, and awaiting one would hold the composer's send lock for the length of somebody
+   * else's turn and block the next correction.
+   */
+  onQueue?: (draft: ComposerDraft) => void;
   /** Stop the Bot mid-answer; while pending, the send button becomes a stop button. */
   onStop?: () => void;
   /**
@@ -64,6 +78,7 @@ export function Composer({
   agents = [],
   commands = PLACEHOLDER_COMMANDS,
   onSubmit,
+  onQueue,
   onStop,
   disabled = false,
   pending = false,
@@ -107,13 +122,32 @@ export function Composer({
   const submitDraft = useCallback(
     async (segments: Segment[]) => {
       const submitted = toDraft(segments);
-      if (
-        submitted.isEmpty ||
-        disabled ||
-        isBusy ||
-        submitInFlight.current ||
-        !onSubmit
-      ) {
+      if (submitted.isEmpty || disabled) {
+        return;
+      }
+
+      /*
+       * A TURN IS IN FLIGHT, AND THIS IS THE FORK THE WHOLE AFFORDANCE HANGS ON.
+       *
+       * With somewhere to park it the message goes there and the box empties, so the person sees
+       * their words land. Without, we are back to refusing, which is what every caller that does
+       * not queue still gets.
+       *
+       * It returns before `submitInFlight` and `isSubmitting` are touched on purpose. Those guard
+       * one send from starting twice; a send here is held open for the length of the whole run, so
+       * borrowing them for a parked message would let the first turn lock out every correction
+       * typed while it worked — the exact thing this exists to allow.
+       */
+      if (isBusy) {
+        if (!onQueue) {
+          return;
+        }
+        setValue([]);
+        onQueue(submitted);
+        return;
+      }
+
+      if (submitInFlight.current || !onSubmit) {
         return;
       }
 
@@ -134,7 +168,7 @@ export function Composer({
         wantsFocus.current = true;
       }
     },
-    [disabled, isBusy, onSubmit],
+    [disabled, isBusy, onQueue, onSubmit],
   );
 
   /**
@@ -157,9 +191,33 @@ export function Composer({
     void submitDraft(value);
   };
 
-  const canSend = !disabled && !isBusy && !draft.isEmpty;
-  /** Stop is available only once the agent run is actually pending. */
-  const canStop = Boolean(onStop) && pending;
+  /**
+   * There is a turn in flight and somewhere to park what is being typed.
+   *
+   * Not the same question as "is anything typed" — an empty composer mid-turn can queue nothing,
+   * and the button it wants is Stop.
+   */
+  const canQueue = Boolean(onQueue) && isBusy && !disabled;
+  /** Something is typed, mid-turn, with a queue to put it in. */
+  const parking = canQueue && !draft.isEmpty;
+  const canSend = !disabled && !draft.isEmpty && (!isBusy || canQueue);
+  /**
+   * Stop is available only once the agent run is actually pending, and it gives way to Send the
+   * moment there is something typed to park.
+   *
+   * One button, so one of the two has to yield. Send wins because the correction is the thing that
+   * cannot wait: park it and the box empties, which brings Stop straight back — so stopping is
+   * never more than one press away, and the press before it is the one that saves the sentence.
+   * Showing both would be honest and would also put two round buttons in a row on a compact
+   * composer that has room for one.
+   */
+  const canStop = Boolean(onStop) && pending && !parking;
+  /**
+   * The same arrow either way, because it is the same gesture, but a screen reader is told which of
+   * the two it is about to do. "Send" on a button that will not send for another minute is a small
+   * lie told to exactly the people who cannot see the queue it lands in.
+   */
+  const sendLabel = parking ? "Queue message" : "Send message";
 
   if (compact) {
     return (
@@ -217,7 +275,7 @@ export function Composer({
           </Button>
         ) : (
           <Button
-            aria-label="Send message"
+            aria-label={sendLabel}
             className="size-8 rounded-full p-0"
             disabled={!canSend}
             size="icon"
@@ -271,7 +329,7 @@ export function Composer({
               </Button>
             ) : (
               <Button
-                aria-label="Send message"
+                aria-label={sendLabel}
                 className="size-7 rounded-full bg-primary p-0 disabled:cursor-not-allowed disabled:opacity-50"
                 disabled={!canSend}
                 type="submit"

--- a/app/src/components/channels/composer/composer.tsx
+++ b/app/src/components/channels/composer/composer.tsx
@@ -66,10 +66,23 @@ export type ComposerProps = {
    */
   disabled?: boolean;
   /**
-   * A run is in flight. It gates sending, not writing: a channel is `pending` while it is still
+   * A turn is in flight. It gates sending, not writing: a channel is `pending` while it is still
    * connecting and restoring its history, and the composer is on screen throughout.
    */
   pending?: boolean;
+  /**
+   * There is a run on the wire for Stop to reach.
+   *
+   * Not the same question as `pending`, and telling them apart is the whole reason this exists. A
+   * turn is in flight from the moment somebody presses send; the run it becomes does not exist
+   * until the caller has waited for whatever it has to wait for, which on a channel that is still
+   * joining is up to a second and a half. A Stop button drawn in that window aborts a controller
+   * nobody has made yet: the press is swallowed, the message goes anyway, and the one control the
+   * whole affordance leans on has quietly lied.
+   *
+   * Defaults to `pending`, which is the right answer for a caller with no gap between the two.
+   */
+  stoppable?: boolean;
 };
 
 export function Composer({
@@ -82,6 +95,7 @@ export function Composer({
   onStop,
   disabled = false,
   pending = false,
+  stoppable,
 }: ComposerProps) {
   const [value, setValue] = useState<Segment[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -202,8 +216,11 @@ export function Composer({
   const parking = canQueue && !draft.isEmpty;
   const canSend = !disabled && !draft.isEmpty && (!isBusy || canQueue);
   /**
-   * Stop is available only once the agent run is actually pending, and it gives way to Send the
-   * moment there is something typed to park.
+   * Stop is available only once there is a run for it to reach, and it gives way to Send the moment
+   * there is something typed to park.
+   *
+   * `stoppable` rather than `pending`, because a turn is in flight before its run is, and a button
+   * that cannot do the thing it names is worse than no button at all.
    *
    * One button, so one of the two has to yield. Send wins because the correction is the thing that
    * cannot wait: park it and the box empties, which brings Stop straight back — so stopping is
@@ -211,7 +228,7 @@ export function Composer({
    * Showing both would be honest and would also put two round buttons in a row on a compact
    * composer that has room for one.
    */
-  const canStop = Boolean(onStop) && pending && !parking;
+  const canStop = Boolean(onStop) && (stoppable ?? pending) && !parking;
   /**
    * The same arrow either way, because it is the same gesture, but a screen reader is told which of
    * the two it is about to do. "Send" on a button that will not send for another minute is a small

--- a/app/src/components/channels/composer/index.ts
+++ b/app/src/components/channels/composer/index.ts
@@ -6,5 +6,11 @@ export {
   type CommandOption,
   type ComposerDraft,
 } from "./draft";
+export {
+  type QueueAction,
+  type QueuedMessage,
+  type QueueTransition,
+  reduceQueue,
+} from "./queue";
 export { PLACEHOLDER_COMMANDS } from "./sources";
 export { type AgentOption, toAgentOptions } from "./triggers";

--- a/app/src/components/channels/composer/queue.test.ts
+++ b/app/src/components/channels/composer/queue.test.ts
@@ -35,18 +35,31 @@ describe("submitting", () => {
     expect(result.queue).toEqual([]);
   });
 
-  test("an idle send leaves an existing queue exactly where it was", () => {
-    // Not a state this reaches in the app, but the rule is about the message and not about the
-    // queue: nothing already waiting is disturbed by something that did not have to wait.
+  test("an idle send takes anything already waiting with it", () => {
+    // Not a state the app is supposed to reach, which is exactly why the rule has to hold here on
+    // its own: a new message that jumped the queue would run before the correction it corrects.
     const waiting = park([], "one", "no, the other one");
     const result = reduceQueue(waiting, {
       busy: false,
-      draft: draft("hello"),
+      draft: draft("the Q3 file"),
       id: "two",
       type: "submit",
     });
 
-    expect(result.queue).toBe(waiting);
+    expect(result.run?.text).toBe("no, the other one\nthe Q3 file");
+    expect(result.queue).toEqual([]);
+  });
+
+  test("an idle send that empties a queue carries its skills too", () => {
+    const waiting = park([], "one", "/search invoices", ["search"]);
+    const result = reduceQueue(waiting, {
+      busy: false,
+      draft: draft("/summarize it", ["summarize"]),
+      id: "two",
+      type: "submit",
+    });
+
+    expect(result.run?.commandIds).toEqual(["search", "summarize"]);
   });
 
   test("a send while the Bot is working waits instead of running", () => {

--- a/app/src/components/channels/composer/queue.test.ts
+++ b/app/src/components/channels/composer/queue.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test";
+import type { ComposerDraft } from "./draft";
+import { type QueuedMessage, reduceQueue } from "./queue";
+
+function draft(text: string, commandIds: string[] = []): ComposerDraft {
+  return { text, agentId: null, commandIds, isEmpty: false };
+}
+
+/** Park one message and hand back the queue it produced, which is what every case starts from. */
+function park(
+  queue: readonly QueuedMessage[],
+  id: string,
+  text: string,
+  commandIds: string[] = [],
+): readonly QueuedMessage[] {
+  return reduceQueue(queue, {
+    busy: true,
+    draft: draft(text, commandIds),
+    id,
+    type: "submit",
+  }).queue;
+}
+
+describe("submitting", () => {
+  test("an idle send goes straight out and queues nothing", () => {
+    const sent = draft("open the invoices page");
+    const result = reduceQueue([], {
+      busy: false,
+      draft: sent,
+      id: "one",
+      type: "submit",
+    });
+
+    expect(result.run).toBe(sent);
+    expect(result.queue).toEqual([]);
+  });
+
+  test("an idle send leaves an existing queue exactly where it was", () => {
+    // Not a state this reaches in the app, but the rule is about the message and not about the
+    // queue: nothing already waiting is disturbed by something that did not have to wait.
+    const waiting = park([], "one", "no, the other one");
+    const result = reduceQueue(waiting, {
+      busy: false,
+      draft: draft("hello"),
+      id: "two",
+      type: "submit",
+    });
+
+    expect(result.queue).toBe(waiting);
+  });
+
+  test("a send while the Bot is working waits instead of running", () => {
+    const result = reduceQueue([], {
+      busy: true,
+      draft: draft("no, the other one"),
+      id: "one",
+      type: "submit",
+    });
+
+    expect(result.run).toBeNull();
+    expect(result.queue).toEqual([
+      { id: "one", text: "no, the other one", commandIds: [] },
+    ]);
+  });
+
+  test("keeps the order they were typed in", () => {
+    let queue = park([], "one", "first");
+    queue = park(queue, "two", "second");
+    queue = park(queue, "three", "third");
+
+    expect(queue.map((message) => message.text)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+});
+
+describe("settling", () => {
+  test("a burst of corrections costs one turn, not three", () => {
+    let queue = park([], "one", "no, the other one");
+    queue = park(queue, "two", "the Q3 file");
+    queue = park(queue, "three", "and skip the summary");
+
+    const result = reduceQueue(queue, { type: "settle" });
+
+    expect(result.run?.text).toBe(
+      "no, the other one\nthe Q3 file\nand skip the summary",
+    );
+    expect(result.queue).toEqual([]);
+  });
+
+  test("stopping the Bot is what makes the correction run", () => {
+    // The whole of stop-then-steer. Nothing below says "stop": pressing it ends the turn, and the
+    // end of a turn is the only thing the drain is listening for.
+    const queue = park([], "one", "stop reading, just summarise it");
+
+    const result = reduceQueue(queue, { type: "settle" });
+
+    expect(result.run?.text).toBe("stop reading, just summarise it");
+    expect(result.queue).toEqual([]);
+  });
+
+  test("a turn ending with nothing waiting starts nothing", () => {
+    const result = reduceQueue([], { type: "settle" });
+
+    expect(result.run).toBeNull();
+    expect(result.queue).toEqual([]);
+  });
+
+  test("the drained turn is addressed to nobody in particular", () => {
+    const queue = park([], "one", "@Knowledge check that again");
+
+    // The mention stays in the words; the conversation is already bound to one coworker.
+    expect(reduceQueue(queue, { type: "settle" }).run?.agentId).toBeNull();
+  });
+
+  test("carries the skills that were invoked, once each", () => {
+    let queue = park([], "one", "/search invoices", ["search"]);
+    queue = park(queue, "two", "/search receipts too", ["search"]);
+    queue = park(queue, "three", "/summarize it", ["summarize"]);
+
+    expect(reduceQueue(queue, { type: "settle" }).run?.commandIds).toEqual([
+      "search",
+      "summarize",
+    ]);
+  });
+
+  test("draining twice does not resend what has already gone", () => {
+    const queue = park([], "one", "no, the other one");
+    const drained = reduceQueue(queue, { type: "settle" });
+
+    expect(reduceQueue(drained.queue, { type: "settle" }).run).toBeNull();
+  });
+});
+
+describe("removing", () => {
+  test("takes a message back before it runs", () => {
+    let queue = park([], "one", "no, the other one");
+    queue = park(queue, "two", "actually never mind");
+
+    const result = reduceQueue(queue, { id: "two", type: "remove" });
+
+    expect(result.queue.map((message) => message.text)).toEqual([
+      "no, the other one",
+    ]);
+    expect(result.run).toBeNull();
+  });
+
+  test("what is left is what still runs on settle", () => {
+    let queue = park([], "one", "keep this");
+    queue = park(queue, "two", "drop this");
+    queue = reduceQueue(queue, { id: "two", type: "remove" }).queue;
+
+    expect(reduceQueue(queue, { type: "settle" }).run?.text).toBe("keep this");
+  });
+
+  test("removing the last one leaves nothing to run", () => {
+    const queue = park([], "one", "second thoughts");
+    const left = reduceQueue(queue, { id: "one", type: "remove" }).queue;
+
+    expect(left).toEqual([]);
+    expect(reduceQueue(left, { type: "settle" }).run).toBeNull();
+  });
+
+  test("an id that is not in the queue changes nothing at all", () => {
+    // Same array, not an equal one: a removal that missed must not cost a re-render.
+    const queue = park([], "one", "no, the other one");
+
+    expect(reduceQueue(queue, { id: "elsewhere", type: "remove" }).queue).toBe(
+      queue,
+    );
+  });
+
+  test("two identical corrections are two entries and only one is taken back", () => {
+    let queue = park([], "one", "no, the other one");
+    queue = park(queue, "two", "no, the other one");
+
+    const result = reduceQueue(queue, { id: "one", type: "remove" });
+
+    expect(result.queue).toEqual([
+      { id: "two", text: "no, the other one", commandIds: [] },
+    ]);
+  });
+});

--- a/app/src/components/channels/composer/queue.ts
+++ b/app/src/components/channels/composer/queue.ts
@@ -1,0 +1,137 @@
+import type { ComposerDraft } from "./draft";
+
+/**
+ * What happens to a message typed while the Bot already has the turn.
+ *
+ * The composer used to refuse it. Enter did nothing, the words stayed in the box, and a person
+ * watching their coworker head off in the wrong direction had two options: stop the turn and start
+ * again, losing whatever it had already done, or wait for it to finish being wrong. Neither is the
+ * thing they wanted, which was to say "no, the other one" while it was working and have that land.
+ *
+ * So a message typed mid-turn is parked rather than dropped, and everything parked runs as ONE
+ * follow-up turn when the current one settles. One turn and not one per message, because three
+ * quick corrections are usually one correction typed in three breaths: replaying them separately
+ * makes the Bot answer the first, act on it, and only then read the sentence saying not to.
+ *
+ * Settling is not the same as succeeding. The drain is keyed on the turn ENDING and never asks how
+ * it ended, which is what makes Stop a way of steering rather than a way of giving up: park a
+ * correction, press Stop, and the correction is what runs next. Nothing here special-cases the stop
+ * button, and that is the point — a path with its own branch is a path that can be forgotten.
+ *
+ * THE QUEUE IS MEMORY IN ONE TAB AND NOTHING HERE PRETENDS OTHERWISE. The turn is driven from the
+ * browser, so the browser is the only place that knows one is in flight, and this state lives and
+ * dies with the tab holding it. A reload loses the intent to run these words later. The words are
+ * the person's own and sit on screen for as long as they wait, so nothing is being kept from
+ * anybody; but a queue is not an outbox and must not be read as one. It is drawn only while a turn
+ * is in flight, so a reload finds no queue and shows none, which is better than a list of messages
+ * quietly promising to run and never running.
+ */
+
+/** One message waiting for the Bot to finish, in the words the person typed. */
+export type QueuedMessage = {
+  /**
+   * Minted by the caller, because taking one back needs a handle that survives the list changing
+   * around it and the text will not do: two identical corrections are two entries.
+   */
+  id: string;
+  text: string;
+  /**
+   * The `/` chips that were in it, so a skill invoked mid-turn still applies when the message
+   * eventually runs rather than being silently dropped on the way through the queue.
+   */
+  commandIds: string[];
+};
+
+export type QueueAction =
+  /**
+   * Somebody pressed send.
+   *
+   * `busy` is supplied rather than worked out here. The composer is the only thing holding both
+   * halves of that answer — the parent's `pending` and its own send that has not resolved — and a
+   * second opinion computed somewhere else would disagree with it exactly during the moment between
+   * a send starting and the agent reporting itself as running, which is precisely when somebody
+   * typing fast needs the answer to be right.
+   */
+  | { type: "submit"; id: string; draft: ComposerDraft; busy: boolean }
+  /** The turn is over, however it ended: finished, failed, or stopped. */
+  | { type: "settle" }
+  /** Second thoughts, before it has run. */
+  | { type: "remove"; id: string };
+
+export type QueueTransition = {
+  /** The queue afterwards. The same array when nothing moved, so a render can be skipped. */
+  queue: readonly QueuedMessage[];
+  /** A turn to start now, or null when there is nothing to run. */
+  run: ComposerDraft | null;
+};
+
+/**
+ * The whole rule, as one pure function, so the interesting cases can be checked without a browser
+ * and a live model between the test and the behaviour.
+ */
+export function reduceQueue(
+  queue: readonly QueuedMessage[],
+  action: QueueAction,
+): QueueTransition {
+  switch (action.type) {
+    case "submit": {
+      // An idle send is not a queue of one. There is nothing to wait behind, so it goes straight
+      // out exactly as it did before any of this existed, and the queue is not involved at all.
+      if (!action.busy) {
+        return { queue, run: action.draft };
+      }
+      return {
+        queue: [
+          ...queue,
+          {
+            id: action.id,
+            text: action.draft.text,
+            commandIds: [...action.draft.commandIds],
+          },
+        ],
+        run: null,
+      };
+    }
+
+    case "settle": {
+      if (queue.length === 0) {
+        return { queue, run: null };
+      }
+      return { queue: [], run: joinQueued(queue) };
+    }
+
+    case "remove": {
+      const kept = queue.filter((message) => message.id !== action.id);
+      return {
+        queue: kept.length === queue.length ? queue : kept,
+        run: null,
+      };
+    }
+  }
+}
+
+/**
+ * Everything waiting, as the one turn it is about to become.
+ *
+ * Newlines rather than spaces. What the person typed were separate messages, and running them
+ * together into a paragraph invents a sentence nobody wrote; keeping the line breaks keeps them as
+ * lines of a single instruction, which is how a burst of corrections reads out loud anyway.
+ *
+ * Never empty. The composer refuses an empty draft before it reaches the queue, so a drained turn
+ * always has something in it to send.
+ */
+function joinQueued(queue: readonly QueuedMessage[]): ComposerDraft {
+  return {
+    text: queue.map((message) => message.text).join("\n"),
+    /*
+     * Nothing routes on a mention here. A queued message lands in a conversation already pinned to
+     * one coworker for the life of its thread, so there is nothing an `@` could change; the text of
+     * the mention stays in the words, where it was typed and where it still reads as addressed.
+     */
+    agentId: null,
+    // The same skill queued twice is still one instruction. Sending it twice would put the same
+    // paragraph in front of the Bot two times and say nothing new by doing it.
+    commandIds: [...new Set(queue.flatMap((message) => message.commandIds))],
+    isEmpty: false,
+  };
+}

--- a/app/src/components/channels/composer/queue.ts
+++ b/app/src/components/channels/composer/queue.ts
@@ -18,13 +18,17 @@ import type { ComposerDraft } from "./draft";
  * correction, press Stop, and the correction is what runs next. Nothing here special-cases the stop
  * button, and that is the point — a path with its own branch is a path that can be forgotten.
  *
- * THE QUEUE IS MEMORY IN ONE TAB AND NOTHING HERE PRETENDS OTHERWISE. The turn is driven from the
+ * THE QUEUE IS MEMORY IN ONE MOUNT AND NOTHING HERE PRETENDS OTHERWISE. The turn is driven from the
  * browser, so the browser is the only place that knows one is in flight, and this state lives and
- * dies with the tab holding it. A reload loses the intent to run these words later. The words are
- * the person's own and sit on screen for as long as they wait, so nothing is being kept from
- * anybody; but a queue is not an outbox and must not be read as one. It is drawn only while a turn
- * is in flight, so a reload finds no queue and shows none, which is better than a list of messages
- * quietly promising to run and never running.
+ * dies with the component holding it. A reload loses the intent to run these words later, and so
+ * does walking to another channel: the channel view is keyed on the channel, so switching unmounts
+ * the conversation and takes anything parked in it with it, after the person has watched their
+ * words land on screen. Neither is worth a persistence layer for words that only mean anything
+ * inside a turn that is already over by the time you come back, but both are worth saying out loud.
+ * The words are the person's own and sit on screen for as long as they wait, so nothing is being
+ * kept from anybody; but a queue is not an outbox and must not be read as one. It is drawn only
+ * while a turn is in flight, so a reload finds no queue and shows none, which is better than a list
+ * of messages quietly promising to run and never running.
  */
 
 /** One message waiting for the Bot to finish, in the words the person typed. */
@@ -75,10 +79,33 @@ export function reduceQueue(
 ): QueueTransition {
   switch (action.type) {
     case "submit": {
-      // An idle send is not a queue of one. There is nothing to wait behind, so it goes straight
-      // out exactly as it did before any of this existed, and the queue is not involved at all.
+      /*
+       * An idle send is not a queue of one. There is nothing to wait behind, so it goes straight
+       * out exactly as it did before any of this existed.
+       *
+       * WITH SOMETHING ALREADY WAITING IT TAKES THAT WITH IT rather than going first. The two
+       * disagreeing is not supposed to be reachable — the drain empties the queue on the same edge
+       * that frees the composer — but "not supposed to be reachable" is an argument about two
+       * components' timing, and this file is meant to hold the rule on its own. Jumping the line
+       * would run a correction after the sentence correcting it, which is the exact reordering the
+       * whole queue exists to prevent, so the safe reading of an impossible state is the one that
+       * keeps what the person typed in the order they typed it.
+       */
       if (!action.busy) {
-        return { queue, run: action.draft };
+        if (queue.length === 0) {
+          return { queue, run: action.draft };
+        }
+        return {
+          queue: [],
+          run: joinQueued([
+            ...queue,
+            {
+              id: action.id,
+              text: action.draft.text,
+              commandIds: [...action.draft.commandIds],
+            },
+          ]),
+        };
       }
       return {
         queue: [

--- a/app/src/components/channels/conversation-view.tsx
+++ b/app/src/components/channels/conversation-view.tsx
@@ -25,6 +25,7 @@ export function ConversationView({
   commands,
   disabled = false,
   pending = false,
+  stoppable,
   queueWhileBusy = false,
   onSubmit,
   onStop,
@@ -39,7 +40,21 @@ export function ConversationView({
    */
   commands?: readonly CommandOption[];
   disabled?: boolean;
+  /**
+   * A turn is in flight: the Bot has been asked something and has not come back yet.
+   *
+   * It has to mean the TURN and not the run underneath it. A turn that uses the browser is several
+   * runs in a row with the agent reporting itself idle between them, and a caller that passes its
+   * agent's run status straight through will tell this component the conversation is free in the
+   * middle of an answer. `queueWhileBusy` is the part that cannot survive that, because the queue
+   * drains on this falling.
+   */
   pending?: boolean;
+  /**
+   * There is a run for Stop to abort, which is a narrower fact than `pending` and is the honest one
+   * to draw a Stop button from. Defaults to `pending` for a caller with no gap between the two.
+   */
+  stoppable?: boolean;
   /**
    * Let somebody type at a Bot that is already working, and run what they typed when it finishes.
    *
@@ -47,6 +62,11 @@ export function ConversationView({
    * that will still be here when the turn ends. The compose screen creates the channel on send and
    * navigates away; a message parked there would go down with the unmount, and a message that
    * silently disappears is a worse answer than a send button that will not go.
+   *
+   * The other place somebody talks to a Bot, the direct `/bot` chat, does not get this either, and
+   * not by a decision made here: that screen draws CopilotKit's own chat rather than this composer,
+   * so there is nothing on it for this flag to reach. Giving it the same affordance means either
+   * moving it onto this composer or asking for it upstream, and neither is a queue.
    */
   queueWhileBusy?: boolean;
   onSubmit: (draft: ComposerDraft) => void | Promise<void>;
@@ -69,10 +89,17 @@ export function ConversationView({
   /**
    * A turn this screen started and has not seen finish.
    *
-   * `pending` alone will not do. It says the agent is running, and there is a gap between calling
-   * `onSubmit` and the agent reporting itself as running in which a person typing quickly would
-   * otherwise have their second message read as the start of a second turn — two runs at once, on
-   * the same thread, racing each other's history.
+   * It is a backstop under `pending` rather than the thing that makes `pending` usable. A caller
+   * that reports the turn honestly already covers the gap between `onSubmit` being called and the
+   * turn showing up in its own state; one that does not leaves a gap in which a person typing
+   * quickly would have their second message read as the start of a second turn, two runs at once on
+   * one thread racing each other's history.
+   *
+   * It cannot be the whole answer, and it was a mistake to let it look like one. This only knows
+   * about turns that came in through the composer. A channel starts turns by other routes — the
+   * first message of a new channel, a button inside a rendered component — and for those the only
+   * thing standing between a parked correction and a mid-answer drain is what the caller passes as
+   * `pending`.
    *
    * The composer tracks the same await for its own send button. Two trackers of one promise, which
    * is duplication, and they cannot drift: they rise in the same tick and fall on the same resolve.
@@ -138,9 +165,16 @@ export function ConversationView({
    * flight, and it believes that from the same value this effect reads. A queue that grew here
    * without a turn to wait for would be a queue that never drains, so if that ever becomes possible
    * this dependency list is where it will show up.
+   *
+   * IT REFUSES WHILE THE CONVERSATION IS DISABLED, which is the one thing "however it ended" must
+   * not be read to cover. A coworker deleted mid-turn takes the channel with it: the composer stops
+   * accepting messages and the notice under it says the conversation can no longer reply, and a
+   * queue that drained anyway would post one more user turn into a channel the screen has already
+   * said is finished. The cost is that anything parked when that happens stays on screen unrun,
+   * under a notice that explains why, which is the honest half of the trade.
    */
   useEffect(() => {
-    if (inFlight || queuedRef.current.length === 0) {
+    if (disabled || inFlight || queuedRef.current.length === 0) {
       return;
     }
     const run = apply({ type: "settle" });
@@ -152,7 +186,7 @@ export function ConversationView({
       // can put the words back in the box; there is no box to put these back into, and the screen
       // already reports a failed turn through its own notice.
     });
-  }, [apply, inFlight]);
+  }, [apply, disabled, inFlight]);
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -202,6 +236,13 @@ export function ConversationView({
            * turn instead of joining the queue.
            */
           pending={inFlight}
+          /*
+           * The caller's answer, not `inFlight`. `running` is true from the instant `start` is
+           * entered, which is before `onSubmit` has done anything at all, so a Stop drawn from
+           * `inFlight` appears while there is still nothing to stop — the press is swallowed and the
+           * message goes anyway.
+           */
+          stoppable={stoppable ?? pending}
         />
       </div>
     </div>

--- a/app/src/components/channels/conversation-view.tsx
+++ b/app/src/components/channels/conversation-view.tsx
@@ -1,11 +1,20 @@
 import type { Message } from "@ag-ui/core";
-import type { ReactNode } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { ChatTranscript } from "@/components/channels/chat-transcript";
 import {
   type AgentOption,
   type CommandOption,
   Composer,
   type ComposerDraft,
+  type QueueAction,
+  type QueuedMessage,
+  reduceQueue,
 } from "@/components/channels/composer";
 
 export function ConversationView({
@@ -16,6 +25,7 @@ export function ConversationView({
   commands,
   disabled = false,
   pending = false,
+  queueWhileBusy = false,
   onSubmit,
   onStop,
 }: {
@@ -30,10 +40,120 @@ export function ConversationView({
   commands?: readonly CommandOption[];
   disabled?: boolean;
   pending?: boolean;
+  /**
+   * Let somebody type at a Bot that is already working, and run what they typed when it finishes.
+   *
+   * Off by default, and asked for rather than assumed, because it is only true of a conversation
+   * that will still be here when the turn ends. The compose screen creates the channel on send and
+   * navigates away; a message parked there would go down with the unmount, and a message that
+   * silently disappears is a worse answer than a send button that will not go.
+   */
+  queueWhileBusy?: boolean;
   onSubmit: (draft: ComposerDraft) => void | Promise<void>;
   /** Stop the Bot mid-answer; forwarded to turn the send button into a stop button. */
   onStop?: () => void;
 }) {
+  /*
+   * THE QUEUE LIVES HERE BECAUSE BOTH HALVES OF IT DO.
+   *
+   * The composer is what knows a turn is in flight and is where a message is typed; the transcript
+   * is where the person has to be able to see that it landed. This is the nearest thing that owns
+   * them both, and putting the list in either one would mean handing it straight back out again.
+   *
+   * See `composer/queue.ts` for what this state is worth: it is memory in one tab, it does not
+   * survive a reload, and it is not an outbox.
+   */
+  const [queued, setQueued] = useState<readonly QueuedMessage[]>([]);
+  const queuedRef = useRef<readonly QueuedMessage[]>(queued);
+
+  /**
+   * A turn this screen started and has not seen finish.
+   *
+   * `pending` alone will not do. It says the agent is running, and there is a gap between calling
+   * `onSubmit` and the agent reporting itself as running in which a person typing quickly would
+   * otherwise have their second message read as the start of a second turn — two runs at once, on
+   * the same thread, racing each other's history.
+   *
+   * The composer tracks the same await for its own send button. Two trackers of one promise, which
+   * is duplication, and they cannot drift: they rise in the same tick and fall on the same resolve.
+   * The alternative is a callback out of the composer announcing an edge, which is a larger surface
+   * for the same fact.
+   */
+  const [running, setRunning] = useState(false);
+  const inFlight = pending || running;
+
+  /**
+   * Every change to the queue goes through here, so the ref and the state can never disagree.
+   *
+   * The ref is what the decisions read. React state is a render behind, and both callers below have
+   * to know what is actually queued at the moment they are called rather than at the moment they
+   * were last rendered — one of them is an effect firing on the same commit that emptied the list.
+   */
+  const apply = useCallback((action: QueueAction) => {
+    const next = reduceQueue(queuedRef.current, action);
+    queuedRef.current = next.queue;
+    setQueued(next.queue);
+    return next.run;
+  }, []);
+
+  const start = async (draft: ComposerDraft) => {
+    setRunning(true);
+    try {
+      await onSubmit(draft);
+    } finally {
+      setRunning(false);
+    }
+  };
+  /** Read through a ref so an inline `onSubmit` from the route does not re-run the drain effect. */
+  const startRef = useRef(start);
+  startRef.current = start;
+
+  /**
+   * Send now, or park it. Which one is the composer's call: it holds the only accurate view of
+   * whether a turn is in flight, and `reduceQueue` holds what follows from the answer.
+   */
+  const submit = useCallback(
+    (draft: ComposerDraft, whileBusy: boolean) => {
+      const run = apply({
+        busy: whileBusy,
+        draft,
+        id: crypto.randomUUID(),
+        type: "submit",
+      });
+      return run ? startRef.current(run) : undefined;
+    },
+    [apply],
+  );
+
+  /**
+   * The turn ended. Whatever was waiting for it goes now, as one message.
+   *
+   * KEYED ON THE TURN BEING OVER AND NOT ON HOW IT ENDED, which is what makes Stop useful rather
+   * than final: a person who parks a correction and then presses Stop has said "not that, this",
+   * and this is the line that hears the second half of it. A finished run, a failed one and a
+   * stopped one all arrive here the same way, so there is no stop path to forget.
+   *
+   * The one edge it watches is `inFlight` falling, and it does not watch the queue. Nothing can be
+   * parked while the conversation is idle: the composer only parks when it believes a turn is in
+   * flight, and it believes that from the same value this effect reads. A queue that grew here
+   * without a turn to wait for would be a queue that never drains, so if that ever becomes possible
+   * this dependency list is where it will show up.
+   */
+  useEffect(() => {
+    if (inFlight || queuedRef.current.length === 0) {
+      return;
+    }
+    const run = apply({ type: "settle" });
+    if (!run) {
+      return;
+    }
+    void startRef.current(run).catch(() => {
+      // Swallowed on purpose, and only here. A failed send from the composer throws so the composer
+      // can put the words back in the box; there is no box to put these back into, and the screen
+      // already reports a failed turn through its own notice.
+    });
+  }, [apply, inFlight]);
+
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <div className="flex flex-1 min-h-0">
@@ -51,6 +171,10 @@ export function ConversationView({
             .map((command) => command.name)
             .join(",")}
           messages={messages}
+          onRemoveQueued={(id) => {
+            apply({ id, type: "remove" });
+          }}
+          queued={queued}
         />
       </div>
       <div className="max-w-2xl mx-auto w-full px-0 pb-4 shrink-0">
@@ -61,9 +185,23 @@ export function ConversationView({
           className="w-full mt-auto"
           compact
           disabled={disabled}
+          onQueue={
+            queueWhileBusy
+              ? (draft) => {
+                  submit(draft, true);
+                }
+              : undefined
+          }
           onStop={onStop}
-          onSubmit={onSubmit}
-          pending={pending}
+          onSubmit={(draft) => submit(draft, false)}
+          /*
+           * `inFlight` rather than the `pending` this was given. A drained turn is started from the
+           * effect above rather than from the composer, so the composer's own send tracking knows
+           * nothing about it — told only `pending`, it would believe the conversation was idle for
+           * as long as the drained run took to start, and the next thing typed would open a third
+           * turn instead of joining the queue.
+           */
+          pending={inFlight}
         />
       </div>
     </div>


### PR DESCRIPTION
![Let somebody talk to a Bot that is already working](https://raw.githubusercontent.com/jerelvelarde/openbot/pr-media/gifs/openbot-queue-and-steer.gif)

## The problem

Typing into a channel while the Bot had the turn did nothing. The composer stayed writable, took the keystrokes, then silently refused the send: `submitDraft` returned early whenever a run was in flight, and the round button had already become Stop. The words sat in the box with no way out of it.

That leaves somebody watching their coworker head off in the wrong direction with two bad options: press Stop and lose whatever the turn had already done — the pages it read, the tool calls it made, the half of the answer that was right — or wait for it to finish being wrong. The longer the turn, the worse that trade, which is backwards. What people actually do is talk over it, saying "no, the other one" while it works. The product had no way to hear that.

## The approach

A message typed mid-turn is now parked rather than dropped. It appears in the transcript straight away as the person's own bubble, faded, with `Queued` and a `Remove` underneath. When the turn ends, everything parked runs as one follow-up turn with the texts joined by newlines. Three corrections cost one turn, not three: replayed separately, the Bot would answer the first, act on it, and only then read the sentence saying not to.

The rule is one pure reducer, `app/src/components/channels/composer/queue.ts` — `submit` (which takes a `busy` flag), `settle`, `remove`. Nothing jumps the line: an idle send arriving with words already waiting runs them together in typed order. The drain is keyed on the turn ending and never asks how it ended, which is what makes Stop a way of steering rather than of giving up. It refuses in one case, a disabled conversation, because a coworker deleted mid-turn takes the channel with it; parked words then stay on screen unrun, under the notice explaining why.

**Knowing when the turn is over is the hard half.** `agent.isRunning` reports the run on the wire, and a turn that touches the browser is several runs in a row: the Bot asks for a click, the run ends so the browser can answer, another run starts carrying the answer. OpenBot registers every computer tool as a frontend tool, so those gaps open on ordinary work. A queue keyed on them drains mid-answer: a second turn races the first on one thread, and the history repair covers a still-executing tool call with a fabricated "produced no result", which providers refuse as two results for one call. The turn is therefore counted at the one funnel every user turn passes through, `ChannelChat`'s `say`. `ConversationView`'s own send tracking survives as a backstop only, since it sees composer sends and not the compose screen's seed or a button inside a rendered component.

**Stop is counted separately**, around `copilotkit.runAgent` alone, because it reaches a run through the core's abort controller and that controller does not exist until `say` has finished waiting for the runtime agent — up to a second and a half on a channel still joining. Drawn from the turn, Stop appeared in that window, aborted nothing, and let the message go anyway. The composer takes the two facts as two props, `pending` and `stoppable`.

The queue is held by `ConversationView`, the nearest component owning both the composer and the transcript, and it is memory in one mount: a reload loses it, and so does walking to another channel. It is drawn only while a turn is in flight, so a reload finds nothing rather than a list quietly promising to run and never running.

Three smaller tradeoffs:

- **One button, and Send wins.** Mid-turn with something typed, the round button is Send, labelled "Queue message" to a screen reader; with the box empty it is Stop, and only once there is a run to reach. Parking empties the box, so Stop comes straight back.
- **Queueing is opt-in per screen.** `/channel/new` creates the channel on send and navigates away, so anything parked there would go down with the unmount. It is a `queueWhileBusy` prop, off by default.
- **Parking scrolls the transcript to the end**, because the new line otherwise lands off screen — measured at eighty-odd pixels under the fold. The cost is the scroller's anchor for the rest of that turn.

## What is not covered

- **The direct `/bot` chat**, which renders the SDK's own `CopilotChat` rather than this composer.
- **The compose screen `/channel/new`**, deliberately, for the unmount reason above.
- **Durability.** No persistence, no sync between tabs, no recovery after a reload, a channel switch or a crash.
- **A disabled conversation.** If the coworker is deleted mid-turn, parked messages never run.
- **Editing or reordering.** A queued message can be removed and retyped, not edited in place or moved.
- **A per-message `@mention` on a drained turn** is dropped, as it already is on every message in a channel, which is pinned to one coworker for the life of its thread.
- **Component-level tests.** There is no DOM harness in the repository, so the rendering, the Stop path and the scroll behaviour were checked by hand in a browser against a live Bot.
- **Anything on the server.** No schema, migration or audit changes.

## Verification

All gates run from a clean tree on the branch head:

- `bun run format` and `bun run format:check` — clean, no fixes applied
- `bun run lint` — exit 0; 24 warnings, all pre-existing elsewhere in the repo, none in the files this branch touches
- `bun run typecheck` — app, server and worker all exit 0
- `bun run test` — 605 pass, 5 skip, 0 fail across 70 files. Upstream main's baseline is 594, so this branch adds 16; the skips are pre-existing
- `bun run build` — exit 0

The 16 are one new file, `app/src/components/channels/composer/queue.test.ts`, which holds the queue rule down without a browser or a model in the loop: newline joining in typed order, settling however the turn ended, a second settle resending nothing, removal taking back exactly one entry, skills surviving once each, and an idle send taking a waiting queue with it.

## Merge notes

`feat/agent-stream-stall-watchdog` changes the same three files, adding a `stopped` prop to `ConversationView`, threading it into `ChatTranscript`, and editing the same `<ConversationView>` element in `channel-chat.tsx`. One conflict there is not textual: that branch leaves `pending={agent.isRunning}` where this one passes `pending={agent.isRunning || turnsInFlight > 0}` and adds `stoppable`. Whichever lands second must keep the counted form, because `agent.isRunning` alone goes false between the runs of a browser-using turn.
