### PR TITLE
Generate the token a Bot needs to call its tools back

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -67,6 +67,33 @@ if [ -z "$MANAGED_AGENT_TOKEN" ]; then
 fi
 export MANAGED_AGENT_TOKEN
 
+# The secret a framework Bot presents when it calls a tool back through this server. The other
+# direction of the pair above: that one is the server proving itself to the Bot, this one is the Bot
+# proving itself to the server, and they are deliberately two different secrets.
+#
+# Generated here for the same reason, and it has to be. `.env.example` ships it empty, which is the
+# right default for a deployment: absent, no Bot may call tools back and it is told so rather than
+# quietly allowed. On a laptop that default meant every MCP tool was dead on arrival. An
+# administrator could enable Google Drive, grant `search_files` to a Bot, read "May call this tool"
+# on the grant screen, and get "This Bot has no credential for calling tools back through its
+# deployment" on every single call, with no audit row, because the call never reached the server to
+# be recorded.
+AGENT_TOOL_TOKEN="$(setting AGENT_TOOL_TOKEN "")"
+if [ -z "$AGENT_TOOL_TOKEN" ]; then
+  AGENT_TOOL_TOKEN="$(openssl rand -base64 32)"
+  if grep -qE '^AGENT_TOOL_TOKEN=' "$ROOT/.env"; then
+    # A present but empty line, which is what .env.example ships.
+    tmp="$(mktemp)"
+    grep -vE '^AGENT_TOOL_TOKEN=' "$ROOT/.env" > "$tmp"
+    printf 'AGENT_TOOL_TOKEN=%s\n' "$AGENT_TOOL_TOKEN" >> "$tmp"
+    mv "$tmp" "$ROOT/.env"
+  else
+    printf '\nAGENT_TOOL_TOKEN=%s\n' "$AGENT_TOOL_TOKEN" >> "$ROOT/.env"
+  fi
+  printf '\033[2m%s\033[0m\n' "Generated AGENT_TOOL_TOKEN and wrote it to .env."
+fi
+export AGENT_TOOL_TOKEN
+
 green() { printf '\033[32m%s\033[0m\n' "$1"; }
 red()   { printf '\033[31m%s\033[0m\n' "$1"; }
 info()  { printf '\033[2m%s\033[0m\n' "$1"; }


### PR DESCRIPTION
## What this changes

`scripts/start.sh` now generates `AGENT_TOOL_TOKEN` and writes it to `.env`, exactly as it already does for `MANAGED_AGENT_TOKEN`.

Found while trying to answer one question: has anybody actually called a Google Drive tool and got an answer back?

## The symptom

Enable Google Drive, grant `search_files` to a Bot, and the grant screen says:

> May call this tool. Every call is still checked against the boundaries and written to the audit trail.

Ask the Bot, and every call comes back:

> Refused. This Bot has no credential for calling tools back through its deployment.

With **no audit row at all**. The screen's promise is true of calls that arrive; none did. The refusal comes from `agent-langgraph/src/index.ts:251`, on the Bot side, so the call never reaches the server to be recorded.

## Why

`.env.example` ships `AGENT_TOOL_TOKEN` empty, and its comment is right about why:

> The secret a framework Bot presents when it calls a tool back through this server. Absent, no Bot may call tools back and it is told so rather than being quietly allowed.

Correct fail-closed default for a deployment. But `start.sh` is the laptop path the README sends everybody down, and it left the token empty, so **every MCP tool was dead on arrival on a fresh clone**. Nothing in the flow points at the cause: the token you have to set is not named on the grant screen, in the refusal, or anywhere a person following the README would look.

Note these are two different secrets in two different directions, deliberately:

| variable | direction |
| --- | --- |
| `MANAGED_AGENT_TOKEN` | the server proving itself to the Bot |
| `AGENT_TOOL_TOKEN` | the Bot proving itself to the server |

`start.sh` already generates the first, with a comment that applies word for word to the second: the server and the Bot are separate processes that have to agree on it across restarts. So the second is generated the same way, beside it, and written to `.env` so a later `docker compose up` by hand sees the same value.

Deployments are unaffected: a value already set is kept, and the empty default in `.env.example` still means fail-closed for anyone not using `start.sh`.

## Proof

Cleared the variable, re-ran `start.sh`:

```
Generated AGENT_TOOL_TOKEN and wrote it to .env.
  server ready
  app ready
Ready. http://localhost:3010
```

Container picked it up: `Bot has it (44 chars)`.

Then the same request in the browser, and this is the point of the change — it now reaches the gateway and fails in the right place, on the record:

```json
{
  "bot": "risk-analyst",   "tool": "search_files",
  "server": "google-drive", "effect": "read",
  "actor":     "AqarPaoMdN0KXTpLJaObzBNey7KDNaJE",
  "reachedAs": "AqarPaoMdN0KXTpLJaObzBNey7KDNaJE",
  "decision": { "mode": "enforce", "rule": "true", "allowed": true, "carriedOut": true },
  "failure": "You have not connected your Google Drive account. Connect it in Settings and ask again."
}
```

`reachedAs` equal to `actor` is the whole per-person thesis, recorded: the tool was reached **as the person asking**, not as a service account. `effect: read` is the read/write classification. And the refusal now names the real cause, which a person can act on.

Before this change none of that existed, because the call never left the Bot.

## Where it runs

No new state outliving a request, nothing different on a second replica, nothing serialised, nothing fanned out to a browser, no new listener, port or schedule. One generated secret, persisted to `.env` on a laptop.

## Boundary and audit

This does not widen anything. It lets a call reach the boundary that previously could not, which is the opposite: every call it enables is grant-checked, policy-checked and recorded, and the first thing it proved is a refusal.

## Changelog

No entry. Nothing a configured deployment does differs; this is the laptop path catching up with a secret it already generates a sibling of.

## Also found, not fixed here

Two things worth their own decision rather than a quiet change:

- **The grant screen says "May call this tool" when the deployment cannot make any tool call at all.** The coworker page already knows how to say this — *"This coworker has no credential, so it can hold a conversation but cannot use any tool it has been granted"* — it just is not said on the screen where the grant is made.
- **`viaMention` in `channel.routed` is hardcoded `false`** (`server/src/routing/routes.ts:62`) and can never be `true`. Choosing a coworker with `@` short-circuits the router, so no row is written at all, and the trail cannot say why a mentioned conversation went where it did. Either the field carries no information and should go, or a mention should be recorded too.

## Suite

`bun run format:check` clean. Shell-only change; no test touches `start.sh`.