### PR TITLE
Run the container-boot check only when a PR is a merge candidate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,15 @@ jobs:
   image:
     name: image
     runs-on: ubuntu-latest
+    # The only slow job: it builds the container and boots it, ~14 minutes. The four checks above are
+    # seconds and stay on every push, because they catch most things cheaply. This one is the cost, so
+    # on a pull request it runs only when an admin adds the `full-ci` label — the point at which the PR
+    # is actually a merge candidate. On main and through the release workflow_call it always runs, so
+    # nothing reaches a release without it. `verify` treats a skipped job as passing, so an unlabelled
+    # PR is green on the cheap checks alone.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
The `image` job (build the container, boot it, ~14 min) ran on every pull request and every push. The other four checks are seconds. So the slow, expensive one fired on work nowhere near merge — wasted minutes on every push.

Now on a pull request `image` runs only when an admin adds the **`full-ci`** label — the moment the PR is actually a merge candidate. On `main` and through the release `workflow_call` it always runs, so nothing reaches a release without having booted. `verify` already counts a skipped job as a pass, so an unlabelled PR is green on the cheap checks alone.

No behaviour change to what the checks test; only when the slow one fires.