### PR TITLE
fix(agent-bot): run as non-root bun user

### DIFF
--- a/agent-bot/Dockerfile
+++ b/agent-bot/Dockerfile
@@ -3,12 +3,14 @@
 FROM oven/bun:1.3-alpine
 
 WORKDIR /app
-COPY agent-bot/package.json ./agent-bot/
+RUN chown bun:bun /app
+USER bun
+COPY --chown=bun:bun agent-bot/package.json ./agent-bot/
 RUN cd agent-bot && bun install
 
 # Preserve the repo layout so `../../shared/bot-prompt` resolves the same in the image and locally.
-COPY shared ./shared
-COPY agent-bot/src ./agent-bot/src
+COPY --chown=bun:bun shared ./shared
+COPY --chown=bun:bun agent-bot/src ./agent-bot/src
 
 ENV PORT=4200
 EXPOSE 4200


### PR DESCRIPTION
## Summary
- Add `USER bun` to `agent-bot/Dockerfile` so the container process no longer runs as root (CWE-250).
- Chown `/app` and use `COPY --chown=bun:bun` so bun install and runtime file access still work after the user switch.

## Verification
Built the image and confirmed:
- `id` inside container returns `uid=1000(bun)`.
- `whoami` returns `bun`; writes to `/etc` and `/root` are denied.
- `/health` returns `{"status":"ok",...}` and `POST /ag-ui` returns 200.
- Image metadata: `User=bun`, `Cmd=[bun agent-bot/src/index.ts]`, port 4200 exposed.
- Works with `--read-only` rootfs + tmpfs `/tmp`.

Closes #39