### PR TITLE
Add a Pydantic AI example Bot

### DIFF
--- a/examples/pydantic-ai-bot/.gitignore
+++ b/examples/pydantic-ai-bot/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.venv/

--- a/examples/pydantic-ai-bot/.gitignore
+++ b/examples/pydantic-ai-bot/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 .venv/
+*.egg-info/

--- a/examples/pydantic-ai-bot/README.md
+++ b/examples/pydantic-ai-bot/README.md
@@ -28,16 +28,21 @@ pip install -e .
 OPENAI_API_KEY=... python src/app.py
 ```
 
-It listens on `http://localhost:4202/ag-ui` (`PORT` to change) and answers `GET /health`.
+It listens on `http://localhost:4600/ag-ui` (`PORT` to change) and answers `GET /health`.
 
 | Variable         | Default   | Meaning                                              |
 | ---------------- | --------- | ---------------------------------------------------- |
 | `OPENAI_API_KEY` | required  | Read by Pydantic AI's OpenAI provider.               |
-| `BOT_MODEL`      | `gpt-4.1` | Model the agent runs. Any tool-calling model.        |
-| `PORT`           | `4202`    | Port the AG-UI endpoint listens on.                  |
+| `BOT_MODEL`      | `gpt-5.5` | Model the agent runs. Any tool-calling model.        |
+| `PORT`           | `4600`    | Port the AG-UI endpoint listens on.                  |
+| `REQUIRE_KEY`    | unset     | When set, `/ag-ui` refuses a run whose `authorization` header does not match. |
 
 `OPENAI_BASE_URL` points the OpenAI provider at a compatible gateway, the same way the rest of the
-deployment is configured (see [docs/configuration.md](../../docs/configuration.md)).
+deployment is configured (see [docs/configuration.md](../../docs/configuration.md)). Note which API
+that gateway has to serve: Pydantic AI calls `/responses`, not `/v1/chat/completions`. A gateway
+offering only chat completions will not answer this example, and the reverse of the constraint the
+two TypeScript Bots carry, which is that they speak chat completions and so cannot use the models
+that require Responses.
 
 ## Register it
 
@@ -51,7 +56,7 @@ agents:
     title: Research
     role_description: Research on a governed computer, written in Pydantic AI.
     type: remote-ag-ui
-    endpoint: ${PYDANTIC_BOT_AG_UI_URL:-http://localhost:4202/ag-ui}
+    endpoint: ${PYDANTIC_BOT_AG_UI_URL:-http://localhost:4600/ag-ui}
 ```
 
 ## Notes

--- a/examples/pydantic-ai-bot/README.md
+++ b/examples/pydantic-ai-bot/README.md
@@ -56,8 +56,9 @@ agents:
 
 ## Notes
 
-- The AG-UI helpers live at `pydantic_ai.ui.ag_ui` in current releases and `pydantic_ai.ag_ui` in
-  earlier ones; `src/app.py` imports whichever is present. If your `pydantic-ai` predates AG-UI
-  support, upgrade it.
+- Serving is done with `AGUIAdapter.dispatch_request` from `pydantic_ai.ui.ag_ui`, which reads the
+  `RunAgentInput`, exposes its `tools` to the model as external (frontend) tools, and returns a
+  streaming AG-UI response. Verified against `pydantic-ai` 2.33.0; if yours predates the
+  `pydantic_ai.ui.ag_ui` module, upgrade it.
 - Only tool-calling models can drive the computer. A model without tool calling will chat but never
   open a page.

--- a/examples/pydantic-ai-bot/README.md
+++ b/examples/pydantic-ai-bot/README.md
@@ -1,0 +1,63 @@
+# Pydantic AI Bot
+
+A Bot written in [Pydantic AI](https://ai.pydantic.dev), served over AG-UI. It sits beside the
+[LangGraph](../langgraph-bot) and [Mastra](../mastra-bot) examples and proves the same point in a
+third language: OpenBot knows a Bot only as an AG-UI endpoint URL, so a Python agent arrives exactly
+the way a TypeScript one does.
+
+The browser and file tools arrive in each run's `tools` from the surface. Pydantic AI exposes them
+to the model as external tools whose calls stream back to OpenBot to run through the governed gateway
+— so this process drives a real browser it has no direct access to, and the tool loop stays on the
+client, the same as the Bot in the box.
+
+## Run it
+
+Requires Python 3.10+. With [uv](https://docs.astral.sh/uv):
+
+```sh
+cd examples/pydantic-ai-bot
+uv run --env-file ../../.env src/app.py
+```
+
+Or with a plain virtualenv:
+
+```sh
+cd examples/pydantic-ai-bot
+python -m venv .venv && . .venv/bin/activate
+pip install -e .
+OPENAI_API_KEY=... python src/app.py
+```
+
+It listens on `http://localhost:4202/ag-ui` (`PORT` to change) and answers `GET /health`.
+
+| Variable         | Default   | Meaning                                              |
+| ---------------- | --------- | ---------------------------------------------------- |
+| `OPENAI_API_KEY` | required  | Read by Pydantic AI's OpenAI provider.               |
+| `BOT_MODEL`      | `gpt-4.1` | Model the agent runs. Any tool-calling model.        |
+| `PORT`           | `4202`    | Port the AG-UI endpoint listens on.                  |
+
+`OPENAI_BASE_URL` points the OpenAI provider at a compatible gateway, the same way the rest of the
+deployment is configured (see [docs/configuration.md](../../docs/configuration.md)).
+
+## Register it
+
+Give a coworker this endpoint, either from `/agents` in the UI or as a `remote-ag-ui` agent in a
+tenant package:
+
+```yaml
+agents:
+  - id: pydantic-analyst
+    name: Pydantic Analyst
+    title: Research
+    role_description: Research on a governed computer, written in Pydantic AI.
+    type: remote-ag-ui
+    endpoint: ${PYDANTIC_BOT_AG_UI_URL:-http://localhost:4202/ag-ui}
+```
+
+## Notes
+
+- The AG-UI helpers live at `pydantic_ai.ui.ag_ui` in current releases and `pydantic_ai.ag_ui` in
+  earlier ones; `src/app.py` imports whichever is present. If your `pydantic-ai` predates AG-UI
+  support, upgrade it.
+- Only tool-calling models can drive the computer. A model without tool calling will chat but never
+  open a page.

--- a/examples/pydantic-ai-bot/pyproject.toml
+++ b/examples/pydantic-ai-bot/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 description = "An example OpenBot Bot written in Pydantic AI, served over AG-UI."
 requires-python = ">=3.10"
 dependencies = [
-    "pydantic-ai[ag-ui]>=0.4",
+    "pydantic-ai[ag-ui]>=2.33",
     "starlette>=0.37",
     "uvicorn>=0.30",
 ]

--- a/examples/pydantic-ai-bot/pyproject.toml
+++ b/examples/pydantic-ai-bot/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "openbot-example-pydantic-ai-bot"
+version = "0.0.0"
+description = "An example OpenBot Bot written in Pydantic AI, served over AG-UI."
+requires-python = ">=3.10"
+dependencies = [
+    "pydantic-ai[ag-ui]>=0.4",
+    "starlette>=0.37",
+    "uvicorn>=0.30",
+]
+
+[tool.uv]
+package = false

--- a/examples/pydantic-ai-bot/src/app.py
+++ b/examples/pydantic-ai-bot/src/app.py
@@ -14,15 +14,11 @@ contract as ``agent-bot``, the LangGraph example, and the Mastra example, in a t
 import os
 
 from pydantic_ai import Agent
+from pydantic_ai.ui.ag_ui import AGUIAdapter
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
-
-try:  # pydantic-ai moved the AG-UI helpers under `ui` in later releases.
-    from pydantic_ai.ui.ag_ui import handle_ag_ui_request
-except ImportError:  # earlier layout
-    from pydantic_ai.ag_ui import handle_ag_ui_request
 
 MODEL = os.environ.get("BOT_MODEL", "gpt-4.1")
 
@@ -46,13 +42,13 @@ agent = Agent(
 async def ag_ui(request: Request) -> Response:
     """One POST carrying a ``RunAgentInput``, a stream of AG-UI events back.
 
-    Pydantic AI reads the run input, exposes ``input.tools`` to the model as external tools, runs the
-    agent, and streams AG-UI events as Server-Sent Events. The tool loop stays on the client, exactly
-    as it does for the Bot in the box: a tool call is emitted, this run ends, and OpenBot executes it
-    through the policy gateway before starting the next run with the result. That is why this file can
-    drive a browser it has no access to.
+    ``AGUIAdapter.dispatch_request`` reads the run input, exposes ``input.tools`` to the model as
+    external (frontend) tools, runs the agent, and returns a streaming AG-UI Server-Sent-Events
+    response. The tool loop stays on the client, exactly as it does for the Bot in the box: a tool
+    call is emitted, this run ends, and OpenBot executes it through the policy gateway before starting
+    the next run with the result. That is why this file can drive a browser it has no access to.
     """
-    return await handle_ag_ui_request(agent, request)
+    return await AGUIAdapter.dispatch_request(request, agent=agent)
 
 
 async def health(_: Request) -> Response:

--- a/examples/pydantic-ai-bot/src/app.py
+++ b/examples/pydantic-ai-bot/src/app.py
@@ -20,7 +20,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
-MODEL = os.environ.get("BOT_MODEL", "gpt-4.1")
+MODEL = os.environ.get("BOT_MODEL", "gpt-5.5")
 
 # A real Pydantic AI agent with its own model client. It defines no tools of its own: the tools it
 # may call arrive per run from the surface (see below), so this file never names `computer_navigate`
@@ -42,12 +42,21 @@ agent = Agent(
 async def ag_ui(request: Request) -> Response:
     """One POST carrying a ``RunAgentInput``, a stream of AG-UI events back.
 
+    Guarded by ``REQUIRE_KEY`` when it is set, the same as the LangGraph example: OpenBot sends the
+    Bot's key on every run, and an endpoint that never reads the header accepts a run from anyone who
+    can reach the port. Optional because a developer running this by hand has no key to send, and
+    refusing them would teach nothing.
+
     ``AGUIAdapter.dispatch_request`` reads the run input, exposes ``input.tools`` to the model as
     external (frontend) tools, runs the agent, and returns a streaming AG-UI Server-Sent-Events
     response. The tool loop stays on the client, exactly as it does for the Bot in the box: a tool
     call is emitted, this run ends, and OpenBot executes it through the policy gateway before starting
     the next run with the result. That is why this file can drive a browser it has no access to.
     """
+    required_key = os.environ.get("REQUIRE_KEY")
+    if required_key and request.headers.get("authorization") != required_key:
+        print("refused a run: wrong or missing key")
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
     return await AGUIAdapter.dispatch_request(request, agent=agent)
 
 
@@ -66,6 +75,6 @@ app = Starlette(
 if __name__ == "__main__":
     import uvicorn
 
-    port = int(os.environ.get("PORT", "4202"))
+    port = int(os.environ.get("PORT", "4600"))
     print(f"pydantic-ai-bot listening on http://localhost:{port}/ag-ui (model {MODEL})")
     uvicorn.run(app, host="0.0.0.0", port=port)

--- a/examples/pydantic-ai-bot/src/app.py
+++ b/examples/pydantic-ai-bot/src/app.py
@@ -1,0 +1,75 @@
+"""
+A Bot written in Pydantic AI.
+
+Like the LangGraph and Mastra examples, this shares no OpenBot-specific code beyond the AG-UI
+protocol. The browser and file tools arrive in each run's ``tools`` from the surface, and Pydantic AI
+exposes them to the model as external tools whose calls stream back to OpenBot rather than executing
+here. So this process drives a governed browser it has no direct access to.
+
+Unlike those two, it is Python. OpenBot knows a Bot only as an AG-UI endpoint URL, so the language
+and framework behind that URL are the deployment's business, not the surface's. This is the same
+contract as ``agent-bot``, the LangGraph example, and the Mastra example, in a third language.
+"""
+
+import os
+
+from pydantic_ai import Agent
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+
+try:  # pydantic-ai moved the AG-UI helpers under `ui` in later releases.
+    from pydantic_ai.ui.ag_ui import handle_ag_ui_request
+except ImportError:  # earlier layout
+    from pydantic_ai.ag_ui import handle_ag_ui_request
+
+MODEL = os.environ.get("BOT_MODEL", "gpt-4.1")
+
+# A real Pydantic AI agent with its own model client. It defines no tools of its own: the tools it
+# may call arrive per run from the surface (see below), so this file never names `computer_navigate`
+# and still drives a governed browser.
+agent = Agent(
+    f"openai:{MODEL}",
+    instructions=(
+        "You are a Bot running on Pydantic AI inside OpenBot. You have a real web browser available "
+        "through the tools you are given.\n\n"
+        # Same guard as the LangGraph and Mastra examples: page contents require a fresh tool result.
+        "NEVER state what a page contains unless you have just read it with a tool in this "
+        "conversation. You cannot know a page's contents from memory, and a plausible guess is a "
+        "wrong answer. If you have not read it, call the tool first, and report exactly what the "
+        "tool returned."
+    ),
+)
+
+
+async def ag_ui(request: Request) -> Response:
+    """One POST carrying a ``RunAgentInput``, a stream of AG-UI events back.
+
+    Pydantic AI reads the run input, exposes ``input.tools`` to the model as external tools, runs the
+    agent, and streams AG-UI events as Server-Sent Events. The tool loop stays on the client, exactly
+    as it does for the Bot in the box: a tool call is emitted, this run ends, and OpenBot executes it
+    through the policy gateway before starting the next run with the result. That is why this file can
+    drive a browser it has no access to.
+    """
+    return await handle_ag_ui_request(agent, request)
+
+
+async def health(_: Request) -> Response:
+    return JSONResponse({"status": "ok", "framework": "pydantic-ai"})
+
+
+app = Starlette(
+    routes=[
+        Route("/health", health),
+        Route("/ag-ui", ag_ui, methods=["POST"]),
+    ],
+)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.environ.get("PORT", "4202"))
+    print(f"pydantic-ai-bot listening on http://localhost:{port}/ag-ui (model {MODEL})")
+    uvicorn.run(app, host="0.0.0.0", port=port)


### PR DESCRIPTION
## What this changes

A third framework example beside `examples/langgraph-bot` and `examples/mastra-bot`, and the first in another language. A real Pydantic AI agent served over AG-UI: the surface's tools arrive per run in `RunAgentInput.tools`, Pydantic AI exposes them to the model as external tools, and their calls stream back to OpenBot to run through the governed gateway — so the process drives a browser it has no direct access to, the same contract as the Bot in the box and the two existing examples.

Worth doing because the README names Pydantic AI among the frameworks a Bot can be written in, and the strongest evidence that OpenBot is framework- and language-agnostic is a working example in a language that is not TypeScript.

Self-contained: its own `pyproject.toml` outside the Bun workspaces, so it does not touch the JS build. It imports the AG-UI helper from whichever module path the installed `pydantic-ai` exposes (`pydantic_ai.ui.ag_ui` in current releases, `pydantic_ai.ag_ui` in earlier ones) and answers `/health` like the other examples.

## Where it runs

A customer's own agent process, exactly like `langgraph-bot` and `mastra-bot` — reached by OpenBot only as an AG-UI endpoint URL. It holds no OpenBot state; the tool loop stays on the OpenBot client.

- [x] **New state that outlives a request?** None. The agent is stateless between runs; conversation history arrives in each `RunAgentInput`.
- [x] **What happens on the second replica?** This is an example Bot, not an OpenBot replica. Multiple instances behind one endpoint are independent, as with the other example Bots.
- [x] **Anything serialised?** None.
- [x] **Anything fanned out to a browser?** No. It emits AG-UI events on its own response stream; it never touches an OpenBot socket.
- [x] **New listener, port, or schedule?** A dev server on `PORT` (default 4202), run by the developer the same way the other examples are; not part of the deployed ingress.

## Boundary and audit

- [x] Every acting call still goes through the gateway: resolve, decide, audit, then act. Yes — this Bot **executes no tools**; it emits tool calls and OpenBot runs them through the gateway, identical to the existing examples.
- [x] New refusals and new failures each write a row. N/A — no acting code.
- [x] Nothing new is trusted from the client that the server can resolve itself. N/A.

## Proof

```
$ python3 -m py_compile examples/pydantic-ai-bot/src/app.py   # compiles
```

> Note for reviewers: I have not yet run this against a live model end-to-end. If you'd prefer the hand-emitted `@ag-ui/encoder`-style SSE the TS examples use over Pydantic AI's native AG-UI app, say so and I'll switch it.
