### PR TITLE
Keep a New chat from being undone by the check it raced

### DIFF
--- a/app/src/lib/copilot/bot-thread.ts
+++ b/app/src/lib/copilot/bot-thread.ts
@@ -144,10 +144,16 @@ export function useBotThread(agentId: string): BotThread {
   // Shared between the effect's own resolution mint and `startNew`'s mint so the two can never
   // race each other into two POST /mint calls fighting over the same localStorage slot.
   const mintingRef = useRef(false);
+  // Set once `startNew` has taken over, so the mount-time check that is still in flight does not
+  // then overwrite the fresh thread with the remembered one. `checkKnown` is a read, not a mint, so
+  // `mintingRef` is clear while it runs and would not have stopped `startNew` starting during it.
+  const startedNewRef = useRef(false);
 
   useEffect(() => {
     let current = true;
     mountedRef.current = true;
+    // A new agent resolves from scratch, so any earlier `startNew` no longer speaks for this one.
+    startedNewRef.current = false;
     setThreadId(undefined);
     setHistory("ready");
 
@@ -172,7 +178,10 @@ export function useBotThread(agentId: string): BotThread {
       adoptFresh();
     } else {
       void checkKnown(existing).then((outcome) => {
-        if (!current) return;
+        // `startedNewRef` as well as `current`: the agent may have changed (which `current` catches),
+        // or the person may have pressed New chat while this check was in flight, and a check about
+        // the thread they just left must not put it back.
+        if (!current || startedNewRef.current) return;
         const decision = threadToUse({
           remembered: existing,
           known: outcome.known,
@@ -195,6 +204,8 @@ export function useBotThread(agentId: string): BotThread {
   const startNew = useCallback(() => {
     if (mintingRef.current) return;
     mintingRef.current = true;
+    // From here the mount-time check must not touch the thread: the person has asked for a new one.
+    startedNewRef.current = true;
     void mint().then((minted) => {
       mintingRef.current = false;
       if (!mountedRef.current) return;

--- a/app/src/lib/copilot/bot-thread.ts
+++ b/app/src/lib/copilot/bot-thread.ts
@@ -204,8 +204,6 @@ export function useBotThread(agentId: string): BotThread {
   const startNew = useCallback(() => {
     if (mintingRef.current) return;
     mintingRef.current = true;
-    // From here the mount-time check must not touch the thread: the person has asked for a new one.
-    startedNewRef.current = true;
     void mint().then((minted) => {
       mintingRef.current = false;
       if (!mountedRef.current) return;
@@ -213,6 +211,20 @@ export function useBotThread(agentId: string): BotThread {
       // end up worse off — mid-conversation and suddenly unable to send — than before they pressed
       // it.
       if (!minted) return;
+      /*
+       * Latched here rather than at the press, and the difference is a blank screen.
+       *
+       * Set on the press, a mint that then fails leaves the mount-time check disarmed with nothing
+       * having replaced the thread: `bot.tsx` renders the chat only when there is one, so the person
+       * is left looking at an empty pane with no message and no way back but a reload. Set here, a
+       * failed mint disarms nothing and the remembered thread is still restored.
+       *
+       * This is not a weaker guard. Assignment and the check below both run to completion on one
+       * thread, so a `checkKnown` that resolves after this sees it, and one that resolves before it
+       * has already restored a thread that this line is about to replace — which is what the person
+       * asked for.
+       */
+      startedNewRef.current = true;
       remember(agentId, minted);
       setThreadId(minted);
       setHistory("ready");


### PR DESCRIPTION
## What this changes

A race in `useBotThread` (from #81). The hook verifies a remembered thread on mount — `checkKnown`, a network round-trip — before handing the id out. `startNew` (the **New chat** button) runs from an event handler and its mint is *not* held behind that check: `checkKnown` is a read, not a mint, so the `mintingRef` guard that serialises the two mints is clear while it runs.

So the two race:

1. Chat mounts with a remembered thread; `checkKnown(existing)` is in flight.
2. The person presses **New chat**; `startNew` mints a fresh thread.
3. `startNew`'s mint resolves first → `setThreadId(minted)`.
4. `checkKnown` resolves (`known: true`) → its handler runs `setThreadId(existing)`.

The new chat is silently replaced by the old one — the person asked for a fresh conversation, watched it appear, and landed back in the previous one, with nothing on screen to explain it. Exactly the *"pressing New chat should never leave you worse off"* the hook already reasons about, in the one window it did not cover: the `current` flag the resolution reads only catches the agent changing or the component unmounting.

The fix mirrors the guards already there. `startNew` sets a `startedNewRef`; the mount-time resolution reads it, so a check about the thread the person just left cannot overwrite the one they just asked for. It resets at the top of the effect, so a new agent resolves from scratch.

## Where it runs

- [x] **New state that outlives a request?** None. One more `useRef` guard in the same hook, alongside the existing `current` and `mountedRef`. Nothing crosses to another process.
- [x] **What happens on the second replica?** N/A — this is per-browser component state; the turn is driven from the browser and this id lives and dies with the mount.
- [x] **Anything serialised / fanned out / new listener?** No. The only persistence (`localStorage`) is unchanged; the fix stops a stale write to React state, not to storage.

## Boundary and audit

- [x] No acting call, gateway, policy or audit path is touched. This is client-side thread-id resolution for the direct Bot chat.

## Proof

- `bun run typecheck` (app) — clean.
- `bun test app/tests app/src` — 121 pass, unchanged. The hook's async coordination is not unit-tested here (the existing `current`/`mountedRef` guards are not either); the pure decision it wraps, `threadToUse`, is, and stays green. The fix is the same guard shape as those two, verified by the interleaving above.
- `biome check` — clean.

One `useRef` and one condition, matching the guards beside it; no storage, network, or decision logic changed.
