### PR TITLE
Have Knowledge admit no source is connected, instead of citing one

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -212,7 +212,7 @@ agents:
     role_description: Answer company knowledge questions and cite sources.
     avatar_seed: knowledge
     type: built-in
-    system_prompt: Answer from authorized company knowledge and cite every source.
+    system_prompt: Answer from authorized company knowledge, and say so plainly when no source is connected rather than inventing a citation.
 
   - id: risk-analyst
     name: Risk Analyst

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -212,7 +212,7 @@ agents:
     role_description: Answer company knowledge questions and cite sources.
     avatar_seed: knowledge
     type: built-in
-    system_prompt: Answer from authorized company knowledge, and say so plainly when no source is connected rather than inventing a citation.
+    system_prompt: Answer from authorized company knowledge and cite your sources. When none is connected, say so plainly rather than inventing a citation.
 
   - id: risk-analyst
     name: Risk Analyst

--- a/examples/fintech/agents.yaml
+++ b/examples/fintech/agents.yaml
@@ -14,7 +14,7 @@ agents:
     role_description: Help answer company knowledge questions and cite sources when available.
     avatar_seed: knowledge
     type: built-in
-    system_prompt: Answer from authorized company knowledge and cite every source.
+    system_prompt: Answer from authorized company knowledge, and say so plainly when no source is connected rather than inventing a citation.
   # The Bot that ships in the box (agent-bot), addressed exactly the way a customer's own Bot would
   # be: an AG-UI endpoint in the registry. Names in dollar-brace form are read from the environment,
   # so the address belongs to the deployment. Replace it with your own service and nothing changes.

--- a/examples/fintech/agents.yaml
+++ b/examples/fintech/agents.yaml
@@ -14,7 +14,7 @@ agents:
     role_description: Help answer company knowledge questions and cite sources when available.
     avatar_seed: knowledge
     type: built-in
-    system_prompt: Answer from authorized company knowledge, and say so plainly when no source is connected rather than inventing a citation.
+    system_prompt: Answer from authorized company knowledge and cite your sources. When none is connected, say so plainly rather than inventing a citation.
   # The Bot that ships in the box (agent-bot), addressed exactly the way a customer's own Bot would
   # be: an AG-UI endpoint in the registry. Names in dollar-brace form are read from the environment,
   # so the address belongs to the deployment. Replace it with your own service and nothing changes.


### PR DESCRIPTION
## What this changes

The Knowledge coworker's `role_description` in `examples/fintech/agents.yaml` already says it should "cite sources when available" — correctly hedged, since not every deployment has a knowledge source connected. Its `system_prompt`, the text actually sent to the model, disagreed: "Answer from authorized company knowledge and cite every source," with no hedge at all. The same unconditional wording is repeated in the `agents.yaml` example inside `docs/configuration.md`.

Out of the box, `TENANT_PACKAGE_DIR` defaults to this fintech example, so a fresh install ships a Knowledge coworker instructed to always cite a source, whether or not one is connected — a citation invented under instruction reads the same as a real one.

This changes the wording in both places to match the hedge already present in the same block, matching a pattern the connectors page already uses on purpose: `app/src/routes/_authed/admin/connectors.tsx` shows "No setup screen yet" for an unconfigured OneDrive connector rather than a broken or blank control, specifically so the product says plainly what isn't there instead of implying it. The Knowledge prompt should hold itself to the same rule.

This is a narrow fix to the example config and its matching doc block. It does not touch the underlying gap that a Knowledge coworker has no retrieval behind it in this repo yet — I'm filing that separately as an issue, since it's a bigger, cross-cutting change that should be proposed before it's built.

## Where it runs

- **New state that outlives a request?** None. This is a string in two static files.
- **What happens on the second replica?** Identical behavior on every replica; nothing is held in a process.
- **Anything serialised?** N/A, no writes.
- **Anything fanned out to a browser?** No.
- **New listener, port, or schedule?** No.

## Boundary and audit

- N/A — no gateway, policy, or audit path touched.

## Proof

This is a two-line text change to a YAML string and its doc mirror; no runtime code, imports, or tests reference the exact string (`grep -rn "cite every source"` matched only these two files before the change).

I could not get a clean local run of `format:check`/`lint`/`typecheck` in this dev environment: `bunx biome format .` and `bunx biome lint .` both crash (access violation) on this machine, and `bun run typecheck` reports `Cannot find module 'yaml'`/`'zod'`/etc. from several files. I confirmed both failures are pre-existing and unrelated to this change by stashing it and reproducing the identical errors on a clean `main` checkout with zero edits — looks like a package-linking issue local to this Windows setup, not something this PR introduces. `bun test tests/fintech-package.test.ts`, which exercises this example package, doesn't assert the exact prompt string either way and isn't affected. Happy to have CI be the real signal here.
