### PR TITLE
Let Google sign-in trust the port the app actually uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ GOOGLE_OAUTH_CLIENT_SECRET=
 
 Then set the two that decide who gets in and from where:
 
-- `TRUSTED_ORIGINS` — where the app is served from, `http://localhost:3010` locally. It defaults to `http://localhost:3000`, which is not where `start.sh` serves the app.
+- `TRUSTED_ORIGINS` — where the app is served from. Unset, that is `http://localhost:3010`, which is where `start.sh` serves the app.
 - `INITIAL_ADMIN_EMAILS` — comma separated. An address listed here becomes an administrator the first time it signs in; everybody else becomes a user.
 
 Remove `OPENBOT_DEV_NO_AUTH`, then restart: the sign-in button is written into the app's generated config at startup, so it appears only once all four settings are present. Accounts, sessions and roles are stored in the same PostgreSQL database as everything else.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,7 +86,7 @@ Two things are worth knowing before pointing a deployment at any gateway. Not ev
 | `GOOGLE_OAUTH_CLIENT_SECRET` | Google OAuth client secret.                                                            |
 | `BETTER_AUTH_SECRET`         | At least 32 characters. Required with Google OAuth.                                    |
 | `BETTER_AUTH_URL`            | Public API server base URL. Required with Google OAuth.                                |
-| `TRUSTED_ORIGINS`            | Comma-separated app origins accepted by the API.                                       |
+| `TRUSTED_ORIGINS`            | Comma-separated app origins accepted by the API. Unset, `http://localhost:3010`.       |
 | `INITIAL_ADMIN_EMAILS`       | Comma-separated users seeded as administrators.                                        |
 
 Google OAuth client id and secret must be configured together. If Google OAuth is configured, `BETTER_AUTH_SECRET` and `BETTER_AUTH_URL` are also required.

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -218,9 +218,11 @@ function authConfig(
     baseUrl,
     secret,
     google,
+    // start.sh serves the app on 3010. A clone that enables Google sign-in without
+    // setting TRUSTED_ORIGINS must still accept the origin the app actually answers on.
     trustedOrigins: commaSeparated(environment, "TRUSTED_ORIGINS").length
       ? commaSeparated(environment, "TRUSTED_ORIGINS")
-      : ["http://localhost:3000"],
+      : ["http://localhost:3010"],
     initialAdminEmails: commaSeparated(environment, "INITIAL_ADMIN_EMAILS"),
   };
 }

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -137,7 +137,7 @@ describe("deployment configuration", () => {
         clientId: "google-client-id",
         clientSecret: "google-client-secret",
       },
-      trustedOrigins: ["http://localhost:3000"],
+      trustedOrigins: ["http://localhost:3010"],
       initialAdminEmails: ["admin@openbot.test", "owner@openbot.test"],
     });
   });


### PR DESCRIPTION
## What this changes

When Google sign-in is enabled and `TRUSTED_ORIGINS` is unset, the API now accepts `http://localhost:3010` — the origin `start.sh` actually serves. The old fallback was port 3000, so a clone that copied `.env.example`, started the stack, and wired Google OAuth could be rejected for an origin it was never served from.

Deriving the default from `BETTER_AUTH_URL` would still be wrong: that URL is the API (3001), not the app.

The README no longer warns about a 3000-vs-3010 footgun. `docs/configuration.md` records the new default. `.env.example` already set 3010 and is unchanged.

## Where it runs

- [x] **New state that outlives a request?** None.
- [x] **What happens on the second replica?** Each process reads the same environment. The default is the same on every process.
- [x] **Anything serialised?** None.
- [x] **Anything fanned out to a browser?** None.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: resolve, decide, audit, then act.
- [x] New refusals and new failures each write a row. None added.
- [x] Nothing new is trusted from the client that the server can resolve itself.

## Proof

- `bun run format` / `format:check` — clean
- `bun run lint` — exit 0
- `bun run typecheck` — app, server and worker all exit 0
- `bun test server/tests/config.test.ts` — 19 pass, 0 fail
- `bun run build` — app, server and worker all exit 0

## Test plan

- [ ] Enable Google sign-in without setting `TRUSTED_ORIGINS`, run `scripts/start.sh`, and confirm the app origin `http://localhost:3010` is accepted
- [ ] Set `TRUSTED_ORIGINS` to a custom origin and confirm that still wins over the default