### PR TITLE
Stop the tool-call repair recursing into itself

### DIFF
--- a/app/src/lib/copilot/repair-history.ts
+++ b/app/src/lib/copilot/repair-history.ts
@@ -22,7 +22,12 @@ function isToolResult(message: Message): message is Message & ToolResult {
  */
 export function repairUnansweredToolCalls(
   messages: ReadonlyArray<Message>,
-  newId: () => string = () => newId(),
+  /*
+   * Named so it cannot shadow the import it defaults to. A parameter called `newId` defaulting to
+   * `newId()` resolves to itself and recurses until the stack goes, and it does so only on the
+   * repair branch, which every test avoided by passing its own. Biome said so, as an unused import.
+   */
+  mintId: () => string = newId,
 ): ReadonlyArray<Message> {
   const answered = new Set<string>();
   for (const message of messages) {
@@ -47,7 +52,7 @@ export function repairUnansweredToolCalls(
       // OpenAI requires the results to follow their calls, and some providers require the order to
       // match the `tool_calls` array as well.
       repaired.push({
-        id: newId(),
+        id: mintId(),
         role: "tool",
         toolCallId: call.id,
         content: UNANSWERED,

--- a/app/tests/repair-history.test.ts
+++ b/app/tests/repair-history.test.ts
@@ -123,3 +123,39 @@ describe("repairing a history before it is sent", () => {
     expect(repairUnansweredToolCalls(messages, ids)).toBe(messages);
   });
 });
+
+/**
+ * The default id source, which every test above replaces with its own.
+ *
+ * That is the reason a self-recursive default survived review: the parameter exists so a test can
+ * make ids predictable, so no test ever ran the default, and the default only runs on the repair
+ * branch. This one calls it the way the only real caller does, with the argument omitted.
+ */
+describe("repairUnansweredToolCalls without an id source", () => {
+  test("repairs using its own ids rather than recursing", () => {
+    const messages: Message[] = [
+      { id: "a", role: "user", content: "go" },
+      {
+        id: "b",
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          {
+            id: "call-1",
+            type: "function",
+            function: { name: "act", arguments: "{}" },
+          },
+        ],
+      },
+    ];
+
+    const repaired = repairUnansweredToolCalls(messages);
+
+    expect(repaired).toHaveLength(3);
+    const result = repaired[2] as Message & { toolCallId: string };
+    expect(result.role).toBe("tool");
+    expect(result.toolCallId).toBe("call-1");
+    // A real id, not an empty string and not the call's own id.
+    expect(result.id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});


### PR DESCRIPTION
## What this changes

`repairUnansweredToolCalls` takes an id source so tests can make ids predictable:

```ts
newId: () => string = () => newId(),
```

Inside that default, `newId` resolves to the **parameter**, not the import on line 2. The default
calls itself until the stack goes. Introduced by #62.

It hangs exactly when the function does its job. The parameter is only invoked on the repair branch,
reached when there is an unanswered tool call, and the one real caller
(`channel-chat.tsx` L228) omits the argument. Every existing test passes its own ids, so no test ever
ran the default.

Renamed the parameter so it cannot shadow the import, and added a test that calls it the way the
real caller does.

Found by @guidovizoso. Biome had flagged it too, as `noUnusedImports` on line 2, which I waved
through as a warning when I made the change.

## Where it runs

- **New state that outlives a request?** None. A pure function over a message array.
- **What happens on the second replica?** Identical; nothing is held.
- **Anything serialised?** N/A.
- **Anything fanned out to a browser?** No.
- **New listener, port, or schedule?** No.

## Boundary and audit

- N/A. No gateway, policy, or audit path touched.

## Changelog

- No entry. It fixes an unreleased defect introduced by #62, which has not shipped in a release.

## Proof

The new test fails on the old code by hanging rather than by asserting, which is the honest
reproduction. 745 tests pass, `biome check` clean on both files, typecheck clean.