### PR TITLE
Wait before rebuilding a computer that just lost a race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,13 @@ Sessions survive and nobody signs in again.
   laptop `http://localhost` counts as one, so this never showed up in development; on a real
   address it does not, and the surface did nothing at all when you pressed send. No message, no
   error. Ids now come from an API with no such restriction.
+- **The first browser action a Bot was ever asked for failed.** Creating a computer and starting it
+  are two calls to Docker, and a name the daemon has not published yet answers the second with a 404.
+  The supervisor treats that as a lost race and rebuilds, which is right, but it went straight back
+  round: the retry landed a millisecond later, saw the same unpublished name, and spent the only
+  other attempt on it. The whole request then failed as Docker being unreachable, the person was told
+  the computer could not be started, and the next message worked. It waits one poll interval before
+  rebuilding now, which is what the health wait already uses for the same question.
 
 ### Changed
 

--- a/supervisor/src/docker.ts
+++ b/supervisor/src/docker.ts
@@ -45,6 +45,13 @@ function statusOf(error: unknown): number | undefined {
   return (error as { statusCode?: number }).statusCode;
 }
 
+/** One poll interval, used both by the health wait and by the retry that follows a lost race. */
+function pause(ms: number): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(resolve, ms);
+  return promise;
+}
+
 export type ComputerState = {
   botId: string;
   container: string;
@@ -180,7 +187,7 @@ async function waitUntilAnswering(
     } catch {
       // Mid-creation, or gone. The deadline is what ends this.
     }
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    await pause(250);
   }
 }
 
@@ -311,10 +318,22 @@ export async function ensure(
         await docker.getContainer(names.container).start();
       } catch (error) {
         const status = statusOf(error);
-        // Gone between creating it and starting it: a concurrent reset took the container away, or
-        // the create this request lost the race to was itself rolled back. Nothing about the Bot has
-        // changed, so the answer is to build it again rather than to report Docker as unreachable.
-        if (status === 404 && attempt > 1) continue;
+        /*
+         * Gone between creating it and starting it: a concurrent reset took the container away, the
+         * create this request lost the race to was itself rolled back, or the daemon has not yet
+         * published the name this request just created. Nothing about the Bot has changed, so the
+         * answer is to build it again rather than to report Docker as unreachable.
+         *
+         * Paused first, because the retry is the whole budget. Going straight back round arrives
+         * within a millisecond, sees the same not-yet-published name, and spends the second attempt
+         * on the state that failed the first: the first browser action a Bot is ever asked for fails,
+         * and the second one, seconds later, works. One poll interval is what the health wait uses
+         * for the same question.
+         */
+        if (status === 404 && attempt > 1) {
+          await pause(250);
+          continue;
+        }
         // 304 is "already running", which is success for an idempotent verb.
         if (status !== 304) {
           throw new DockerUnavailableError(String(error));


### PR DESCRIPTION
## What this changes

Creating a computer and starting it are two calls to Docker. A container name the daemon has not published yet answers the second with a 404, and `ensure` already reads that correctly as a lost race whose answer is to rebuild.

It retried immediately, though, and with `ATTEMPTS = 2` the retry is the entire budget: it arrived within a millisecond, `inspectOwned` still saw nothing, the create came back 409 because the name was in fact taken, and `start` returned 404 again with no attempt left. The whole request then failed as `DockerUnavailableError`, which is surfaced to the person as the computer not being startable and recorded as `computer.action_failed`.

The symptom is that the first browser action a Bot is ever asked for fails, and the same request seconds later works, so it reads as a flaky Bot rather than as a race. On this machine (OrbStack) it hit two of three Bots on their first ever action.

One poll interval before rebuilding fixes it — 250 ms, which is what `waitUntilAnswering` already uses for the same question about the same container. Both sleeps now share a `pause` helper.

## Where it runs

- [x] **New state that outlives a request?** None. The change is a delay inside one `ensure` call.
- [x] **What happens on the second replica?** Unchanged, and slightly better. Two replicas asking for one Bot's computer concurrently is the race this retry path exists for: the loser now looks again after the winner's create has settled instead of before it, which is the difference between rebuilding successfully and reporting Docker as unreachable. Idempotency still rests on the container name and the ownership label, not on timing.
- [x] **Anything serialised?** Nothing new. Concurrent `ensure` calls are still resolved by Docker refusing a duplicate name with 409, which this path already treats as success.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** None. No new timer either: one bounded await on an existing retry path.

## Boundary and audit

- [x] Every acting call still goes through the gateway. Untouched: this is below it, in provisioning.
- [x] New refusals and new failures each write a row. No new class. The failure this removes was already written as `computer.action_failed` with the Docker message, which is how it was diagnosed.
- [x] Nothing new is trusted from the client. Nothing here reads a request.

## Changelog

- [x] A line under `Unreleased` → `Fixed`.

## Proof

Before, on a first-ever action for a Bot, from `audit_events`:

```
computer.action_allowed  general-assistant  computer_navigate  https://example.com
computer.action_failed   general-assistant  computer_navigate  The supervisor could not reach Docker
  (Error: (HTTP code 404) no such container - No such container: openbot-computer-general-assistant).
  A computer cannot be started without it.
```

Then the same request a minute later succeeded, with the container present. The same pair appeared for `risk-analyst` on its first action.

After, on this commit: rebuilt the supervisor, deleted `openbot-computer-risk-analyst` outright, and asked that Bot to open a page. The container was created and started on the first attempt, the page rendered in the live screen, and `audit_events` has `computer.action_allowed` with no failure row beside it. A second Bot (`knowledge`) also provisioned first time.
