### PR TITLE
Fix possible by not specifying a USER, a program in the container may run as 'root' in Dockerfile

### DIFF
--- a/agent-bot/Dockerfile
+++ b/agent-bot/Dockerfile
@@ -12,4 +12,5 @@ COPY agent-bot/src ./agent-bot/src
 
 ENV PORT=4200
 EXPOSE 4200
+USER bun
 CMD ["bun", "agent-bot/src/index.ts"]


### PR DESCRIPTION
Proposing a fix for something flagged in `agent-bot/Dockerfile`. It is around line 15.

The Dockerfile does not specify a USER, causing the application to run as root. Running with unnecessary root privileges increases the risk of privilege escalation; if an attacker compromises the process, they can gain full control over the container. This is a high‑severity issue (CWE‑250).

Added USER bun to run the application as a non‑root user, eliminating the security hazard of running as root.

For reference: rule `dockerfile.security.missing-user.missing-user`, [CWE-250 (Execution with Unnecessary Privileges)](https://cwe.mitre.org/data/definitions/250.html). Rated high.

I do not know the codebase, so please check the change fits how the rest of it works. Happy to adjust it or close this if the reasoning is off.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
