### PR TITLE
Keep the computer fleet off a signed-in user's listing

### DIFF
--- a/server/src/computer/routes.ts
+++ b/server/src/computer/routes.ts
@@ -208,10 +208,16 @@ export function createComputerRoutes(
    * The computers, for the admin surface.
    *
    * Not per-Bot in the path the way the acting routes are: this asks the computer what it holds, and
-   * it holds a list. `:botId` is still there because every route under this router has it and the
-   * gateway wants somebody to attribute the call to.
+   * it holds a list. `:botId` is still there because every route under this router has it. The
+   * list itself is every computer, so a signed-in user is not enough; an administrator has to ask.
    */
   routes.get("/:botId/computers", async (context) => {
+    // The session guard and the question of whether this person may act as the Bot in the path are
+    // both applied by the middleware above. Neither is the question here: the answer is the whole
+    // fleet whatever `:botId` says, so it takes administering the deployment.
+    const denied = requireAdmin(context);
+    if (denied) return denied;
+
     try {
       return context.json(await gateway.computers());
     } catch (error) {

--- a/server/tests/computer-routes.test.ts
+++ b/server/tests/computer-routes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { MiddlewareHandler } from "hono";
-import type { AppVariables } from "../src/auth/guards";
+import type { AppVariables, AuthenticatedActor } from "../src/auth/guards";
 import type { ComputerGateway } from "../src/computer/gateway";
 import type { PolicyStore } from "../src/computer/policy-store";
 import { createComputerRoutes } from "../src/computer/routes";
@@ -38,5 +38,97 @@ describe("computer routes", () => {
       mimeType: "image/png",
     });
     expect(requestedBotIds).toEqual(["bot-17"]);
+  });
+});
+
+/**
+ * The fleet listing is the one route here that is not about the Bot in its path.
+ *
+ * `:botId` is ignored and the handler returns every computer, so a signed-in person asking about a
+ * Bot they own learned every Bot id in the deployment and whether its computer was running,
+ * private coworkers included. Being signed in is not the question; administering the deployment is.
+ */
+const member: AuthenticatedActor = {
+  id: "user-1",
+  email: "member@openbot.test",
+  role: "user",
+};
+
+const administrator: AuthenticatedActor = {
+  id: "admin-1",
+  email: "admin@openbot.test",
+  role: "admin",
+};
+
+function asActor(
+  actor: AuthenticatedActor,
+): MiddlewareHandler<{ Variables: AppVariables }> {
+  return async (context, next) => {
+    context.set("actor", actor);
+    await next();
+  };
+}
+
+function appFor(actor: AuthenticatedActor, computers: () => Promise<unknown>) {
+  let listed = 0;
+  const countingGateway = {
+    async computers() {
+      listed += 1;
+      return computers();
+    },
+  } as ComputerGateway;
+
+  return {
+    app: createComputerRoutes(
+      countingGateway,
+      {} as PolicyStore,
+      asActor(actor),
+      // Permissive. Whether this person may act as the Bot in the path is a different question with
+      // its own suite, and `:botId` is not what this route answers about anyway.
+      async () => true,
+    ),
+    listed: () => listed,
+  };
+}
+
+describe("computer fleet listing", () => {
+  test("refuses a signed-in user the fleet, and does not ask the gateway", async () => {
+    const { app, listed } = appFor(member, async () => ({
+      isolation: "per-bot",
+      computers: [
+        { botId: "private-coworker", running: true, startedAt: null },
+      ],
+    }));
+
+    const response = await app.request("http://openbot.test/any-bot/computers");
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "Administrator access required.",
+    });
+    // Refused before the gateway is asked: a check that runs after the fleet has been read is not a
+    // check, it is a filter on the response.
+    expect(listed()).toBe(0);
+  });
+
+  test("lets an administrator see the fleet", async () => {
+    const fleet = {
+      isolation: "per-bot" as const,
+      computers: [
+        {
+          botId: "private-coworker",
+          running: true,
+          startedAt: "2026-08-20T00:00:00.000Z",
+          egress: null,
+        },
+      ],
+    };
+    const { app, listed } = appFor(administrator, async () => fleet);
+
+    const response = await app.request("http://openbot.test/any-bot/computers");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(fleet);
+    expect(listed()).toBe(1);
   });
 });


### PR DESCRIPTION
## The problem

The admin computers page asks for every Bot's machine. That list lived behind a session only. `:botId` is unused, and the handler returns `gateway.computers()`, so any signed-in person who could hit one valid bot path learned every Bot id and whether its computer was running, including private coworkers.

This is not #35/#37 (acting as another Bot) or #29/#30 (a bot id becoming a filesystem path). It is the global listing, and it does not use the path id.

## The approach

The same `requireAdmin` the policy routes already use. A signed-in user is refused before the gateway is asked. An administrator still gets the fleet.

## Proof

- `bun test server/tests/computer-routes.test.ts` — 2 pass, 0 fail
- `bunx biome format` / `lint` on the touched files — clean

## Test plan

- [ ] Sign in as a non-admin and open `/admin/computers` or `GET /api/computers/<any-bot>/computers`. Expect 403 and no fleet.
- [ ] Sign in as an administrator and load the same route. Expect the computer list as before.