### PR TITLE
Report a surface-owned tool call to the surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,13 @@ Sessions survive and nobody signs in again.
   laptop `http://localhost` counts as one, so this never showed up in development; on a real
   address it does not, and the surface did nothing at all when you pressed send. No message, no
   error. Ids now come from an API with no such restriction.
+- **A framework Bot asked for a browser action and nothing happened.** `agent-langgraph` ends a run
+  when the model calls a tool the surface owns, which is how a tool that lives in the browser is
+  supposed to work: the run finishes, the surface acts, and the next run carries the result. But the
+  call was only reported to the surface from the node that executes this deployment's own tools, and
+  that node is exactly what an ending run skips. The person saw their own message, no answer under
+  it, and no explanation, because a run that finishes carrying nothing is not an error. Every Bot
+  action in the browser was affected: opening a page, filling a form, asking for help at a sign-in.
 
 ### Changed
 

--- a/agent-langgraph/src/index.ts
+++ b/agent-langgraph/src/index.ts
@@ -436,7 +436,6 @@ async function runAgent(input: RunAgentInput): Promise<Response> {
         // Accumulated rather than emitted per chunk, because a tool call's arguments arrive in
         // fragments and AG-UI wants one call. The framework hands back assembled `tool_calls` on the
         // final message, which is precisely the plumbing agent-bot does by hand.
-        let finalMessage: AIMessage | null = null;
         /** Calls seen on the way past, so a result can be paired with the arguments it answered. */
         const pending = new Map<
           string,
@@ -470,7 +469,6 @@ async function runAgent(input: RunAgentInput): Promise<Response> {
           if (event.event === "on_chat_model_end") {
             const output = event.data?.output as AIMessage | undefined;
             if (output) {
-              finalMessage = output;
               for (const call of output.tool_calls ?? []) {
                 pending.set(call.id ?? call.name, {
                   name: call.name,
@@ -519,6 +517,31 @@ async function runAgent(input: RunAgentInput): Promise<Response> {
         }
 
         closeText();
+
+        /*
+         * Calls this process did not run, which is what a tool the surface owns looks like from here.
+         *
+         * The graph ends the run on one of those rather than inventing a result, so the `tools` node
+         * never fires and the loop above never reports the call. Without this the run is a clean
+         * RUN_STARTED/RUN_FINISHED pair carrying nothing at all: the person's message sits there with
+         * no answer under it, the surface never learns there was a browser action to execute, and
+         * because an empty run is not an error by the protocol, nothing says so. No result is sent
+         * with them; producing it is the surface's half, and it begins the next run holding it.
+         */
+        for (const [id, call] of pending) {
+          send({
+            type: "TOOL_CALL_START",
+            toolCallId: id,
+            toolCallName: call.name,
+          } as BaseEvent);
+          send({
+            type: "TOOL_CALL_ARGS",
+            toolCallId: id,
+            delta: JSON.stringify(call.args),
+          } as BaseEvent);
+          send({ type: "TOOL_CALL_END", toolCallId: id } as BaseEvent);
+        }
+        pending.clear();
 
         send({
           type: "RUN_FINISHED",


### PR DESCRIPTION
## What this changes

`agent-langgraph` ends a run when the model calls a tool the surface owns, which is the right shape and is documented as such in the conditional edge: the run finishes, the browser acts, and the surface starts the next run with the result in hand.

The `TOOL_CALL_*` events were only sent from the branch watching `on_chain_end` for the `tools` node — the node that executes this deployment's own tools, and precisely the node an ending run skips. So the assembled call sat in `pending` and was never emitted. The run was a clean `RUN_STARTED`/`RUN_FINISHED` pair carrying nothing at all: the person's message with no answer under it, no tool call for the surface to execute, and no explanation, because an empty run is not an error by the protocol and the stopped-turn banner only fires on `RUN_ERROR`.

Every browser action was affected, since all of them are `useFrontendTool` registrations: opening a page, filling a form, asking for help at a sign-in. As the default `/bot` agent is `risk-analyst`, which points at this Bot, that is the first thing a fresh clone tries.

The fix drains `pending` before `RUN_FINISHED`, emitting `TOOL_CALL_START`/`ARGS`/`END` and no result — producing the result is the surface's half, and it begins the next run holding it. `finalMessage` is removed with it: it was written twice and never read, which is what was left behind when the events it was accumulated for were not sent.

## Where it runs

- [x] **New state that outlives a request?** None. `pending` is per-run, inside the stream's own closure, and is now emptied before the run ends rather than being left populated.
- [x] **What happens on the second replica?** No change. A run is one request against one Bot process, and the tool call now leaves in that response instead of being dropped in it. Nothing is read back later.
- [x] **Anything serialised?** Nothing new.
- [x] **Anything fanned out to a browser?** Only the AG-UI stream that already answers this request, over events the protocol already defines.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway. This adds no execution path: it reports a call the surface then executes through the gateway exactly as it does for a built-in agent, which is where resolve/decide/audit happen. Before this, the browser action never reached the gateway at all, so nothing was recorded because nothing was attempted.
- [x] New refusals and new failures each write a row. No new refusal or failure class; a refused action now reaches the point where it can be refused and recorded.
- [x] Nothing new is trusted from the client. The events carry the call the model made, assembled by the framework in this process.

## Changelog

- [x] A line under `Unreleased` → `Fixed`.

## Proof

Local stack on this commit, `COMPUTER_SUPERVISOR_URL` set so each Bot gets its own container.

Before, three times over, on `/bot` (default agent, so `risk-analyst`): *"Open news.ycombinator.com and tell me the top story"*, *"Use your browser to open https://example.com and tell me the exact h1 text"*, and a third variation. Each produced no assistant message, no `computer.*` row in `audit_events`, and no computer container. Plain prose turns on the same Bot answered normally, so the transport was fine.

After: same Bot, *"Open https://example.com on your computer and quote its h1 exactly"* → the live screen renders the page and the answer is `"Example Domain"`. `audit_events` has the matching row:

```
07:58:44 | computer.action_allowed | risk-analyst | computer_navigate | https://example.com
```

and no failure row beside it. `openbot-computer-risk-analyst` was deleted before the run, so that container was also built from nothing during it.
