### PR TITLE
Fix three things a from-scratch install found

### DIFF
--- a/app/src/lib/computers/queries.ts
+++ b/app/src/lib/computers/queries.ts
@@ -41,17 +41,20 @@ export const computerKeys = {
 };
 
 /**
- * A placeholder id in the path. The endpoint answers with every computer regardless, so this is
- * addressing a collection through a member's route rather than naming one.
+ * The deployment-wide fleet route.
+ *
+ * Not a Bot id in a member route, which is what this used to be. That placeholder stopped working
+ * when the server began checking whether the caller may act as the Bot in the path: a placeholder
+ * is not a Bot, so the list 404d and this screen showed nothing at all.
  */
-const FLEET_ID = "openbot-computer";
+const FLEET_PATH = "/api/computers/fleet";
 
 /** No envelope key: the body carries both the list and the isolation mode. */
 export function computerFleetQueryOptions() {
   return queryOptions({
     queryKey: computerKeys.fleet(),
     queryFn: async (): Promise<ComputerFleet> => {
-      const response = await client(`/api/computers/${FLEET_ID}/computers`, {
+      const response = await client(FLEET_PATH, {
         fallback: "The computers could not be listed.",
       });
       return response.json();

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -141,13 +141,16 @@ for table in agent_profiles agent_preferences; do
 done
 green "  coworker tables migrated"
 
-MANAGED_URL="$(grep -E '^MANAGED_AGENT_AG_UI_URL=' "$ROOT/.env" | tail -1 | cut -d= -f2-)"
-if [ -z "$MANAGED_URL" ]; then
-  red "  MANAGED_AGENT_AG_UI_URL is not set in .env."
-  red "  See .env.example."
-  exit 1
-fi
-green "  managed coworker endpoint: $MANAGED_URL"
+# Resolved at the top, where the default that .env deliberately does not carry is applied. Reading
+# .env again here would have demanded the line be present in a file the comment above that default
+# says must not contain it, which is how this came to refuse every fresh clone: `cp .env.example
+# .env` leaves it commented out, so the grep matched nothing.
+#
+# It failed silently, too. Under `set -o pipefail` a grep that matches nothing fails its whole
+# pipeline, and `set -e` then aborts the assignment before the check below could say why. The same
+# grep survives inside `setting()` only because `local v="$(...)"` takes `local`'s own exit status
+# and masks it. So: report what was resolved, and do not re-read the file.
+green "  managed coworker endpoint: $MANAGED_AGENT_AG_UI_URL"
 
 info "2/4  Server"
 require_free_or_ours "$SERVER_PORT" server

--- a/server/src/components/store.ts
+++ b/server/src/components/store.ts
@@ -125,7 +125,7 @@ export function createComponentStore(database: Database): ComponentStore {
       const missing = entries.filter((entry) => !known.has(entry.name));
       if (missing.length === 0) return { added: [] };
 
-      await database
+      const inserted = await database
         .insert(components)
         .values(
           missing.map((entry) => ({
@@ -142,9 +142,15 @@ export function createComponentStore(database: Database): ComponentStore {
         )
         // Two browsers announcing the same new component at once is ordinary, not a fault: whichever
         // arrives second must be a no-op rather than a duplicate-key error thrown at a page load.
-        .onConflictDoNothing();
+        .onConflictDoNothing()
+        // What was actually inserted, which after `onConflictDoNothing` is only the rows this call
+        // won the race for. Returning `missing` instead would report the intent: the loser of that
+        // ordinary race would name every component it had tried to insert, and the caller writes an
+        // audit row per name, so a first start with two tabs open recorded all thirteen components
+        // twice. The insert was already protected; the trail was not.
+        .returning({ name: components.name });
 
-      return { added: missing.map((entry) => entry.name) };
+      return { added: inserted.map((row) => row.name) };
     },
 
     async list() {

--- a/server/src/computer/routes.ts
+++ b/server/src/computer/routes.ts
@@ -32,7 +32,7 @@ import { type PolicyStore, parseActionPolicy } from "./policy-store";
  * The bot-access middleware matches `/:botId/*`, and Hono's `/*` matches zero segments, so a
  * single-segment path like `/policy` reaches it as a Bot id. These have their own guards.
  */
-const DEPLOYMENT_ROUTES = new Set(["policy"]);
+const DEPLOYMENT_ROUTES = new Set(["policy", "fleet"]);
 
 export function createComputerRoutes(
   gateway: ComputerGateway,
@@ -229,6 +229,26 @@ export function createComputerRoutes(
    * it holds a list. `:botId` is still there because every route under this router has it. The
    * list itself is every computer, so a signed-in user is not enough; an administrator has to ask.
    */
+  /**
+   * Every computer in the deployment.
+   *
+   * Its own route rather than `/:botId/computers`, which is what Admin used to call with a
+   * placeholder id. That worked until the bot-access middleware arrived: the placeholder is not a
+   * Bot, `canUseBot` said so, and the screen 404d for everybody including an administrator, showing
+   * an empty page rather than the fleet. The list is deployment-wide, so it is addressed
+   * deployment-wide and named in DEPLOYMENT_ROUTES beside `/policy`.
+   */
+  routes.get("/fleet", requireUser, async (context) => {
+    const denied = requireAdmin(context);
+    if (denied) return denied;
+
+    try {
+      return context.json(await gateway.computers());
+    } catch (error) {
+      return context.json({ error: describe(error) }, statusFor(error));
+    }
+  });
+
   routes.get("/:botId/computers", async (context) => {
     // The session guard and the question of whether this person may act as the Bot in the path are
     // both applied by the middleware above. Neither is the question here: the answer is the whole

--- a/server/tests/component-store.integration.test.ts
+++ b/server/tests/component-store.integration.test.ts
@@ -285,6 +285,36 @@ describe("learning what a build ships", () => {
     expect(stored?.withheldFrom).toEqual([botA]);
   });
 
+  test("two browsers announcing at once add it once, and record it once", async () => {
+    /*
+     * The insert has always been safe: `onConflictDoNothing` is there because two page loads racing
+     * is ordinary. What was not safe was the answer. `added` reported what the call had *tried* to
+     * insert, so the loser of that ordinary race named every component anyway, and the caller writes
+     * one audit row per name. A first start with two tabs open recorded all thirteen shipped
+     * components twice, in the trail whose whole value is that it says what happened once.
+     *
+     * Concurrent rather than sequential on purpose: the sequential case was always covered by
+     * "announcing again adds nothing", and it passed throughout.
+     */
+    const racer = {
+      name: `testRaced_${suite}`,
+      title: "Raced",
+      kind: "card",
+      description: "Announced by two page loads at the same moment.",
+    };
+
+    const [first, second] = await Promise.all([
+      store.syncCatalogue([racer]),
+      store.syncCatalogue([racer]),
+    ]);
+
+    const named = [...first.added, ...second.added];
+    expect(named).toEqual([racer.name]);
+
+    const rows = (await store.list()).filter((one) => one.name === racer.name);
+    expect(rows).toHaveLength(1);
+  });
+
   test("announcing nothing is not a request to forget everything", async () => {
     // A build with no components, or a failed manifest, must not empty the catalogue.
     const before = (await store.list()).length;

--- a/server/tests/computer-fleet-route.test.ts
+++ b/server/tests/computer-fleet-route.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import type { MiddlewareHandler } from "hono";
+import { Hono } from "hono";
+import type { AppVariables } from "../src/auth/guards";
+import type { ComputerGateway } from "../src/computer/gateway";
+import type { PolicyStore } from "../src/computer/policy-store";
+import { createComputerRoutes } from "../src/computer/routes";
+
+/**
+ * The fleet is a fact about the deployment, not about a Bot. This is the same bug as the boundary
+ * one in computer-policy-route.test.ts, a second time.
+ *
+ * Admin listed the fleet by calling `/:botId/computers` with a placeholder id, on the reasoning that
+ * the endpoint answers with every computer whatever the path says. True when it was written. Then
+ * the bot-access middleware arrived, the placeholder was not a Bot, `canUseBot` said so, and
+ * `/admin/computers` answered 404 for everybody including an administrator. The screen renders
+ * nothing at all while the list is null, so it did not even look broken: it looked like a
+ * deployment with no computers, while two containers were running.
+ *
+ * The middleware's own comment asked for this: "a second deployment-wide route added later should
+ * have to think about this line." It was added later and did not. So the fleet has a route of its
+ * own now, and this holds it there.
+ *
+ * Found by driving the screen against a deployment that had computers, not by reading the diff.
+ */
+
+const ADMIN = { id: "u1", email: "admin@openbot.test", role: "admin" } as const;
+
+function app(role: "admin" | "user" = "admin") {
+  const asActor: MiddlewareHandler<{ Variables: AppVariables }> = async (
+    context,
+    next,
+  ) => {
+    context.set("actor", { ...ADMIN, role });
+    await next();
+  };
+
+  const gateway = {
+    computers: async () => ({
+      isolation: "per-bot",
+      computers: [
+        { botId: "risk-analyst", running: true, startedAt: null },
+        { botId: "general-assistant", running: false, startedAt: null },
+      ],
+    }),
+  } as unknown as ComputerGateway;
+
+  const policyStore = {
+    get: () => ({ mode: "enforce", deny: [], allow: ["true"] }),
+    set: async () => undefined,
+  } as unknown as PolicyStore;
+
+  const routes = createComputerRoutes(
+    gateway,
+    policyStore,
+    asActor,
+    // No Bot is reachable, which is the deployment the bug showed up in: listing the fleet must not
+    // depend on the caller having access to a Bot that happens to share the collection's name.
+    async () => false,
+  );
+
+  return new Hono<{ Variables: AppVariables }>().route(
+    "/api/computers",
+    routes,
+  );
+}
+
+describe("listing every computer in the deployment", () => {
+  test("an administrator gets the fleet, whatever Bots they can reach", async () => {
+    const response = await app().request("http://t/api/computers/fleet");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      isolation: "per-bot",
+      computers: [{ botId: "risk-analyst" }, { botId: "general-assistant" }],
+    });
+  });
+
+  test("it is still administrator-only", async () => {
+    // The exemption is from the bot-access check, not from the admin check. The fleet names every
+    // Bot in the deployment, which is exactly what a plain user must not be handed.
+    const response = await app("user").request("http://t/api/computers/fleet");
+
+    expect(response.status).toBe(403);
+  });
+
+  test("a Bot route is still gated", async () => {
+    // One named path, not a hole.
+    const response = await app().request(
+      "http://t/api/computers/some-bot/status",
+    );
+
+    expect(response.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## What this is

A release gate. I deleted every OpenBot container, image, volume and `node_modules`, rebuilt from nothing following the README exactly, and drove the result in a browser. Three defects, fixed here, in the order a new user would hit them.

## 1. The quick start refused every fresh clone

`scripts/start.sh` exited **1**, silently, after "coworker tables migrated". No server, no app, no message.

`.env.example` ships `MANAGED_AGENT_AG_UI_URL` commented out, and that is correct. The comment beside the default ninety lines earlier in `start.sh` says so itself: the default belongs in the script rather than in `.env`, because `docker run --env-file .env` must not inherit a URL pointing at a process the one-container image does not contain. Line 144 then re-read `.env` and demanded the line be present in the file that comment says must not carry it.

The silence has its own cause, and it is worth knowing:

```
$ grep -E '^MANAGED_AGENT_AG_UI_URL=' .env ; echo $?
1
```

Under `set -o pipefail` that fails the whole pipeline, and `set -e` aborts the assignment **before** the `if` that would have printed `MANAGED_AGENT_AG_UI_URL is not set in .env`. The identical grep survives inside `setting()` only because `local v="$(...)"` takes `local`'s own exit status and masks the failure. Confirmed in isolation:

```
in function: [] survived
EXIT=1          # the same assignment outside a function
```

Fixed by reporting the value already resolved and exported at the top, and not re-reading the file. `start.sh` now runs clean to `Ready.` with `licence valid · mode intelligence · Bots: general-assistant, knowledge, risk-analyst`.

## 2. Every component was recorded twice on a first start

13 shipped components, 26 `component.published` audit rows, all inside 16 milliseconds of a single server start.

`syncCatalogue` returned `missing` — what it had *tried* to insert — rather than what it inserted. The insert is already race-safe (`onConflictDoNothing`, with a comment saying two browsers announcing at once is "ordinary, not a fault"). The audit trail was not: the loser of that ordinary race named every component anyway, and the caller writes one row per name. Two tabs open on a first start is enough.

Now returns the rows Postgres actually inserted. Proven by clearing the catalogue and racing two tabs again: **41 rows = 28 + 13**, one per component, where it was 26 for 13 before.

## 3. `/admin/computers` listed nothing, ever

A documented main surface ("View, stop, and reset Bot computers") showed an empty page while two computers were running.

Admin addressed the fleet through `/:botId/computers` with a placeholder id, which was sound when written — the endpoint answers with every computer whatever the path says. Then the bot-access middleware arrived, the placeholder was not a Bot, `canUseBot` said so, and the list 404d for everybody including an administrator. Because the screen renders `null` while the list is null, it did not look broken; it looked like a deployment with no computers.

The API was fine the whole time:

```
/api/computers/risk-analyst/computers  → 200, both computers
/api/computers/openbot-computer/computers → 404 {"error":"There is no such Bot."}
```

This is the second time this exact trap has been sprung — the first was the Boundaries screen — and the middleware's own comment asked for it not to happen again: *"a second deployment-wide route added later should have to think about this line."* So the fleet has a route of its own now, named beside `/policy`, still administrator-only.

After the fix the screen lists both computers with the right names and start times, matching `docker ps` to the second, and **Stop** genuinely stops the container (`Exited (0)`) and writes `computer.stopped`.

## Tests

Both regressions have one. Each fails without its fix and passes with it, checked by reverting:

| test | without the fix |
| --- | --- |
| `computer-fleet-route.test.ts` — administrator gets the fleet | `Expected: 200, Received: 404` |
| `component-store.integration.test.ts` — two browsers announcing at once | `Expected - 0, Received + 1` |

The race test is deliberately concurrent: the sequential case was always covered by "announcing again adds nothing", and it passed throughout.

`start.sh` has no test. It is a shell entry point with no harness in this repo, and adding one is a bigger change than this.

## What I verified while I was in there

Not part of the diff, but this is the evidence the release is sound:

- **Auto-routing.** An untagged message about structured cash deposits reached Risk Analyst. Confirmed in the record, not the UI: `{"chosen":"risk-analyst","viaMention":false,"fallback":false,"candidates":[...3]}`.
- **The browser is a real browser.** Bot said the HN top story was "Kobo can run apps now". Checked three ways: the audit row for `computer_navigate`, a live screenshot from the container reporting `url: https://news.ycombinator.com/` with real Chromium (`headless_shell`) running in it, and an independent fetch of HN from outside the whole system. All three agree.
- **The boundary works both ways.** A deny rule refused the same navigation and named itself in the transcript and the audit row (`allowed: false, carriedOut: false`). A shell rule refused `whoami` with *"the command `whoami` is blocked by the rule `tool.name == \"computer_run_command\"`"*. It survives a restart: `source: "an administrator, saved in this deployment"`.
- **The shell and Activity tab.** Real output, `Linux c40d1eed3b2a … aarch64 GNU/Linux`, with the command and time beside it.
- **Per-Bot isolation.** A container per Bot, created on demand, refusing my deployment-wide token.
- **Coworkers.** Created one from `/agents`, started a channel, got an on-topic answer.
- **Google Drive.** Enables, explains the per-person model, lists the four read tools, and blocks honestly: *"This deployment has no public URL, so nobody can complete a consent flow."*

## Not fixed here

Recorded rather than swept in:

- The channel view takes **15–20 seconds** to become interactive, and input typed before then is silently discarded. Nothing is lost once it settles, but it is the first thing anybody will do.
- Screenshots in a reloaded transcript sit as full-size empty grey panels for several seconds before the frame arrives. I first read this as them not surviving a reload at all; they do, and the picture is correct when it lands. The panel reserves its full height immediately and says nothing while it waits, so a reloaded conversation looks broken until it is not.
- `/api/components/for-agent/default` 404s on every page load. Same placeholder-id shape as defect 3, on a path that tolerates it.
- A Base UI `nativeButton` error is logged on every page load, from `AppSidebar`.
- `bun install` at the root does not install `agent-bot`, so `bun run test` on a fresh clone fails two tests until you install there too.
- The README's "curated catalogue ships for Atlassian, Box, Slack, Salesforce and ServiceNow" — only Google Drive appears in `/admin/plugins`.

## Proof

Rebuilt from nothing: all five images, 12 migrations, 28 tables, none of the seven tables dropped tonight present, no `vector` extension.

| | result |
| --- | --- |
| `bun run test` | **1139 pass, 8 skip, 0 fail**, 1147 across 103 files |
| `bun run typecheck` | clean, all four packages |
| `bun run format:check` | clean |
| `bunx biome lint .` | 1 info, identical to `main` |
| `bun run build` | clean |

**No changelog entry.** That file is being caught up separately tonight and I did not want to collide with it; these are three fixes to unreleased work from the last day.

