### PR TITLE
Keep the deployment's secrets out of a Bot's shell

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,15 @@ COMPUTER_TOKEN=
 # Local only. Lets a Bot browse this machine's own services; never set this in a deployment.
 AGENT_COMPUTER_ALLOW_PRIVATE_HOSTS=true
 #
+# What a Bot's shell commands can read out of the environment, beyond what a command needs to run:
+# PATH, the locale and terminal names, and the proxy variables are always passed. Nothing else is,
+# because the computer process is handed the container's environment and in the one-container image
+# that is the API's, down to the key that decrypts stored credentials.
+#
+# Comma separated, and read literally. Naming a secret here says to pass that secret, which is a
+# decision an operator can make; taking everything by default was not.
+# COMPUTER_SHELL_ENV=GITHUB_TOKEN,BUILD_CHANNEL
+#
 # What a Bot may do on its computer, as one JSON object. Absent uses the built-in default, which
 # permits the acting tools and forbids nothing, and records every action either way.
 #

--- a/agent-computer/src/shell.ts
+++ b/agent-computer/src/shell.ts
@@ -11,8 +11,9 @@ import { spawn } from "node:child_process";
  * the same as it does for a click. This file is the hands, not the judgement.
  *
  * WHAT THIS DOES DEFEND is the shape of the call rather than its content: a command cannot run
- * forever, cannot return unbounded output, and runs in the workspace rather than wherever the
- * process happens to be.
+ * forever, cannot return unbounded output, runs in the workspace rather than wherever the process
+ * happens to be, and sees the environment a command needs rather than the one the deployment runs
+ * on.
  *
  * ISOLATION IS THE CONTAINER'S JOB. A shell can reach whatever the container can reach, so the
  * deployment that gives a Bot one should give each Bot a computer of its own. In a container shared
@@ -30,6 +31,72 @@ const MAX_TIMEOUT_MS = 600_000;
  * a person can still read, and the result says it was truncated rather than quietly ending.
  */
 const MAX_OUTPUT_BYTES = 64 * 1024;
+
+/**
+ * What a command sees of the deployment it runs in.
+ *
+ * A child process inherits its parent's environment, and this parent is the computer. In the
+ * one-container image that process sits beside the API and `docker/s6/s6-rc.d/computer/run` hands it
+ * the container's environment deliberately, so what a command would inherit is everything the API
+ * was given: the key that decrypts stored credentials, the database URL, the model key. `env` is a
+ * command like any other, and the trail records that a command ran without recording what it
+ * returned, so reading all of them is one call that leaves an unremarkable row.
+ *
+ * AN ALLOW LIST RATHER THAN A DENY LIST. A deny list is the secrets that existed on the day it was
+ * written. The next variable somebody adds to a deployment is not on it, and a boundary that stops
+ * holding without saying so is the failure this repository has already taken two features back for.
+ *
+ * What stays is what a command needs to run at all, plus the proxy variables, because a deployment
+ * behind a proxy has an `apt-get` that reaches nothing without them.
+ *
+ * THIS IS A FLOOR, NOT THE BOUNDARY. `sudo` is passwordless in the image, and root in a shared
+ * container can read another process's environment whatever this function returns. What it removes
+ * is the one-word version.
+ */
+const ALWAYS_PASSED = [
+  "PATH",
+  "LANG",
+  "LANGUAGE",
+  "LC_ALL",
+  "TERM",
+  "TZ",
+  "USER",
+  "LOGNAME",
+  "HOSTNAME",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
+];
+
+/**
+ * The environment for one command.
+ *
+ * `COMPUTER_SHELL_ENV` names anything else a deployment wants a command to see, comma separated. It
+ * is an opt-in and it is read literally: an operator who names a secret there has said to pass that
+ * secret, which is a different thing from a shell that takes everything by default.
+ */
+export function commandEnvironment(
+  env: Record<string, string | undefined>,
+  workspaceDir: string,
+): Record<string, string> {
+  const named = (env.COMPUTER_SHELL_ENV ?? "")
+    .split(",")
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0);
+
+  const passed: Record<string, string> = {};
+  for (const name of [...ALWAYS_PASSED, ...named]) {
+    const value = env[name];
+    if (value !== undefined) passed[name] = value;
+  }
+
+  // Last, so that neither list can point a command's home somewhere other than its workspace.
+  passed.HOME = workspaceDir;
+  return passed;
+}
 
 export type ShellResult = {
   command: string;
@@ -78,7 +145,7 @@ export function createShell(workspaceDir: string) {
        */
       const child = spawn("/bin/bash", ["-lc", input.command], {
         cwd: workspaceDir,
-        env: { ...process.env, HOME: workspaceDir },
+        env: commandEnvironment(process.env, workspaceDir),
       });
 
       let stdout = "";

--- a/agent-computer/tests/shell.test.ts
+++ b/agent-computer/tests/shell.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { commandEnvironment } from "../src/shell";
+
+/**
+ * What a Bot's command can read out of the deployment.
+ *
+ * The case that matters is the first one. A command inherits whatever the computer process holds,
+ * and in the one-container image that is the API's environment: the key that decrypts every stored
+ * credential, the database URL, the model key. A test that only checked `PATH` survives would have
+ * been green while `env` returned all of them.
+ */
+
+const DEPLOYMENT = {
+  PATH: "/usr/local/bin:/usr/bin:/bin",
+  HOME: "/home/pwuser",
+  LANG: "C.UTF-8",
+  KEY_ENCRYPTION_KEY: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+  DATABASE_URL: "postgres://openbot:hunter2@127.0.0.1:5432/openbot",
+  OPENAI_API_KEY: "sk-live-not-for-a-bot",
+  COMPUTER_TOKEN: "the-secret-between-the-api-and-this-process",
+  INTELLIGENCE_API_KEY: "cpk-live",
+  COPILOTKIT_LICENSE_TOKEN: "licence",
+  AGENT_TOOL_TOKEN: "per-agent-callback",
+  SUPERVISOR_TOKEN: "supervisor",
+};
+
+describe("the environment one command gets", () => {
+  test("the deployment's secrets are not in it", () => {
+    const environment = commandEnvironment(DEPLOYMENT, "/workspace");
+
+    for (const name of [
+      "KEY_ENCRYPTION_KEY",
+      "DATABASE_URL",
+      "OPENAI_API_KEY",
+      "COMPUTER_TOKEN",
+      "INTELLIGENCE_API_KEY",
+      "COPILOTKIT_LICENSE_TOKEN",
+      "AGENT_TOOL_TOKEN",
+      "SUPERVISOR_TOKEN",
+    ]) {
+      expect(environment[name]).toBeUndefined();
+    }
+  });
+
+  test("what a command needs to run at all is still there", () => {
+    const environment = commandEnvironment(DEPLOYMENT, "/workspace");
+
+    expect(environment.PATH).toBe("/usr/local/bin:/usr/bin:/bin");
+    expect(environment.LANG).toBe("C.UTF-8");
+  });
+
+  test("home is the workspace, whatever the deployment's home was", () => {
+    // The file tools and a command have to see one directory, and the inherited HOME is the
+    // container user's, not this Bot's.
+    const environment = commandEnvironment(DEPLOYMENT, "/workspace");
+
+    expect(environment.HOME).toBe("/workspace");
+  });
+
+  test("a proxied deployment keeps its proxy variables", () => {
+    // Without these an `apt-get install` behind a corporate proxy hangs rather than failing, and
+    // installing a tool is most of why a Bot has a shell.
+    const environment = commandEnvironment(
+      {
+        ...DEPLOYMENT,
+        HTTPS_PROXY: "http://proxy.internal:8080",
+        no_proxy: "127.0.0.1,localhost",
+      },
+      "/workspace",
+    );
+
+    expect(environment.HTTPS_PROXY).toBe("http://proxy.internal:8080");
+    expect(environment.no_proxy).toBe("127.0.0.1,localhost");
+  });
+
+  test("a deployment can name what else a command should see", () => {
+    const environment = commandEnvironment(
+      {
+        ...DEPLOYMENT,
+        GITHUB_TOKEN: "ghp-for-the-bot",
+        BUILD_CHANNEL: "nightly",
+        COMPUTER_SHELL_ENV: "GITHUB_TOKEN, BUILD_CHANNEL",
+      },
+      "/workspace",
+    );
+
+    // Spaces around a name are an operator writing a list, not a different variable.
+    expect(environment.GITHUB_TOKEN).toBe("ghp-for-the-bot");
+    expect(environment.BUILD_CHANNEL).toBe("nightly");
+    // Naming two does not bring the rest with them.
+    expect(environment.KEY_ENCRYPTION_KEY).toBeUndefined();
+  });
+
+  test("naming a variable that is not set does not invent an empty one", () => {
+    // `test -z "$X"` and `test -v X` are different questions, and a command that branches on the
+    // second should see what the deployment actually has.
+    const environment = commandEnvironment(
+      { ...DEPLOYMENT, COMPUTER_SHELL_ENV: "NEVER_SET" },
+      "/workspace",
+    );
+
+    expect("NEVER_SET" in environment).toBe(false);
+  });
+
+  test("the pass-through list cannot move home out of the workspace", () => {
+    const environment = commandEnvironment(
+      { ...DEPLOYMENT, COMPUTER_SHELL_ENV: "HOME" },
+      "/workspace",
+    );
+
+    expect(environment.HOME).toBe("/workspace");
+  });
+});

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,6 +110,7 @@ Google OAuth client id and secret must be configured together. If Google OAuth i
 - `WORKSPACE_DIR`
 - `PROFILES_DIR`
 - `COMPUTER_BOT_ID`
+- `COMPUTER_SHELL_ENV`
 - `EGRESS_PROXY_DEFAULT`
 - `EGRESS_PROXY_<BOT_ID>`
 


### PR DESCRIPTION
## What this changes

A command spawned by `computer_run_command` was given the computer process's own environment (`agent-computer/src/shell.ts:81`). Under `docker-compose.yml` that is one variable, `COMPUTER_TOKEN`. Under the one-container image it is the container's environment, which `docker/s6/s6-rc.d/computer/run:1` hands over deliberately and which `docs/deployment.md` fills from `--env-file .env`: the key that decrypts stored credentials, the database URL, the model key. `env` returned all of them, and the default policy permits the tool.

Now a command gets what a command needs. `PATH`, the locale and terminal names, and the proxy variables, because an `apt-get` behind a corporate proxy reaches nothing without them. `HOME` is the workspace, set last so nothing can move it. `COMPUTER_SHELL_ENV` names anything else a deployment wants passed through, comma separated and read literally, so naming a secret there is an operator's decision rather than the default it was.

An allow list rather than a deny list, because a deny list is the secrets that existed on the day it was written, and the next variable somebody adds to a deployment is not on it.

Closes #66.

## What this does not do

This is a floor, not the boundary, and the image already says why: `Dockerfile:134-137` notes that a Bot can become root, that per-Bot computers and gVisor are what make that sane, and that "in a container shared between Bots, or one holding a database, a Bot with sudo can reach all of it." Root in a shared container can read another process's environment whatever this function returns. What this removes is the one-word version of it. The larger question, whether a shell belongs in a container that also holds the database and is shared between every Bot, is in the issue rather than in this branch, because it is a product decision and not a bug fix.

## Where it runs

- [x] **New state that outlives a request?** None. `commandEnvironment` is a pure function of the environment it is handed and the workspace path.
- [x] **What happens on the second replica?** The same thing. Every computer process filters its own environment identically; there is nothing shared to disagree about.
- [x] **Anything serialised?** Nothing. No writes.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** No. One new optional variable, `COMPUTER_SHELL_ENV`, read at spawn time.

## Boundary and audit

- [x] Every acting call still goes through the gateway: resolve, decide, audit, then act. Untouched — this changes what the hands are holding, not who decides.
- [x] New refusals and new failures each write a row. No new refusal or failure path; a command that relied on an inherited variable now sees it unset rather than being refused.
- [x] Nothing new is trusted from the client. `COMPUTER_SHELL_ENV` is deployment configuration, read from the computer's own environment, never from a request.

## Proof

`commandEnvironment` is exported and pure, taking the environment as an argument the way `egressFor` does, so the cases can be read without a container. `agent-computer/tests/shell.test.ts` covers seven: the eight secrets a one-container deployment holds are absent; `PATH` and the locale survive; `HOME` is the workspace whatever the deployment's `HOME` was; a proxied deployment keeps `HTTPS_PROXY` and `no_proxy`; `COMPUTER_SHELL_ENV` passes two named variables with surrounding spaces tolerated and brings nothing else with them; naming a variable that is not set does not invent an empty one, because `test -z "$X"` and `test -v X` are different questions; and naming `HOME` in that list cannot move a command's home out of its workspace.

`bun test tests/shell.test.ts` from `agent-computer` reports **7 pass, 0 fail, 18 `expect()` calls**.

**The remaining gates I could not run here, and would rather say so than imply otherwise.** `bunx biome` exits with an access violation on this machine and `bun run typecheck` cannot resolve `yaml`, `zod` and others; both reproduce on a clean checkout of `main` with no changes, so they are this Windows setup rather than this branch, and I could not run the container either. I have kept every line inside 80 columns and followed the formatting of the file beside it, but CI is the real check on that, and I will fix whatever it reports.

Reviewed by reading rather than running: no `ENV` in the `Dockerfile` that a command plausibly needs is dropped, there is no `DEBIAN_FRONTEND` to lose, and `sudo` resets the environment by default in any case, so `sudo apt-get install` behaves exactly as before.
