### PR TITLE
Refuse on a deny rule that never answers the question

### DIFF
--- a/server/src/computer/policy.ts
+++ b/server/src/computer/policy.ts
@@ -190,6 +190,15 @@ const POLICY_FUNCTIONS: Record<string, (...args: never[]) => unknown> = {
  * `onError` decides what a broken expression means, because the safe answer differs by list: a broken
  * `allow` must not permit, and a broken `deny` must not stop denying. Both are logged loudly, because
  * a policy that silently misbehaves is worse than one that visibly refuses.
+ *
+ * A rule can be broken two ways and only one of them throws. `"Submit order"` is valid CEL: it parses,
+ * it evaluates, and it answers with a string, which is not an answer to "does this rule apply". That
+ * is what somebody writes who reads the deny list as a list of labels rather than expressions, and
+ * reading it as "no match" would let the action through under the permissive allow rule that ships by
+ * default, with nothing logged and the rule still listed on the Boundaries page as though it were in
+ * force. So anything other than a boolean is a broken rule, and takes the same fail-closed path as a
+ * throw. False is a real answer and stays one; a deny list that read every false as a denial would
+ * refuse everything.
  */
 function matches(
   expression: string,
@@ -197,13 +206,22 @@ function matches(
   onError: boolean,
 ): boolean {
   try {
-    return (
-      evaluate(
-        expression,
-        context as unknown as Record<string, unknown>,
-        POLICY_FUNCTIONS as Record<string, CallableFunction>,
-      ) === true
+    const result = evaluate(
+      expression,
+      context as unknown as Record<string, unknown>,
+      POLICY_FUNCTIONS as Record<string, CallableFunction>,
     );
+    if (typeof result === "boolean") return result;
+
+    console.error(
+      JSON.stringify({
+        type: "computer-policy-expression-error",
+        expression,
+        error: `expected a true or false answer, got ${result === null ? "null" : typeof result}`,
+        treatedAs: onError,
+      }),
+    );
+    return onError;
   } catch (error) {
     console.error(
       JSON.stringify({

--- a/server/tests/computer-policy.test.ts
+++ b/server/tests/computer-policy.test.ts
@@ -87,6 +87,49 @@ describe("evaluateActionPolicy", () => {
     expect(decision.source).toBe("deny");
   });
 
+  // The other way a rule is broken. These parse and evaluate, so nothing throws; they simply do not
+  // answer the question that was asked, and the only safe reading of a deny rule that did not answer
+  // is that it denied. `"Submit order"` is what somebody writes who thinks the list takes labels
+  // rather than expressions, and it is a valid CEL string.
+  test.each([
+    ['"Submit order"', "a bare string, i.e. the list read as labels"],
+    ["element.name", "a bare field reference"],
+    ['contains(element.name, "submit") ? element.name : false', "a ternary"],
+    ["repeat.count", "a number"],
+  ])(
+    "a deny expression that is not a question (%s: %s) still denies",
+    (rule) => {
+      const decision = evaluateActionPolicy(
+        { ...permissive, deny: [rule] },
+        context(),
+      );
+      expect(decision.allowed).toBe(false);
+      expect(decision.source).toBe("deny");
+    },
+  );
+
+  // The mirror. A rule that does not answer must not permit either, which is what this already did by
+  // reading anything other than true as no match.
+  test("an allow expression that is not a question does not permit", () => {
+    const decision = evaluateActionPolicy(
+      { mode: "enforce", deny: [], allow: ['"Submit order"'] },
+      context(),
+    );
+    expect(decision.allowed).toBe(false);
+    expect(decision.source).toBe("default");
+  });
+
+  // A rule that answers "no" is not broken, and must not be read as one: a deny list where every
+  // false reading became a denial would refuse everything.
+  test("a deny expression that answers false permits", () => {
+    const decision = evaluateActionPolicy(
+      { ...permissive, deny: ['contains(element.name, "cancel")'] },
+      context(),
+    );
+    expect(decision.allowed).toBe(true);
+    expect(decision.source).toBe("allow");
+  });
+
   test("a broken allow expression does not permit", () => {
     const decision = evaluateActionPolicy(
       { mode: "enforce", deny: [], allow: ["also not ( valid"] },


### PR DESCRIPTION
Closes #26.

`matches` read an expression result as `evaluate(...) === true`, so a rule that parsed and evaluated but answered with something other than a boolean was neither a match nor an error. In the deny list that meant it did not deny, and the permissive `allow: ["true"]` that ships by default let the action through.

`deny: ["Submit order"]` is the way in: what somebody writes who reads the list as labels rather than expressions, and a valid CEL string. Nothing was logged, because only the throwing path logged, and the rule still sat on the Boundaries page looking as though it were in force.

## What it does

Treat any non-boolean answer as a broken rule and send it down the existing fail-closed path. It denies in the deny list, does not permit in the allow list, and logs either way, with the reason saying what came back instead.

False stays a real answer. A deny list that read every false as a denial would refuse everything.

## Verification

Six cases added to `server/tests/computer-policy.test.ts`. Four are the deny rules that should have denied and did not (a bare string, a bare field reference, a ternary returning a string, a number), failing before and passing after.

Two are the directions that must not move, both passing before and after: a non-boolean in the `allow` list still does not permit, and a deny rule that answers false still permits, which is the check that this does not turn every policy into a refusal.

Checked against every rule the product ships, the `.env.example` example and the four Boundaries presets, across contexts with and without an element, a key and a file. No verdict changes.

Existing tests unchanged and passing. The `server` suite has the same 71 failures before and after this branch, all integration tests wanting a Postgres this machine does not have. `bun run typecheck` and `bunx biome check` are clean.