### PR TITLE
Run the two typecheck scripts nothing ran, and build the images from their lockfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,13 +214,48 @@ jobs:
       - if: always()
         run: docker rm -f openbot-ci >/dev/null 2>&1 || true
 
+  # The two packages `static` cannot reach.
+  #
+  # Root `typecheck` is `bun run --filter '*' typecheck`, which enumerates workspaces, and `workspaces`
+  # is app, server and worker. `agent-computer` and `supervisor` are deployables of their own with their
+  # own lockfiles, and both have shipped a `typecheck` script that nothing ever ran — so a change to
+  # the process holding the only `spawn` in the deployment, or to the only thing holding a Docker
+  # socket, reached an image without a type check.
+  #
+  # A separate job rather than another line in `static` because each installs from its own lockfile:
+  # the root install cannot produce their dependency trees. Matrixed so each reports its own result,
+  # and `fail-fast: false` so one failing does not hide the other's answer.
+  deployables:
+    name: types, ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [agent-computer, supervisor]
+    # Nothing here needs a browser, and the install would otherwise be a few hundred megabytes for
+    # `agent-computer`. Bun does not run an untrusted package's postinstall anyway; this says so on
+    # purpose rather than relying on it.
+    env:
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - run: bun install --frozen-lockfile
+        working-directory: ${{ matrix.package }}
+      - run: bun run typecheck
+        working-directory: ${{ matrix.package }}
+
   # One check for branch protection to require. A new job above is covered by this without anybody
   # remembering to add it to a list, and a job that was skipped for the wrong reason is not a pass.
   verify:
     name: verify
     runs-on: ubuntu-latest
     if: always()
-    needs: [static, test, build, migrations, image]
+    needs: [static, deployables, test, build, migrations, image]
     steps:
       - name: Require every check
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ Sessions survive and nobody signs in again.
 
 ### Changed
 
+- **The images are built from the lockfiles that are committed.** Every deployable but the root one
+  installed with a plain `bun install`, and its `bun.lock` was not even in the build context, so the
+  committed file could not have been honoured and each build resolved dependencies afresh. An image
+  built next month was not the image built today, which is the drift the pinned Bun version was
+  already there to prevent, one layer down — and it is also what a build provenance attestation is
+  signing. `agent-computer`, `supervisor`, `agent-bot` and `agent-langgraph` now copy their lockfile
+  and install `--frozen-lockfile`. CI also typechecks `agent-computer` and `supervisor`, which each
+  shipped a `typecheck` script that nothing ran: they are not workspaces, so root `typecheck` never
+  reached the process holding the only `spawn` in the deployment, or the only one holding a Docker
+  socket.
 - **This deployment does not search documents itself.** A Bot answers from a live system by calling
   that system's own search as the person asking, so the vendor decides what they may see and there is
   no second copy of anybody's documents here to keep in step, to secure, or to leave behind when

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,11 @@ COPY server/package.json server/package.json
 COPY worker/package.json worker/package.json
 RUN bun install --frozen-lockfile
 
-COPY agent-computer/package.json agent-computer/package.json
-RUN cd agent-computer && bun install
+# Its lockfile too, and installed against it. `agent-computer/bun.lock` is committed but was not in
+# the build context, so it could not have been honoured: this resolved afresh every build, which is
+# the drift the note about pinning Bun above is there to prevent, one layer down.
+COPY agent-computer/package.json agent-computer/bun.lock agent-computer/
+RUN cd agent-computer && bun install --frozen-lockfile
 
 # A second tree with the build-time dependencies left out, for the runtime stage to take. Vite,
 # biome and the test tooling are a gigabyte that nothing in a running container imports.

--- a/agent-bot/Dockerfile
+++ b/agent-bot/Dockerfile
@@ -5,8 +5,9 @@ FROM oven/bun:1.3-alpine
 WORKDIR /app
 RUN chown bun:bun /app
 USER bun
-COPY --chown=bun:bun agent-bot/package.json ./agent-bot/
-RUN cd agent-bot && bun install
+COPY --chown=bun:bun agent-bot/package.json agent-bot/bun.lock ./agent-bot/
+# Installed against the committed lockfile, which was not in the build context before.
+RUN cd agent-bot && bun install --frozen-lockfile
 
 # Preserve the repo layout so `../../shared/bot-prompt` resolves the same in the image and locally.
 COPY --chown=bun:bun shared ./shared

--- a/agent-computer/Dockerfile
+++ b/agent-computer/Dockerfile
@@ -11,8 +11,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends unzip \
 ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
-COPY agent-computer/package.json ./
-RUN bun install
+COPY agent-computer/package.json agent-computer/bun.lock ./
+# Installed against the committed lockfile. It was not in the build context before, so the file
+# existed and could not have been honoured.
+RUN bun install --frozen-lockfile
 
 COPY agent-computer/src ./src
 

--- a/agent-langgraph/Dockerfile
+++ b/agent-langgraph/Dockerfile
@@ -5,8 +5,9 @@
 FROM oven/bun:1.3-alpine
 
 WORKDIR /app
-COPY agent-langgraph/package.json ./agent-langgraph/
-RUN cd agent-langgraph && bun install
+COPY agent-langgraph/package.json agent-langgraph/bun.lock ./agent-langgraph/
+# Installed against the committed lockfile, which was not in the build context before.
+RUN cd agent-langgraph && bun install --frozen-lockfile
 
 # The repo's own layout, kept exactly, so `../../shared/bot-prompt` resolves the same here as it
 # does on a laptop. Flattening src to /app/src would change the depth and break only on deploy.

--- a/supervisor/Dockerfile
+++ b/supervisor/Dockerfile
@@ -10,8 +10,9 @@ FROM ghcr.io/spiffe/spire-server:1.15.1 AS spire
 FROM oven/bun:1.3.14-alpine
 
 WORKDIR /app
-COPY supervisor/package.json ./
-RUN bun install
+COPY supervisor/package.json supervisor/bun.lock ./
+# Installed against the committed lockfile, which was not in the build context before.
+RUN bun install --frozen-lockfile
 
 COPY --from=spire /opt/spire/bin/spire-server /usr/local/bin/spire-server
 


### PR DESCRIPTION
## What this changes

Two gates that were written, committed, and never reached. Both cover `agent-computer`, which is the
process a Bot's input reaches a child process in.

### 1. Two `typecheck` scripts that never ran

`agent-computer/package.json` and `supervisor/package.json` each ship
`"typecheck": "tsc --noEmit"`. Root `typecheck` is `bun run --filter '*' typecheck`, which enumerates
workspaces, and `workspaces` is `["app", "server", "worker"]`. `ci.yml` runs `bun run typecheck` and
nothing else typechecks anything, so neither script has ever run in CI.

That is the process holding the only `spawn` in the deployment, and the only one holding a Docker
socket (`supervisor/Dockerfile:1`), reaching an image without a type check. #68 changed `shell.ts`
without one seeing it.

**Both pass today**, so this is a gate turned on rather than a backlog cleared:

```
agent-computer $ bunx tsc --noEmit     # clean
supervisor     $ bunx tsc --noEmit     # clean
```

A separate job rather than another line in `static`, because each installs from its own lockfile and
the root install cannot produce their dependency trees. Matrixed so each reports its own result with
`fail-fast: false`, and added to `verify` so branch protection needs no new entry — which is what #64
built that gate for.

`agent-bot`, `agent-langgraph` and the `examples/` packages have no `typecheck` script at all. That is
a separate question and I have left it alone.

### 2. Lockfiles that were not merely unenforced — they were not in the build context

Every deployable but the root one installed with a plain `bun install`, and none of them copied its
`bun.lock`:

| Dockerfile | before |
| --- | --- |
| `Dockerfile:48-49` | `COPY agent-computer/package.json …` then `bun install` |
| `agent-computer/Dockerfile:14-15` | `COPY agent-computer/package.json ./` then `bun install` |
| `supervisor/Dockerfile:13-14` | `COPY supervisor/package.json ./` then `bun install` |
| `agent-bot/Dockerfile:8-9` | `COPY … agent-bot/package.json …` then `bun install` |
| `agent-langgraph/Dockerfile:8-9` | `COPY … agent-langgraph/package.json …` then `bun install` |

So the committed lockfile could not have been honoured however the command was written — the file was
not there. Each build resolved afresh.

The root `Dockerfile` argues against this itself, twenty-three lines above the install that ignored it:

> Bun is pinned. The installer takes whatever is newest otherwise, so the runtime drifts from the one
> the lockfile was resolved against and an image built next month is not the image built today.

It also bears on #64. That change signs a build provenance attestation for the image digest, and
provenance over a tree resolved at build time attests to less than it looks like: the digest is exact,
and part of what went into it was decided by nothing in this repository.

All four now copy their lockfile and install `--frozen-lockfile`.

The `examples/` packages keep their lockfiles and are untouched: nothing installs them in CI or in an
image, so there is no build to pin.

Closes #112

## Where it runs

- **New state that outlives a request?** None. No runtime code changes at all — this is CI
  configuration and four image builds.
- **What happens on the second replica?** Nothing differs. No process behaviour changes; the images
  are built from a pinned dependency tree rather than a freshly resolved one, which is the same on
  every replica by construction.
- **Anything serialised?** N/A.
- **Anything fanned out to a browser?** No.
- **New listener, port, or schedule?** No new listener or port. One new CI job, which runs per pull
  request like the others and is covered by `verify`.

## Boundary and audit

- No runtime path is touched, so resolve → decide → audit → act is unchanged.
- No new refusals and no new rows.
- Nothing new is trusted from a client. Strictly less is trusted from the network at build time: an
  image's dependency tree is now decided by a committed file rather than by whatever the registry
  serves that day.

## Changelog

Added under `Unreleased` → `Changed`: "The images are built from the lockfiles that are committed."

## Proof

**The four installs were checked against their committed lockfiles before the flag was added**, so
this pins what is already resolved rather than asking for a refresh. Each in a clean directory
containing only its `package.json` and `bun.lock`:

```
agent-computer   bun install --frozen-lockfile   63 packages
supervisor       bun install --frozen-lockfile   73 packages
agent-bot        bun install --frozen-lockfile   43 packages
agent-langgraph  bun install --frozen-lockfile   39 packages
```

**Both new typechecks run clean locally**, which is the whole of what the new job asserts:

```
agent-computer $ bunx tsc --noEmit     # clean
supervisor     $ bunx tsc --noEmit     # clean
```

`ci.yml` parses, and the new job is wired into the gate rather than only defined:

```
jobs:          static, test, build, migrations, image, deployables, verify
verify needs:  static, deployables, test, build, migrations, image
matrix:        {package: [agent-computer, supervisor]}
```

`.dockerignore` does not exclude `bun.lock`, so the new `COPY` lines resolve. The `image` job builds
the root `Dockerfile` on every pull request, so the changed build is exercised here rather than
first at a release.

`bun run lint` clean (including `--error-on-warnings`, from #120). This change touches only YAML,
Dockerfiles and Markdown, none of which biome formats, so `format:check` is unaffected by it.

## What is not covered

- **The `examples/` lockfiles**, per above — nothing builds them.
- **`agent-bot` and `agent-langgraph` still have no typecheck script.** Adding one is writing a new
  gate rather than turning on a written one, and might surface real errors; worth doing, worth doing
  separately.
- **The two new typechecks do not run in the `image` job**, which builds rather than typechecks. They
  are their own job for that reason.
- **Nothing here refreshes a lockfile.** If one of the four ever drifts from its `package.json`, the
  build now fails and says so, which is the point — but it does mean a dependency bump has to update
  the lockfile in the same commit.
