### PR TITLE
Roll back a credential rotation when revoking the old one fails

### DIFF
--- a/server/src/credentials.ts
+++ b/server/src/credentials.ts
@@ -305,7 +305,15 @@ export async function rotateCredential(
   input: CredentialInput & { previousCredentialId: string },
 ) {
   const credential = await persistCredential(service, input);
-  await service.store.revoke(input.previousCredentialId);
+  try {
+    await service.store.revoke(input.previousCredentialId);
+  } catch (error) {
+    // Roll back the new secret so a failed rotation does not leave an unlinked
+    // active credential in the vault. The audit event is skipped too, so the
+    // trail reflects only rotations that actually happened.
+    await service.store.revoke(credential.id).catch(() => {});
+    throw error;
+  }
 
   await recordAuditEvent(service.auditStore, {
     eventType: "credential.rotated",

--- a/server/tests/credentials.test.ts
+++ b/server/tests/credentials.test.ts
@@ -138,6 +138,54 @@ describe("credential encryption", () => {
     ).toEqual(["credential.rotated", "credential.revoked"]);
   });
 
+  test("rolls back the new credential when revoke of the previous one fails", async () => {
+    const created: string[] = [];
+    const revoked: string[] = [];
+    const audited: unknown[] = [];
+    const service = {
+      encryptionKey: key,
+      store: {
+        create: async () => {
+          const id = "credential-new";
+          created.push(id);
+          return { id, revokedAt: null };
+        },
+        revoke: async (id: string) => {
+          revoked.push(id);
+          if (id === "credential-old") {
+            throw new Error("Previous credential not found");
+          }
+          return new Date("2026-08-13T12:00:00.000Z");
+        },
+      },
+      auditStore: {
+        insert: async (event: unknown) => {
+          audited.push(event);
+        },
+      },
+    };
+
+    await expect(
+      rotateCredential(service, {
+        previousCredentialId: "credential-old",
+        kind: "model",
+        provider: "openai",
+        keyId: "primary",
+        metadata: {},
+        plaintext: "new-openai-secret",
+        actorUserId: "admin",
+      }),
+    ).rejects.toThrow("Previous credential not found");
+
+    // The rotation failed, so the vault must not hold an unlinked new secret and the
+    // audit trail must not claim a rotation happened.
+    expect(created).toEqual(["credential-new"]);
+    expect(revoked).toContain("credential-new");
+    expect(
+      audited.map((event) => (event as { eventType: string }).eventType),
+    ).not.toContain("credential.rotated");
+  });
+
   test("decrypts only an active credential for server-side use", async () => {
     const encryptedValue = await encryptSecret(key, "connector-secret");
 


### PR DESCRIPTION
Closes #53.

## The problem

`rotateCredential` writes the new credential, then calls `store.revoke` on the previous one. The two steps are independent, so a failure on the revoke leaves the new credential live in the vault while the caller sees an error and treats the rotation as failed.

`readModelSecret` orders by `createdAt` desc, so the orphan is what the runtime resolves to next time. No `credential.rotated` audit event is written for a failed attempt, so nothing on the audit trail says two live credentials exist for the same `(provider, keyId)`. A caller that retries writes another orphan each time.

## The approach

Wrap the revoke in a try/catch. If it throws, revoke the credential that was just written and rethrow the original error. The secondary revoke swallows its own error so the caller still sees the real cause. The `credential.rotated` audit event stays where it was, past the try/catch, so the trail continues to reflect only rotations that actually happened.

Either both sides moved or neither did.

## What is not covered

- Pre-existing orphans from earlier failed rotations. This change stops new ones; it does not clean up the vault.
- A crash between `persistCredential` and the revoke (process killed, node lost) still leaves an orphan. A durable compensation would need a workflow table or a two-phase write; out of scope for the bug on the table.
- Rotation is not made atomic across `create` and `revoke`. The store interface does not expose a transaction, and adding one touches every backend that implements `CredentialStore`.

## Verification

- Added `rolls back the new credential when revoke of the previous one fails` in `server/tests/credentials.test.ts`. It fails on `main` with `Expected to contain: "credential-new" / Received: [ "credential-old" ]` and passes with the fix. All 13 tests in that file green.
- Full test suite from repo root: `bun run test` reports 684 pass, 5 skip, 0 fail across 78 files.
- `bun run typecheck`, `bun run format`, `bun run build` all clean. `bun run lint` reports the same 25 warnings that are already on `main`.
