### PR TITLE
Keep the playground's delete off a component the build ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,16 @@ Sessions survive and nobody signs in again.
   access and refresh tokens use Better Auth's own encryption, keyed on `BETTER_AUTH_SECRET`.
 - **A failed provider registration looked like a button that did not work.** The error was rendered
   on the page behind the dialog, which was covering it.
+- **Deleting a component in the playground could release one the build ships.** `DELETE
+  /api/sandboxed/:name` deleted from the shared components table by name, without checking
+  which kind of component the name belonged to. Naming a compiled component removed its
+  governance row, and the foreign keys took that component's per-Bot withholdings and its
+  function grants with it. Withholding is the half that fails open: a published component is
+  available to every Bot unless a row says otherwise, so the next catalogue announcement brought
+  the component back published, and available to a Bot it had deliberately been kept from. The
+  audit row called it `kind: "sandboxed"`. The endpoint now refuses a name this surface does not
+  own and answers 404, the way publishing already did. A governance row whose source is already
+  gone is still this surface's to clear.
 - **A Bot could become root inside its container.** `sudo` was granted as `NOPASSWD: ALL`, and the
   comment above it named the two conditions that made that acceptable: the container being one Bot's
   alone, and not holding a database. The image meets neither, because the supervisor is deliberately

--- a/server/src/components/sandboxed-routes.ts
+++ b/server/src/components/sandboxed-routes.ts
@@ -110,8 +110,19 @@ export function createSandboxedRoutes(
     const forbidden = requireAdmin(context);
     if (forbidden) return forbidden;
 
-    await store.remove(context.req.param("name"), actorEmail(context));
-    return context.json({ ok: true });
+    // Answered like `publish`, because it is the same question: this surface owns the components it
+    // authored, and a name with no draft behind it is not one of them. Reporting that as "not found"
+    // rather than as success also stops a caller reading `{ ok: true }` as "the thing you named is
+    // gone", which it was not.
+    try {
+      await store.remove(context.req.param("name"), actorEmail(context));
+      return context.json({ ok: true });
+    } catch (error) {
+      if (error instanceof SandboxedNotFoundError) {
+        return context.json({ error: error.message }, 404);
+      }
+      throw error;
+    }
   });
 
   return routes;

--- a/server/src/components/sandboxed.ts
+++ b/server/src/components/sandboxed.ts
@@ -277,6 +277,38 @@ export function createSandboxedStore(
     },
 
     async remove(name: string, by: string): Promise<void> {
+      /*
+       * Refuse a name this surface does not own.
+       *
+       * `components` is shared with the compiled catalogue and the delete below is by name, with
+       * nothing checking which kind of component the name belonged to. So a compiled component's
+       * governance row could be deleted through the playground's endpoint, and the foreign keys took
+       * its per-Bot withholdings and its function grants with it.
+       *
+       * The withholdings are the half that fails open. A published component is available to every
+       * Bot unless a `component_exclusions` row says otherwise, so losing that row does not hide the
+       * component, it releases it — and the next catalogue announcement rewrites the component with
+       * `published: true`, because that is how one the build ships arrives. A deliberate "not this
+       * Bot" comes back as "every Bot", under an audit row saying `kind: "sandboxed"`, which is the
+       * one thing it was not.
+       *
+       * Asked of the governance row's `kind` rather than of `sandboxed_components`, because ownership
+       * is the actual question and the two answers differ in one case worth keeping: these deletes
+       * are not in a transaction, so a failure between them leaves a governance row with no source.
+       * That orphan is the "catalogue disagrees with the build" state named below, it is this
+       * surface's to clean up, and requiring the source row would have made it undeletable here.
+       */
+      const [governance] = await database
+        .select({ kind: components.kind })
+        .from(components)
+        .where(eq(components.name, name))
+        .limit(1);
+      // "sandboxed" is the kind `save` writes above. A name with no row at all is refused for the
+      // same reason `publish` refuses one: this surface has nothing by that name to act on.
+      if (governance?.kind !== "sandboxed") {
+        throw new SandboxedNotFoundError(name);
+      }
+
       // Delete both rows; a governance row pointing at a component with no source is the visible
       // "catalogue disagrees with the build" state.
       await database

--- a/server/tests/sandboxed-components.integration.test.ts
+++ b/server/tests/sandboxed-components.integration.test.ts
@@ -1,11 +1,20 @@
-import { afterAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { createAuditStore } from "../src/audit";
-import { createSandboxedStore } from "../src/components/sandboxed";
+import {
+  createSandboxedStore,
+  SandboxedNotFoundError,
+} from "../src/components/sandboxed";
 import { createDatabase } from "../src/db/client";
 import { TEST_POOL } from "./support/database";
-import { components, sandboxedComponents } from "../src/db/schema";
+import {
+  agents,
+  componentExclusions,
+  componentFunctions,
+  components,
+  sandboxedComponents,
+} from "../src/db/schema";
 
 /**
  * A component authored in a browser can be edited freely and still reach nobody until it is
@@ -144,5 +153,123 @@ describe("authoring a component without a rebuild", () => {
     // A governance row pointing at a component with no source is the "catalogue disagrees with the
     // build" state the components table exists to make visible.
     expect(governance).toBeUndefined();
+  });
+});
+
+/**
+ * What this surface may delete.
+ *
+ * `components` is shared with the compiled catalogue, so a delete by name on this endpoint could
+ * reach a row the playground never authored. `save` refuses a name that is not a slug and `publish`
+ * refuses a name with no draft behind it; `remove` did neither, which is the asymmetry these pin.
+ */
+describe("deleting a name this surface does not own", () => {
+  const compiled = `chart_test_${suite}`;
+  const bot = `agent_test_${suite}`;
+
+  beforeAll(async () => {
+    await database
+      .insert(agents)
+      .values({ id: bot, name: bot, type: "remote_ag_ui", configuration: {} })
+      .onConflictDoNothing();
+    // A component the build ships, as `syncCatalogue` would have written it.
+    await database.insert(components).values({
+      name: compiled,
+      title: "A compiled chart",
+      kind: "chart",
+      draftDescription: "Drawn by the build.",
+      publishedDescription: "Drawn by the build.",
+      published: true,
+      publishedAt: new Date(),
+      updatedBy: "the build",
+    });
+    // One Bot held back from it. This row is the whole of the decision: a published component is
+    // available to every Bot unless it exists.
+    await database.insert(componentExclusions).values({
+      componentName: compiled,
+      agentId: bot,
+      withheldBy: "admin@openbot.local",
+    });
+    await database.insert(componentFunctions).values({
+      componentName: compiled,
+      functionName: "listRecentOrders",
+      grantedBy: "admin@openbot.local",
+    });
+  });
+
+  afterAll(async () => {
+    await database.delete(components).where(eq(components.name, compiled));
+    await database.delete(agents).where(eq(agents.id, bot));
+  });
+
+  test("refuses a compiled component's name instead of deleting its governance", async () => {
+    await expect(store.remove(compiled, "admin@openbot.local")).rejects.toThrow(
+      SandboxedNotFoundError,
+    );
+
+    const [governance] = await database
+      .select()
+      .from(components)
+      .where(eq(components.name, compiled));
+    expect(governance).toBeDefined();
+    expect(governance?.published).toBe(true);
+  });
+
+  test("leaves the withholding that would otherwise have been released", async () => {
+    // The half that fails OPEN, and the reason this is worth a guard rather than a tidy-up. Losing
+    // this row does not hide the component from the Bot, it releases it to the Bot — and the next
+    // catalogue announcement rewrites the component as published, because that is how one the build
+    // ships arrives. A deliberate "not this Bot" would come back as "every Bot".
+    const withheld = await database
+      .select()
+      .from(componentExclusions)
+      .where(eq(componentExclusions.componentName, compiled));
+    expect(withheld).toHaveLength(1);
+  });
+
+  test("leaves the function grants, which the cascade would also have taken", async () => {
+    // This half fails closed, so it is a capability lost rather than one gained. Asserted anyway:
+    // a component that silently stops being able to read is still a component that stopped working.
+    const granted = await database
+      .select()
+      .from(componentFunctions)
+      .where(eq(componentFunctions.componentName, compiled));
+    expect(granted).toHaveLength(1);
+  });
+
+  test("refuses a name nothing was ever authored under", async () => {
+    // Answered rather than reported as success. `{ ok: true }` for a name that was never there reads
+    // as "the thing you named is gone", which is the one thing it does not establish.
+    await expect(
+      store.remove(`custom_never_${suite}`, "admin@openbot.local"),
+    ).rejects.toThrow(SandboxedNotFoundError);
+  });
+
+  test("still deletes a governance row whose source is already gone", async () => {
+    /*
+     * The orphan, and the reason the guard asks about `kind` rather than about the source row.
+     *
+     * `remove` deletes from two tables and not in one transaction, so a failure between them leaves
+     * exactly this: a governance row of this surface's own kind with nothing behind it. It is the
+     * "catalogue disagrees with the build" state, it belongs to this surface, and gating on the
+     * source row instead would have left it with no way to be cleared.
+     */
+    const orphan = `custom_orphan_${suite}`;
+    await database.insert(components).values({
+      name: orphan,
+      title: "A draft whose source went",
+      kind: "sandboxed",
+      draftDescription: "Authored here.",
+      published: false,
+      updatedBy: "admin@openbot.local",
+    });
+
+    await store.remove(orphan, "admin@openbot.local");
+
+    const [gone] = await database
+      .select()
+      .from(components)
+      .where(eq(components.name, orphan));
+    expect(gone).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What this changes

`DELETE /api/sandboxed/:name` handed the raw path parameter to `store.remove`, which deleted from
`components` — the table shared with the compiled catalogue — with nothing checking which kind of
component the name belonged to.

The three mutating routes on this surface disagreed about what a name may be, and that asymmetry is
the bug rather than the delete itself: `save` refuses a name that is not a slug, `publish` refuses a
name with no draft behind it, `remove` did neither.

For a compiled component's name the `sandboxed_components` delete matched nothing and the
`components` delete succeeded, taking that component's per-Bot withholdings and its function grants
with it through `onDelete: "cascade"`.

The withholdings are the half that fails open, and the schema says why itself — a published component
is available to every Bot unless a `component_exclusions` row says otherwise. Losing that row does not
hide the component, it releases it. Then `syncCatalogue` sees the component as missing on the next
announcement from a browser and writes it back with `published: true`, because that is how one the
build ships arrives. A deliberate "not this Bot" comes back as "every Bot", under an audit row saying
`kind: "sandboxed"` — the one thing the deleted component was not.

The function grants fail closed, so that half is a capability silently lost rather than one gained.

`remove` now refuses a name this surface does not own, and the route answers 404 the way `publish`
already did.

**Gated on the governance row's `kind`, not on the presence of a `sandboxed_components` row.**
Ownership is the actual question, and the two answers differ in one case worth keeping: the two
deletes are not in a transaction, so a failure between them leaves a governance row with no source.
That orphan is the "catalogue disagrees with the build" state the existing comment names, it is this
surface's to clear, and requiring the source row would have made it undeletable through the only
endpoint that could. There is a test for it.

Admin-only either way, so this is a footgun rather than an escalation, and I would not put it higher
than that.

Closes #108

## Where it runs

- **New state that outlives a request?** None. One `select` added inside an existing store method.
- **What happens on the second replica?** Identical. The check reads the same `components` row any
  replica would; nothing is cached, held, or remembered between requests.
- **Anything serialised?** No, and nothing new needs to be. This narrows what a delete may touch, so
  two administrators racing to delete the same name end where they did before: one deletes, the other
  finds nothing of this kind by that name and gets a 404. The pre-existing non-transactional pair of
  deletes is unchanged, and is the reason the `kind` gate is written the way it is rather than as
  `requireRow`.
- **Anything fanned out to a browser?** No.
- **New listener, port, or schedule?** No.

## Boundary and audit

- No change to resolve → decide → audit → act. `requireAdmin` still gates the route, ahead of this.
- **A refusal now writes nothing, and that is deliberate.** The audit row was written after both
  deletes, so a refused delete never reached it. There is no `component.*` event for "refused a
  delete", and the existing `component.refused` means a Bot reaching for a component it does not
  hold, which this is not. Inventing a row for it looked like the larger change and the wrong call
  for a bug fix; happy to add one if you would rather it were recorded.
- The row a successful delete writes is unchanged. It is now only written for a component this
  surface actually owns, which is the fix — previously it claimed `kind: "sandboxed"` about a
  compiled component.
- Nothing new is trusted from the client. Strictly less is: the `:name` parameter used to select the
  row to delete on its own.

## Changelog

Added under `Unreleased` → `Fixed`: "Deleting a component in the playground could release one the
build ships."

## Proof

Five tests added to `server/tests/sandboxed-components.integration.test.ts`, in a new describe block,
covering: a compiled component's name is refused and its governance row survives; the withholding
that would have been released survives; the function grants survive; a name nothing was authored
under is refused; and an orphaned governance row of this surface's own kind is still deleted.

**Honest limit on what I ran.** These are integration tests and this machine has no PostgreSQL —
Docker Desktop is not running, and the embedded PostgreSQL this repo ships is an apt install inside
the container image rather than something reusable on a host. So I have not executed them, and CI is
the first place they will run. I would rather say that than imply a green suite I did not see.

What I did run:

```
server $ bunx tsc --noEmit                         clean
biome format (3 changed files)                     clean
biome lint   (3 changed files)                     clean
bun test server/tests/component-decision.test.ts   5 pass, 0 fail
```

The typecheck is worth more here than it usually is: Drizzle types `.values({...})` against the table
schema, so a missing `notNull` column, a wrong column name, or a bad `agentType` in the fixtures would
have failed it rather than failing at runtime. It passes. The `agents` fixture is copied from
`component-store.integration.test.ts`, which is an existing passing test against the same tables.

Note for anyone reading the diff locally on Windows: this checkout has `core.autocrlf=true`, so
`biome format` reports CRLF against the working tree. `.gitattributes` is `* text=auto` and the
committed blobs are LF; the numbers above are from the LF content as committed.

## What is not covered

- **The two deletes are still not in one transaction.** Unchanged by this, and now with a test that
  documents the orphan it produces and asserts the orphan stays clearable. Wrapping them is a
  separate change and I did not want to fold it in.
- **Nothing stops an administrator deleting a sandboxed component that Bots are using.** That is the
  feature working, not a gap; this PR is only about names this surface does not own.
- **No new audit event for a refused delete**, per the note above.
