### PR TITLE
Stop a grant promising what the deployment cannot honour

### DIFF
--- a/app/src/lib/plugins/queries.ts
+++ b/app/src/lib/plugins/queries.ts
@@ -66,6 +66,15 @@ export type PluginsPage = {
   servers: PluginServer[];
   skills: PluginSkill[];
   /**
+   * Whether a Bot holding no credential of its own can still call a tool back.
+   *
+   * True when the deployment has a shared secret configured for it. A grant decides whether a tool
+   * is offered to a model at all; this decides whether the call it makes can be authenticated. With
+   * neither this nor a credential issued to the Bot, every call is refused before it reaches the
+   * grant, the boundary or the audit trail, which is not something a grant switch can show.
+   */
+  botsMayCallBack: boolean;
+  /**
    * The redirect URI to register with a `user-oauth` vendor, exactly as this deployment will send it.
    *
    * From the server rather than assembled here, because it has to match what was registered

--- a/app/src/routes/_authed/admin/plugins/$key_.tools.$tool.tsx
+++ b/app/src/routes/_authed/admin/plugins/$key_.tools.$tool.tsx
@@ -44,6 +44,18 @@ function RouteComponent() {
   const queryClient = useQueryClient();
   const plugins = useQuery(pluginsPageQueryOptions());
   const { data: agents } = useQuery(agentListQueryOptions());
+  /*
+   * Whether a call from this Bot could be authenticated at all.
+   *
+   * Its own issued credential, or the deployment's shared one. Separate from the grant: the switch
+   * decides whether the tool is offered to the model, this decides whether the call it makes gets
+   * past the front door. A Bot with the grant and neither credential produced "May call this tool"
+   * beside a tool that refused every call, with no audit row, because the call never arrived.
+   */
+  const sharedCallback = plugins.data?.botsMayCallBack === true;
+  const canCallBack = (bot: { id: string }) =>
+    sharedCallback ||
+    agents?.find((one) => one.id === bot.id)?.hasCallbackToken === true;
   const nameFor = useBotNames();
   const [error, setError] = useState<string | null>(null);
 
@@ -162,7 +174,9 @@ function RouteComponent() {
                       <ItemTitle>{bot.name}</ItemTitle>
                       <ItemDescription>
                         {held
-                          ? "May call this tool. Every call is still checked against the boundaries and written to the audit trail."
+                          ? canCallBack(bot)
+                            ? "May call this tool. Every call is still checked against the boundaries and written to the audit trail."
+                            : "Granted, but this Bot has no credential for calling tools back, so every call is refused before it reaches the boundary. Issue one on its own page, or set AGENT_TOOL_TOKEN for the deployment."
                           : "Cannot call this tool. It is not offered to the model at all, so it has nothing to refuse."}
                       </ItemDescription>
                     </ItemContent>

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -683,6 +683,10 @@ export function createApp(
       "/api/plugins",
       createPluginRoutes(pluginStore, requireUser, canUseBot, {
         encryptionKey: config.keyEncryptionKey,
+        // The deployment-wide fallback a Bot may present, as a yes or no. The secret itself stays
+        // in config and is checked in `/api/agent-tools/call`; the surface only needs to know
+        // whether a Bot without its own credential has any way to call back.
+        botsMayCallBack: Boolean(config.agentToolToken),
         publicUrl: config.publicUrl,
         appUrl: config.appUrl,
       }),

--- a/server/src/plugins/routes.ts
+++ b/server/src/plugins/routes.ts
@@ -60,6 +60,15 @@ export function createPluginRoutes(
    */
   connect?: {
     encryptionKey: string;
+    /**
+     * Whether this deployment holds a shared secret a Bot may present when calling a tool back.
+     *
+     * A boolean about configuration, never the secret. Without it, a Bot can only call back if it
+     * holds a credential issued to it alone, and a Bot with neither is refused before the call ever
+     * reaches the grant, the boundary or the trail. The Bots screen needs this to stop promising a
+     * grant the deployment cannot honour.
+     */
+    botsMayCallBack?: boolean;
     publicUrl: string | undefined;
     /**
      * Where the app is, which is not where this API is.
@@ -119,6 +128,15 @@ export function createPluginRoutes(
         auth: entry.auth.kind,
         perInstance: entry.host === null,
       })),
+      /*
+       * Whether a Bot with no credential of its own can still call a tool back.
+       *
+       * The grant switch decides whether a tool is offered to a model; this decides whether any
+       * call it makes can be authenticated at all. They are different questions and the screen used
+       * to answer only the first, so a grant could read "May call this tool" on a deployment where
+       * every call was refused before it reached the boundary.
+       */
+      botsMayCallBack: connect?.botsMayCallBack === true,
       servers: await store.listServers(),
       // Scoped: the deployment's skills plus this person's own. An administrator sees them all.
       skills: await store.listSkills(skillActor(context)),


### PR DESCRIPTION
## What this changes

The Bots list on a tool page answers one more question than it used to.

It said, whenever the switch was on:

> May call this tool. Every call is still checked against the boundaries and written to the audit trail.

That is two questions answered as one. The switch decides whether the tool is **offered to a model**. Whether the call it then makes can be **authenticated** is a different question, and the screen never asked it.

## Why it matters

A Bot may call a tool back only if it holds a credential issued to it, or the deployment holds the shared `AGENT_TOOL_TOKEN`. With neither, every call is refused at the front door — before the grant, before the boundary, before the audit row.

So on such a deployment the screen promised a checked, recorded call, beside a tool that refused everything and recorded nothing, because nothing arrived to be recorded. Following the sentence to `/admin/audit` to see the refusal found no row either, which reads as "it never tried".

This is not hypothetical: it is what a fresh clone looked like until #130, and it is still what any deployment looks like that has not set the token.

## The shape of the fix

`botsMayCallBack`, a boolean, on the **admin-only** `/api/plugins` payload. Deliberately not on `/api/capabilities`, which is reachable signed-out and whose own comment says to add fields there explicitly — a deployment's tool-auth posture is not something to hand an anonymous visitor.

The secret itself does not move and is still only checked in `/api/agent-tools/call`. The per-Bot half needs nothing new: the agent list already carries `hasCallbackToken`.

The new wording names both ways out, because which one applies depends on the Bot:

> Granted, but this Bot has no credential for calling tools back, so every call is refused before it reaches the boundary. Issue one on its own page, or set `AGENT_TOOL_TOKEN` for the deployment.

## Proof

Driven in the browser both ways against a real deployment, with `search_files` granted to Risk Analyst throughout:

**No shared token** — server started with `AGENT_TOOL_TOKEN` empty:

> Risk Analyst — Granted, but this Bot has no credential for calling tools back, so every call is refused before it reaches the boundary. Issue one on its own page, or set…

**Token restored**, via `start.sh`:

> Risk Analyst — May call this tool. Every call is still checked against the boundaries and written to the audit trail.

Ungranted Bots are unchanged in both: *"Cannot call this tool. It is not offered to the model at all, so it has nothing to refuse."*

| | result |
| --- | --- |
| `bun run test` | **1137 pass, 8 skip, 0 fail**, 1145 across 102 files |
| `bun run typecheck` | clean, all four packages |
| `bun run format:check` | clean |
| `bunx biome lint .` | 1 info, identical to `main` |

## Where it runs

No new state outliving a request, nothing different on a second replica, nothing serialised, no new listener, port or schedule. One boolean added to an existing admin response, and a sentence on one screen.

## Boundary and audit

Nothing widens. This adds no capability and removes no check; it reports a fact the deployment already had about itself, on the screen where the decision is made.