### PR TITLE
fix: State what decides channel access, and what allowed_groups is waiting on

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,6 +103,12 @@ A coworker is a durable Bot profile:
 
 A channel is a conversation with one coworker and a CopilotKit Intelligence thread mapping. Starting a new channel creates a new thread.
 
+Who may reach one is decided by membership: every channel route resolves the caller in
+`channel_memberships` and refuses without a row. `channels.allowed_groups` is declared in the
+tenant package and stored, and is not part of that decision — `users.groups` is never populated by
+any sign-in path, so a group-based rule has nothing to evaluate. Treat it as a declaration waiting
+on group membership from the identity provider, not as a control that is running.
+
 See [coworkers.md](coworkers.md).
 
 ## Components

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -306,6 +306,18 @@ channels:
 
 Each channel requires `id`, `name`, `description`, `permitted_agents`, and `allowed_groups`. Every `permitted_agents` entry must match an agent id.
 
+`allowed_groups` is validated and stored, and nothing reads it. It decides nothing today, and a
+deployment that writes one must not treat it as an access control. Both halves of that control are
+missing, not one: `users.groups` exists as a column and no sign-in path, claim mapping or admin
+screen ever populates it, so there is nothing for a channel's list to be compared against. Channel
+access is decided by membership alone — every channel route resolves the caller's row in
+`channel_memberships` and refuses without it.
+
+Package-declared channels get no membership rows from `synchronizeTenantPackage`, so today they
+are unreachable rather than open. The field is kept because the enforcement it is named for needs
+the declaration and needs group membership arriving from the identity provider, and neither this
+column nor `users.groups` is the wrong shape for it.
+
 ### `model.yaml`
 
 ```yaml

--- a/server/src/db/schema/core.ts
+++ b/server/src/db/schema/core.ts
@@ -50,6 +50,14 @@ export const users = pgTable("users", {
   name: text("name"),
   image: text("image"),
   emailVerified: boolean("email_verified").notNull().default(false),
+  /**
+   * The person's groups, for a group-based rule to be evaluated against.
+   *
+   * Empty on every row: no sign-in path, claim mapping or admin screen writes this, and nothing
+   * reads it. It is the other half of `channels.allowedGroups`, and #82 is about the pair. Anything
+   * that starts deciding access on a group has to populate this first, or it decides on an empty
+   * list for everybody.
+   */
   groups: text("groups").array().notNull().default([]),
   createdAt: createdAt(),
   updatedAt: updatedAt(),
@@ -221,6 +229,16 @@ export const channels = pgTable(
     name: text("name").notNull(),
     description: text("description").notNull(),
     suggestedPrompts: text("suggested_prompts").array().notNull().default([]),
+    /**
+     * Which groups the tenant package says this channel is for.
+     *
+     * Written by `synchronizeTenantPackage` and read by nothing. Channel access is membership: every
+     * route resolves the caller in `channelMemberships` and refuses without a row, and this column is
+     * not consulted on the way. It is not currently a hole, because package channels get no
+     * membership rows either and so are unreachable rather than open, but it is a control the name
+     * promises and nothing keeps. See #82, and `users.groups`, which is the half that has to arrive
+     * from the identity provider before this one can decide anything.
+     */
     allowedGroups: text("allowed_groups").array().notNull().default([]),
     packageId: uuid("package_id").references(() => deploymentPackages.id, {
       onDelete: "set null",


### PR DESCRIPTION
## What this changes

Documents `allowed_groups` as what it is today: a declaration the tenant package carries, not a control that decides anything yet.

Fixes #82, and thanks to @andreolf for a really precise writeup — the "not currently exploitable, but it will be the moment membership is wired up" framing is exactly right, and it's what made this easy to pick up.

`synchronizeTenantPackage` writes `channels.allowed_groups` (`server/src/tenant-package.ts:488,496`), the column is declared (`server/src/db/schema/core.ts:224`), and a grep across every `.ts` and `.tsx` finds only tests. Channel access is membership: every route resolves the caller's row in `channel_memberships` and refuses without it.

One thing worth adding to the issue's analysis, because it decides which of the two suggested fixes to take: both halves of the control are waiting, not one. `users.groups` (`server/src/db/schema/core.ts:53`) is also written by nothing and read by nothing — no sign-in path, no claim mapping, no admin screen, no configuration. There's no group membership anywhere in the deployment for a channel's list to be compared against.

That makes enforcement the bigger piece rather than the quicker one. A check today would compare a declared list against an empty one for every person, which either denies everybody or means nothing depending on which way it's written. Getting group membership to arrive from the identity provider is the real feature underneath, and that's a design call worth having on its own.

So this takes the issue's second suggestion for now, and leaves the first one open:

- `docs/configuration.md` — the `channels.yaml` section says the field is validated and stored and read by nothing, points at `users.groups` as the other half, and notes that channel access is membership alone. Also records that package channels get no membership rows, so today they're unreachable rather than open.
- `docs/architecture.md` — the same note where "Coworkers and channels" describes what a channel is, since that's where you'd look to find out who can reach one.
- `server/src/db/schema/core.ts` — a comment on each of the two columns pointing at the other, so the next person to touch either half learns there that it's half of something.

The data stays. Unlike the state #21 took back, neither column is the wrong shape for the rule they're named for — a per-channel list of groups and a per-user list of groups are what a group rule needs, and what's missing is the identity-provider mapping in between. Removing them would also break every existing tenant package, since `allowed_groups` is required in `channels.yaml`.

## Where it runs

- **New state that outlives a request?** None. No runtime code changes: documentation and two schema comments.
- **What happens on the second replica?** Identical behavior everywhere. Nothing changes on any of them.
- **Anything serialised?** N/A, no writes.
- **Anything fanned out to a browser?** No.
- **New listener, port, or schedule?** No.

## Boundary and audit

- N/A. No gateway, policy, or audit path touched. The membership check that decides channel access is unchanged.

## Changelog

No line — a deployment behaves the same afterwards. What changes is that the documentation stops implying otherwise.

## Proof

No failing test to write first, because there's no behavior change to prove: two documents and two columns stop describing something the code doesn't do. What the claim rests on is a grep, and it reproduces:

- `channels.allowed_groups` / `allowedGroups` across every `.ts` and `.tsx`: writers at `server/src/tenant-package.ts:302,488,496`, the column at `server/src/db/schema/core.ts:224`, otherwise only `server/tests/tenant-package.test.ts` and `server/tests/channel-routes.test.ts`. No reader on any access path.
- `users.groups`: the column at `server/src/db/schema/core.ts:53` and nothing else in `server/src` or `app/src`. No `.md`, `.yaml` or `.json` maps an identity-provider claim onto it either.

Ran on this branch:

- `bun run format:check` — clean, 363 files.
- `bun run lint` — 27 warnings, 1 info, identical to unmodified `main`.
- `bun run typecheck` — clean across app, server and worker.
- `bun run build` — clean.
- `bun test` — **780 pass, 5 skip, 79 fail, 864 tests across 91 files**, exactly the unmodified `main` baseline on this machine. The 79 are the database integration tests; there's no local Postgres here and they fail the same way on a clean `main`, which is what the CI `tests` job runs pgvector for. No test added or removed.

## On the red `migrations` check

Not from this branch — it's failing on `main` too, since #87, and every branch cut from `main` inherits it. `meta/0005_snapshot.json` has drifted from `core.ts`, so `drizzle-kit generate` writes a migration nobody asked for and the drift probe fails on the dirty tree. Filed as #91 with the details; the two comments added here produce no DDL.
