### PR TITLE
Keep a rule about one action surface from refusing another

### DIFF
--- a/server/src/computer/gateway.ts
+++ b/server/src/computer/gateway.ts
@@ -419,6 +419,12 @@ export function createComputerGateway(
         ? describeFile(filePath)
         : { path: "", name: "", extension: "" },
       command: subject.command ?? "",
+      // Neutral, like the fields above: this is not an MCP call, but a `deny: mcp.effect == "write"`
+      // names `mcp`, and cel-js throws on an unbound identifier — which fails closed and would refuse
+      // every browser action the moment an operator wrote a rule about their tools. Empty server and
+      // tool and an empty effect match no MCP rule, so a boundary drawn around MCP leaves the browser
+      // alone. The MCP context carries the browser fields empty for the mirror of this reason.
+      mcp: { server: "", tool: "", effect: "" },
     };
 
     const decision = evaluateActionPolicy(options.policy(), context);

--- a/server/src/computer/policy.ts
+++ b/server/src/computer/policy.ts
@@ -130,7 +130,12 @@ export type PolicyContext = {
   mcp?: {
     server: string;
     tool: string;
-    effect: "read" | "write";
+    /**
+     * `read` or `write` on a real MCP call. `""` in the neutral `mcp` a non-MCP action carries, so
+     * that neither `mcp.effect == "read"` nor `== "write"` matches a browser or file action. See the
+     * neutral binding in the gateway, and the same reasoning the browser fields carry on an MCP call.
+     */
+    effect: "read" | "write" | "";
   };
   /**
    * The command a Bot is about to run on its computer, verbatim.

--- a/server/src/plugins/store.ts
+++ b/server/src/plugins/store.ts
@@ -802,6 +802,11 @@ export function createPluginStore(options: PluginStoreOptions) {
         element: { ref: "", role: "", name: "", type: "" },
         key: "",
         file: { path: "", name: "", extension: "" },
+        // Empty, like the browser fields above: an MCP call runs no shell command, but a
+        // `deny: contains(command, "rm -rf")` names `command`, and an unbound identifier throws and
+        // fails closed — which would refuse every MCP call once a deployment wrote a rule about its
+        // shell. An empty command matches no such rule.
+        command: "",
         intent: effect === "write" ? "write_tool" : "read_tool",
         mcp: { server: serverId, tool: toolName, effect },
       };

--- a/server/tests/computer-gateway.test.ts
+++ b/server/tests/computer-gateway.test.ts
@@ -242,6 +242,21 @@ describe("the computer gateway", () => {
     expect(rows[0]?.targetId).toBe("bot-1");
   });
 
+  test("a rule about MCP does not refuse a browser action", async () => {
+    // An operator blocking MCP writes must not thereby block every click. The gateway carries a
+    // neutral `mcp`, so `mcp.effect == "write"` names a bound field and evaluates to false rather
+    // than throwing, which fails closed and would refuse the click.
+    const { gateway, calls, rows } = await gatewayWith({
+      ...PERMISSIVE,
+      deny: ['mcp.effect == "write"'],
+    });
+
+    await gateway.click("bot-1", ACTOR, { ref: "e9", snapshotId: 7 });
+
+    expect(calls).toEqual(["click"]);
+    expect(rows[0]?.eventType).toBe("computer.action_allowed");
+  });
+
   test("the refusal names the rule, so an operator can find it", async () => {
     const { gateway } = await gatewayWith({
       ...PERMISSIVE,

--- a/server/tests/computer-policy.test.ts
+++ b/server/tests/computer-policy.test.ts
@@ -520,3 +520,102 @@ describe("commands", () => {
     expect(decision.allowed).toBe(true);
   });
 });
+
+/**
+ * A boundary drawn around one acting surface must leave the others alone.
+ *
+ * Each surface builds the context it owns and carries the other surfaces' fields at their neutral,
+ * matches-nothing value — the browser context a neutral `mcp`, the MCP context a neutral `command` —
+ * so a rule naming another surface's field evaluates to false rather than throwing. An unbound field
+ * throws, and a thrown rule fails closed, so without this a `deny: mcp.effect == "write"` would refuse
+ * every browser click and a `deny: contains(command, "rm")` every MCP call: an operator forbidding one
+ * thing would silently forbid another, and could not reason about what they had done.
+ */
+describe("a rule about one surface does not refuse another", () => {
+  // The shapes the gateway and the MCP path actually build, including the neutral cross-surface fields.
+  const browserAction: PolicyContext = {
+    tool: { name: "computer_click" },
+    bot: { id: "b" },
+    actor: { id: "a" },
+    page: { url: "https://example.com", host: "example.com" },
+    intent: "activate",
+    element: { ref: "e1", role: "button", name: "Open", type: "" },
+    key: "",
+    file: { path: "", name: "", extension: "" },
+    command: "",
+    mcp: { server: "", tool: "", effect: "" },
+  };
+  const mcpAction: PolicyContext = {
+    tool: { name: "mcp__jira__getIssue" },
+    bot: { id: "b" },
+    actor: { id: "a" },
+    page: { url: "", host: "" },
+    intent: "read_tool",
+    element: { ref: "", role: "", name: "", type: "" },
+    key: "",
+    file: { path: "", name: "", extension: "" },
+    command: "",
+    mcp: { server: "jira", tool: "getIssue", effect: "read" },
+  };
+
+  test("an MCP deny rule leaves a browser action alone", () => {
+    const decision = evaluateActionPolicy(
+      { mode: "enforce", deny: ['mcp.effect == "write"'], allow: ["true"] },
+      browserAction,
+    );
+    expect(decision.allowed).toBe(true);
+  });
+
+  test("neither an MCP read nor an MCP write rule catches a browser action", () => {
+    for (const rule of ['mcp.effect == "read"', 'mcp.effect == "write"']) {
+      const decision = evaluateActionPolicy(
+        { mode: "enforce", deny: [rule], allow: ["true"] },
+        browserAction,
+      );
+      expect(decision.allowed).toBe(true);
+    }
+  });
+
+  test("a shell-command deny rule leaves an MCP call alone", () => {
+    const decision = evaluateActionPolicy(
+      {
+        mode: "enforce",
+        deny: ['contains(command, "rm -rf")'],
+        allow: ["true"],
+      },
+      mcpAction,
+    );
+    expect(decision.allowed).toBe(true);
+  });
+
+  test("the MCP rule still refuses a real MCP write", () => {
+    const decision = evaluateActionPolicy(
+      { mode: "enforce", deny: ['mcp.effect == "write"'], allow: ["true"] },
+      {
+        ...mcpAction,
+        intent: "write_tool",
+        mcp: { server: "jira", tool: "editIssue", effect: "write" },
+      },
+    );
+    expect(decision.allowed).toBe(false);
+    expect(decision.source).toBe("deny");
+  });
+
+  test("the shell rule still refuses a real command", () => {
+    const decision = evaluateActionPolicy(
+      {
+        mode: "enforce",
+        deny: ['contains(command, "rm -rf")'],
+        allow: ["true"],
+      },
+      {
+        ...browserAction,
+        tool: { name: "computer_run_command" },
+        intent: "run_command",
+        command: "rm -rf /",
+      },
+    );
+    expect(decision.allowed).toBe(false);
+    expect(decision.source).toBe("deny");
+  });
+});


### PR DESCRIPTION
## What this changes

A policy expression that names a field the current action does not carry throws in cel-js, and a
thrown rule fails closed, so instead of evaluating to false it **refuses the action**. Each acting
surface already builds its context with the other surfaces' fields at a neutral, matches-nothing
value for exactly this reason — but two were missed, one on each side:

- the **browser** context (`computer/gateway.ts`) had no `mcp`, so `deny: mcp.effect == "write"`
  threw on every click, keypress, navigation and file action and refused all of them;
- the **MCP** context (`plugins/store.ts`) had no `command`, so `deny: contains(command, "rm -rf")`
  threw on every MCP call and refused all of them.

So an operator forbidding one surface silently disabled another — the one thing this policy exists to
let a deployment reason about. This fills the two neutral fields in, matching the ones already there.
`mcp.effect` gains `""` as its neutral value so that neither `== "read"` nor `== "write"` matches a
non-MCP action, the mirror of the empty strings that match no browser rule.

The engine itself still fails closed on a genuinely unbound field — the deliberate floor the policy
unit tests carry (`a rule about an element still decides when the element is unknown`,
`unguarded, it refuses a navigation that has no key at all`). This change does not touch that; it
only completes the context each surface hands the engine.

## Where it runs

- [x] **New state that outlives a request?** None. This is per-action policy context construction.
- [x] **What happens on the second replica?** Identical — no shared state. The decision is a pure
      function of the action and the current policy on whichever replica evaluates it.
- [x] **Anything serialised / fanned out / new listener?** No.

## Boundary and audit

- [x] Every acting call still goes through the gateway: resolve, decide, audit, then act. Only the
      context handed to `evaluateActionPolicy` changed, by gaining the neutral field it was missing.
- [x] Refusals still write a row. The change is that a browser action is no longer refused by an MCP
      rule (and vice versa); a real MCP write and a real shell command are still refused and recorded.
- [x] Nothing new is trusted from the client. The neutral values are constants, not caller input.

## Proof

Behaviour measured with `evaluateActionPolicy`, before and after:

| action | rule | before | after |
| --- | --- | --- | --- |
| `computer_click` | `deny: mcp.effect == "write"` | **refused** | permitted |
| MCP read | `deny: contains(command, "rm -rf")` | **refused** | permitted |
| MCP write | `deny: mcp.effect == "write"` | refused | refused |
| `run_command` (`rm -rf /`) | `deny: contains(command, "rm -rf")` | refused | refused |

- `bun run typecheck` (app/server/worker) — clean.
- `bun test server/tests/computer-policy.test.ts server/tests/computer-gateway.test.ts` — 80 pass.
  New: a `describe("a rule about one surface does not refuse another")` covering both directions and
  proving real rules still fire, and a gateway test proving an MCP rule does not refuse a click at the
  real call site.
- The broader computer/plugin unit suite (174 tests) stays green.

Two neutral fields, one on each surface, matching the ones already there; no engine behaviour
changed.
