### PR TITLE
Call them coworkers on the page that creates them

### DIFF
--- a/app/src/components/agents/agent-profile.tsx
+++ b/app/src/components/agents/agent-profile.tsx
@@ -198,7 +198,7 @@ export function AgentProfile({ agentId }: { agentId: string }) {
 
           {profile.hidden ? (
             <p className="-mt-1 text-xs text-muted-foreground">
-              Hidden from your agents list. This changes nothing for anyone
+              Hidden from your coworkers list. This changes nothing for anyone
               else.
             </p>
           ) : null}

--- a/app/src/components/app-sidebar/app-sidebar.tsx
+++ b/app/src/components/app-sidebar/app-sidebar.tsx
@@ -245,7 +245,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   <EmptyHeader>
                     <EmptyTitle>You don't have channels yet</EmptyTitle>
                     <EmptyDescription className="text-pretty">
-                      Start talking to agents and your channels will appear
+                      Start talking to coworkers and your channels will appear
                       here.
                     </EmptyDescription>
                   </EmptyHeader>
@@ -302,7 +302,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               <div className="size-[28px] flex items-center justify-center">
                 <IconBolt />
               </div>
-              <span className="text-sm trackint-tight">Agents</span>
+              <span className="text-sm trackint-tight">Coworkers</span>
             </SidebarMenuButton>
           </SidebarMenuItem>
           <SidebarMenuItem>

--- a/app/src/routes/_authed/_app/agents/index.tsx
+++ b/app/src/routes/_authed/_app/agents/index.tsx
@@ -52,7 +52,7 @@ function AgentsScreen() {
       <div className="max-w-2xl px-4 w-full mx-auto">
         <div className="mt-12 w-full max-w-2xl">
           <div className="flex flex-row w-full items-center justify-between">
-            <h2 className="font-bold text-lg">Your agents</h2>
+            <h2 className="font-bold text-lg">Your coworkers</h2>
             <Button
               variant="ghost"
               size="sm"
@@ -61,7 +61,7 @@ function AgentsScreen() {
               )}
             >
               <IconPlus />
-              New agent
+              New coworker
             </Button>
           </div>
           <div className="flex flex-row mt-4">
@@ -82,7 +82,7 @@ function AgentsScreen() {
               <Empty className="border border-dashed h-[180px]">
                 <EmptyHeader>
                   <EmptyTitle className="text-muted-foreground">
-                    You don't have any agents created.
+                    You don't have any coworkers created.
                   </EmptyTitle>
                 </EmptyHeader>
               </Empty>
@@ -90,7 +90,7 @@ function AgentsScreen() {
           </div>
         </div>
         <div className="mt-8 w-full max-w-2xl">
-          <h2 className="font-bold text-lg">Explore agents</h2>
+          <h2 className="font-bold text-lg">Explore coworkers</h2>
           <div className="grid grid-cols-4 gap-4 mt-4">
             {!!explore?.length &&
               explore.map((agent, index) => {


### PR DESCRIPTION
## What this changes

PR #11 renamed the product noun to coworker and updated the create form, then missed the roster that opens it. Clicking **New agent** opened a panel titled **New coworker**.

This changes only the leftover user-facing strings on that flow:

- Roster heading, empty state, explore heading, and the button that opens the form
- Profile helper text that still said "agents list"
- Sidebar empty-state line, plus the nav label next to that copy

Routes, file names, identifiers, `/bot`, and AG-UI "Bot" are unchanged.

## Where it runs

- [x] **New state that outlives a request?** None.
- [x] **What happens on the second replica?** Same strings on every replica.
- [x] **Anything serialised?** None.
- [x] **Anything fanned out to a browser?** None.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: resolve, decide, audit, then act.
- [x] New refusals and new failures each write a row.
- [x] Nothing new is trusted from the client that the server can resolve itself.

## Proof

Copy-only.

- `bun run format:check` — clean
- `bun run lint` — exit 0
- `bun run typecheck` — app, server, worker all clean
- `bun test app/tests` — 53 pass, 0 fail

## Test plan

- [ ] Open `/agents` and confirm the heading, empty state, and create button say coworker
- [ ] Click the create button and confirm the panel title still matches
- [ ] Confirm `/bot` and AG-UI "Bot" copy is unchanged