### PR TITLE
Typecheck the two deployables, and hold every lockfile to what is committed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,39 @@ jobs:
       - run: bun run lint
       - run: bun run typecheck
 
+  # The two packages that are deployables in their own right rather than root workspaces. Root
+  # `typecheck` is `bun run --filter '*' typecheck`, and `--filter '*'` enumerates `workspaces`, which
+  # is app, server and worker. So both of these ship a `typecheck` script that nothing has ever run:
+  # `agent-computer` holds the only `spawn` in the deployment and `supervisor` is the only thing
+  # holding a Docker socket, which is a poor pair to leave untyped. Both are clean today, so this
+  # changes nothing about main and only stops the next change being the first one a type checker sees.
+  #
+  # Not by adding them to `workspaces`: each is built from its own lockfile and the Dockerfile depends
+  # on that, so they are installed separately here for the same reason they are installed separately
+  # there. A matrix rather than two jobs, so each package reports its own result and a third one is a
+  # line in the list below and nothing in `verify`, which sees the whole matrix as one entry.
+  deployables:
+    name: types (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    strategy:
+      # One red package must not hide whether the other is red too.
+      fail-fast: false
+      matrix:
+        package: [agent-computer, supervisor]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      # No root install: each package carries its own typescript, and its tsconfig reaches
+      # tsconfig.base.json through the checkout rather than through node_modules.
+      - run: bun install --frozen-lockfile
+        working-directory: ${{ matrix.package }}
+      - run: bun run typecheck
+        working-directory: ${{ matrix.package }}
+
   test:
     name: tests
     runs-on: ubuntu-latest
@@ -220,7 +253,7 @@ jobs:
     name: verify
     runs-on: ubuntu-latest
     if: always()
-    needs: [static, test, build, migrations, image]
+    needs: [static, deployables, test, build, migrations, image]
     steps:
       - name: Require every check
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,13 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-      # No root install: each package carries its own typescript, and its tsconfig reaches
-      # tsconfig.base.json through the checkout rather than through node_modules.
+      # The root install comes first, and it is not redundant. Both packages set
+      # `types: ["bun"]` in their tsconfig, and `@types/bun` is a root devDependency rather than
+      # one of theirs, so tsc resolves it by walking up to the root node_modules. Without this step
+      # the typecheck fails with TS2688 on a fresh checkout, which is what a first attempt at this
+      # job did. It is also what the image already does: Dockerfile installs at the root before
+      # installing agent-computer, and a developer's working copy has both for the same reason.
+      - run: bun install --frozen-lockfile
       - run: bun install --frozen-lockfile
         working-directory: ${{ matrix.package }}
       - run: bun run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,11 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-      # The root install comes first, and it is not redundant. Both packages set
-      # `types: ["bun"]` in their tsconfig, and `@types/bun` is a root devDependency rather than
-      # one of theirs, so tsc resolves it by walking up to the root node_modules. Without this step
-      # the typecheck fails with TS2688 on a fresh checkout, which is what a first attempt at this
-      # job did. It is also what the image already does: Dockerfile installs at the root before
-      # installing agent-computer, and a developer's working copy has both for the same reason.
+      # Two installs, and the root one is load-bearing. Both packages set `types: ["bun"]` in
+      # their tsconfig while `@types/bun` is a root devDependency, so tsc resolves it by walking up
+      # to the root node_modules. Without it the typecheck fails with TS2688 on a fresh checkout.
+      # This is the order the image uses for the same reason: Dockerfile installs at the root
+      # before installing agent-computer.
       - run: bun install --frozen-lockfile
       - run: bun install --frozen-lockfile
         working-directory: ${{ matrix.package }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,13 @@ COPY server/package.json server/package.json
 COPY worker/package.json worker/package.json
 RUN bun install --frozen-lockfile
 
+# The lockfile travels with the manifest, because `--frozen-lockfile` with no lockfile in the context
+# is not an error: bun resolves afresh, succeeds, and the flag has decorated nothing. With both files
+# here, the tree in the image is the tree this repository resolved and committed. Bun is already
+# pinned twenty-odd lines above for the same reason; this is the install below it.
 COPY agent-computer/package.json agent-computer/package.json
-RUN cd agent-computer && bun install
+COPY agent-computer/bun.lock agent-computer/bun.lock
+RUN cd agent-computer && bun install --frozen-lockfile
 
 # A second tree with the build-time dependencies left out, for the runtime stage to take. Vite,
 # biome and the test tooling are a gigabyte that nothing in a running container imports.

--- a/agent-bot/Dockerfile
+++ b/agent-bot/Dockerfile
@@ -5,8 +5,10 @@ FROM oven/bun:1.3-alpine
 WORKDIR /app
 RUN chown bun:bun /app
 USER bun
-COPY --chown=bun:bun agent-bot/package.json ./agent-bot/
-RUN cd agent-bot && bun install
+# The lockfile as well as the manifest: `--frozen-lockfile` with no lockfile present resolves afresh
+# and exits 0, so the file has to be here for the flag to mean anything.
+COPY --chown=bun:bun agent-bot/package.json agent-bot/bun.lock ./agent-bot/
+RUN cd agent-bot && bun install --frozen-lockfile
 
 # Preserve the repo layout so `../../shared/bot-prompt` resolves the same in the image and locally.
 COPY --chown=bun:bun shared ./shared

--- a/agent-computer/Dockerfile
+++ b/agent-computer/Dockerfile
@@ -11,8 +11,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends unzip \
 ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
-COPY agent-computer/package.json ./
-RUN bun install
+# The lockfile as well as the manifest: `--frozen-lockfile` with no lockfile present resolves afresh
+# and exits 0, so the file has to be here for the flag to mean anything.
+COPY agent-computer/package.json agent-computer/bun.lock ./
+RUN bun install --frozen-lockfile
 
 COPY agent-computer/src ./src
 

--- a/agent-langgraph/Dockerfile
+++ b/agent-langgraph/Dockerfile
@@ -5,8 +5,10 @@
 FROM oven/bun:1.3-alpine
 
 WORKDIR /app
-COPY agent-langgraph/package.json ./agent-langgraph/
-RUN cd agent-langgraph && bun install
+# The lockfile as well as the manifest: `--frozen-lockfile` with no lockfile present resolves afresh
+# and exits 0, so the file has to be here for the flag to mean anything.
+COPY agent-langgraph/package.json agent-langgraph/bun.lock ./agent-langgraph/
+RUN cd agent-langgraph && bun install --frozen-lockfile
 
 # The repo's own layout, kept exactly, so `../../shared/bot-prompt` resolves the same here as it
 # does on a laptop. Flattening src to /app/src would change the depth and break only on deploy.

--- a/supervisor/Dockerfile
+++ b/supervisor/Dockerfile
@@ -10,8 +10,11 @@ FROM ghcr.io/spiffe/spire-server:1.15.1 AS spire
 FROM oven/bun:1.3.14-alpine
 
 WORKDIR /app
-COPY supervisor/package.json ./
-RUN bun install
+# The lockfile as well as the manifest: `--frozen-lockfile` with no lockfile present resolves afresh
+# and exits 0. This is the process whose compromise costs the host, so what it runs is the tree that
+# was reviewed, not whatever the registry had this morning.
+COPY supervisor/package.json supervisor/bun.lock ./
+RUN bun install --frozen-lockfile
 
 COPY --from=spire /opt/spire/bin/spire-server /usr/local/bin/spire-server
 


### PR DESCRIPTION
## What this changes

The two packages that run a Bot's computer are now typechecked in CI, and every committed lockfile is installed frozen.

Fixes #112. Thanks @Hotragn — the table of which package has a script against which package CI reaches, and measuring that both are already clean, is what makes this a wiring change rather than a cleanup. Heads up that you said a branch was coming: if you have one further along, say so and I will close this in favour of it.

## 1. The typecheck the two deployables never got

`typecheck` at the root is `bun run --filter '*' typecheck` and `workspaces` is `["app", "server", "worker"]`, so `--filter '*'` never reaches `agent-computer` or `supervisor`. Both ship a `typecheck` script somebody wrote deliberately, and neither has ever run in CI. `agent-computer` holds the only `spawn` in the deployment; `supervisor` is the only thing holding a Docker socket.

Both are clean today, measured under the pinned bun 1.3.14:

```
agent-computer $ bun install --frozen-lockfile   # 64 packages installed
agent-computer $ bun run typecheck               # exit 0, no output
supervisor     $ bun install --frozen-lockfile   # 73 packages installed
supervisor     $ bun run typecheck               # exit 0, no output
```

So this adds a check rather than clearing a backlog, which is also why nobody noticed the scripts were idle.

A `deployables` matrix job runs each package's own script after its own frozen install, `fail-fast: false` so one red package does not hide the other. **It is in `verify`'s `needs`** — branch protection requires `verify` alone, so a job outside it would be advisory and block nothing.

Neither package joins `workspaces`, as the issue asked: `Dockerfile` depends on them being separate installs and `tests/workspace.test.ts` pins the current shape on purpose. A third deployable later is one matrix entry and no change to `verify`, since a matrix reports as a single `needs` result. The tradeoff, stated plainly: the matrix list is still a list, just not one in `verify`. A self-discovering job would remove even that, and would also silently enrol packages nobody meant to.

### Why the job installs twice

Both packages set `types: ["bun"]` in their `tsconfig.json` while `@types/bun` is a **root** devDependency (`package.json:30`), so `tsc` resolves it by walking up to the root `node_modules`. Neither typecheck script is self-contained: on a fresh checkout with only the package installed, both fail with `error TS2688: Cannot find type definition file for 'bun'`.

The job therefore installs at the root and then in the package, which is the order `Dockerfile` already uses — root install at `:46`, `agent-computer` at `:54`. That dependency on the root tree is also part of why these scripts went unnoticed: anywhere anyone ran them by hand already had it.

Verified against a clean tree with every `node_modules` removed, in the job's own order: root install, package install, typecheck, both packages green. Removing the root `node_modules` reproduces `TS2688`; restoring it passes.

`ci.yml` gained #117 twenty minutes before this branch was cut. The `image` job's `if:`, its comment, and `verify`'s skipped-is-a-pass semantics are byte-identical here.

## 2. The lockfiles, and why the flag alone would not have worked

This is the part that came out differently from the issue's proposal, and it is worth reading before approving.

Six of seven committed lockfiles were installed with a bare `bun install`. Adding `--frozen-lockfile` looks like one word per site. It is not:

```
$ cd supervisor && mv bun.lock /tmp/ && bun install --frozen-lockfile
+ hono@4.13.3          # the lockfile pins 4.13.2
73 packages installed
EXIT=0
```

**`--frozen-lockfile` with no lockfile present is not an error.** Bun resolves fresh and exits 0. Every one of these Dockerfiles copied only `package.json`, so the flag on its own would have produced five checks that can never fail — #112's own complaint, reintroduced by its own fix.

So each site copies its lockfile too:

| File | Change |
| --- | --- |
| `Dockerfile:53-54` | `COPY agent-computer/bun.lock`, then `bun install --frozen-lockfile` |
| `agent-computer/Dockerfile:16-17` | lockfile added to the `COPY` |
| `supervisor/Dockerfile:16-17` | same |
| `agent-bot/Dockerfile:10-11` | same, keeping `--chown=bun:bun` |
| `agent-langgraph/Dockerfile:10-11` | same |

All five build contexts are `.` in `docker-compose.yml` and `bun.lock` is not in `.dockerignore`, so every path resolves. A repo-wide `grep "bun install"` now shows the flag at every install site in every workflow and Dockerfile; the only bare ones left are `README.md:91` and `docs/development.md:9`, which are human setup instructions.

The release consequence the issue raises holds: #64 signs provenance for the image digest, and provenance over a tree resolved at build time attests to less than it looks like.

## Where it runs

- **New state that outlives a request?** None. No runtime code changed.
- **What happens on the second replica?** Nothing differs. This is CI configuration and build-time installs.
- **Anything serialised?** Nothing new.
- **Anything fanned out to a browser?** No.
- **New listener, port, or schedule?** No listener and no port. One new CI job on `pull_request` / `push: main` / `workflow_call`, roughly two runner-minutes of cheap work beside `static`.

## Boundary and audit

- Untouched. No acting call, no refusal path, nothing new trusted from a client.

## Changelog

No entry. `CHANGELOG.md` is for when a deployment behaves differently, and #117 — the last CI-only change — added none either. The image's dependency tree is now the committed one rather than one resolved at build time, which is reproducibility rather than behaviour. Flagging rather than deciding silently: happy to add a line under `### Changed` if you would rather have it recorded.

## Proof

**The new checks fail when they should.** Each injection reverted afterwards:

| injection | result |
| --- | --- |
| `const __ciProbe: number = "not a number"` in `agent-computer/src/index.ts` | `error TS2322`, exit 2 |
| same in `supervisor/src/index.ts` | `error TS2322`, exit 2 |
| `hono ^4.10.0 → ^3.0.0` in `supervisor/package.json` | `error: lockfile had changes, but lockfile is frozen`, exit 1 |
| `"left-pad": "^1.3.0"` added, absent from the tree | same error, exit 1 |
| lockfile moved away, `package.json` untouched | **exit 0** — the finding above |

One false positive recorded so nobody repeats it: adding `"ms": "^2.1.3"` to `supervisor/package.json` passes, because `ms` is already in `supervisor/bun.lock` as a transitive dependency. Nothing about the resolution changed. Not a hole in the flag.

`git status` stayed clean through every frozen install, so no lockfile has drifted and no refresh is needed.

YAML validated with the repo's own `yaml` package: jobs parse as `static, deployables, test, build, migrations, image, verify`, and `verify.needs` is `["static","deployables","test","build","migrations","image"]`.

Rest of the suite, against unmodified `main` at `f1701d8`:

- `bun run test` — **918 pass, 8 skip, 112 fail, 1038 tests across 105 files**, identical to `main`. The 112 are the Postgres integration tests; there is no database and no Docker on this machine, and they fail the same way on a clean checkout, which is what the CI `tests` job runs pgvector for.
- `bunx biome lint .` — 25 warnings, 1 info, identical to `main`. (#75 is the separate change that makes those fail the build.)
- `bun run format:check` — clean, 385 files.
- `bun run typecheck` — clean.
- `bun run build` — clean.
- `tests/workspace.test.ts` still passes, because `workspaces` is unchanged.

I could not build the images — no Docker here — so the Dockerfile edits are verified by running the equivalent frozen install in each directory under bun 1.3.14, confirming each `COPY` source exists, that every context is `.`, and that `bun.lock` is not dockerignored. The `image` job builds the root Dockerfile on a `full-ci` PR or on `main`.

## Not in this PR

- **The `examples/` lockfiles.** `examples/langgraph-bot/bun.lock` and `examples/mastra-bot/bun.lock` are installed by nothing at all, so there is no site to add a flag to. Enforcing them means a job that installs sample code, which would let example drift break the gate on `main`. Both are currently consistent (`--frozen-lockfile --dry-run` exits 0 in each). Worth its own issue if you want it.
- **`agent-bot` and `agent-langgraph` in the matrix.** Neither has a `typecheck` script, so enrolling them means writing tsconfigs first — the separate question the issue already set aside.
- **#75**, the lint check exiting 0 on its own warnings, which has its own PR.
