### PR TITLE
Record a Bot callback that could not prove which Bot it was

### DIFF
--- a/app/src/routes/_authed/admin/audit.tsx
+++ b/app/src/routes/_authed/admin/audit.tsx
@@ -35,9 +35,16 @@ const FILTERS = [
   { label: "Computer actions", search: "?eventType=computer.action_allowed" },
   {
     label: "Blocked",
-    // Include every refusal family, not only browser policy refusals.
+    /*
+     * Include every refusal family, not only browser policy refusals.
+     *
+     * `mcp.callback_refused` is here because it is a refusal, even though nothing about a Bot was
+     * judged: a caller could not prove which Bot it was. Somebody filtering for what this deployment
+     * turned away wants that in the list, and it is the one refusal with no policy behind it, so
+     * leaving it out would hide the only evidence that anything was attempted.
+     */
     search:
-      "?eventType=computer.action_refused,mcp.call_rejected,component.refused,component.function_refused",
+      "?eventType=computer.action_refused,mcp.call_rejected,mcp.callback_refused,component.refused,component.function_refused",
   },
   {
     label: "Did not happen",
@@ -140,7 +147,13 @@ function Row({
     event.eventType === "computer.action_refused" ||
     event.eventType === "component.refused" ||
     event.eventType === "component.function_refused" ||
-    event.eventType === "mcp.call_rejected";
+    event.eventType === "mcp.call_rejected" ||
+    /*
+     * A caller that could not prove which Bot it was. Refused like the others, and it has to read
+     * that way here: the fallback below calls anything it does not recognise "Allowed", which for a
+     * refusal is the one wrong answer. A trail that is confidently wrong is worse than a silent one.
+     */
+    event.eventType === "mcp.callback_refused";
   const stalled = event.eventType === "agent.stream_stalled";
   // Allowed by policy but not carried out. A stalled turn belongs in the same family: the Bot was
   // asked and the answer never arrived. Colour is how this table is read, and a row left in the
@@ -228,6 +241,12 @@ function Row({
             {payload.reason}
           </div>
         ) : null}
+        {event.eventType === "mcp.callback_refused" &&
+        typeof payload.refusal === "string" ? (
+          <div className="mt-0.5 text-xs text-muted-foreground">
+            {payload.refusal}
+          </div>
+        ) : null}
         {event.eventType === "bot.declined" &&
         typeof payload.reason === "string" ? (
           <div className="mt-0.5 text-xs text-muted-foreground">
@@ -308,6 +327,8 @@ const DECISIONS: Record<string, string> = {
   "mcp.call_succeeded": "Called on this Bot's behalf",
   "mcp.call_rejected": "Blocked",
   "mcp.call_failed": "The server did not answer",
+  // Not "Blocked": nothing about the Bot was judged, because nothing proved which Bot it was.
+  "mcp.callback_refused": "Could not prove which Bot it was",
 
   "configuration.changed": "Configuration changed",
   "credential.created": "Credential saved",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -734,6 +734,36 @@ export function createApp(
           (await agentProfileStore?.agentForCallbackToken(hash)) ?? null,
       });
       if (!verdict.ok) {
+        /*
+         * Recorded, because this is a boundary being held and every other one here leaves a row.
+         *
+         * The three outcomes inside `callTool` are all written after the caller has proved which Bot
+         * it is. A caller that fails to prove it never reaches them, so this refusal used to leave
+         * nothing at all — and it is the refusal behind the product's most confusing failure: a Bot
+         * whose token no longer matches the deployment's has every call rejected here, returns
+         * nothing to its own model, and the model tells the person there were no results. A false
+         * negative delivered as an answer, with the trail agreeing nothing had happened.
+         *
+         * No Bot id and no actor. Both live in the credential that just failed to verify, so writing
+         * them down would put an unproven claim in the record. The tool name comes from the body and
+         * is capped for the same reason: it is untrusted input, kept because "which tool was being
+         * reached for" is the useful half of the question.
+         */
+        if (auditStore) {
+          await recordAuditEvent(auditStore, {
+            eventType: "mcp.callback_refused",
+            targetType: "mcp_tool",
+            targetId:
+              typeof body?.name === "string"
+                ? body.name.slice(0, 120)
+                : "unknown",
+            payload: {
+              refusal: verdict.reason,
+              status: verdict.status,
+              note: "A caller could not prove which Bot it was, so no grant was consulted.",
+            },
+          });
+        }
         return context.json({ error: verdict.reason }, verdict.status);
       }
 

--- a/server/src/audit.ts
+++ b/server/src/audit.ts
@@ -83,6 +83,29 @@ export const auditEventTypes = [
    */
   "mcp.call_failed",
   /*
+   * Something presenting itself as a Bot asked to spend a grant and was turned away at the door.
+   *
+   * The fourth outcome, and the only one that used to leave nothing behind. The three above are all
+   * written inside `callTool`, which is reached only after the caller has proved which Bot it is.
+   * A caller that fails THAT check never reaches `callTool`, so a refused callback was invisible:
+   * no row, no log, nothing to count.
+   *
+   * Which made the most confusing failure in the product completely silent. A Bot holding a stale
+   * token — the deployment's secret rotated, a container not recreated with it — has every call
+   * rejected at this line, returns nothing to its own model, and the model tells the person "no
+   * files were found". A false negative, delivered as an answer, about a Drive that has the files.
+   * Every place a person would look to check agreed that nothing had happened.
+   *
+   * It is a security row as much as a diagnostic one. This endpoint is how a Bot spends grants, and
+   * an unauthenticated caller probing it generated no evidence at all.
+   *
+   * The row deliberately does NOT name a Bot or an actor. Both arrive in the credential that just
+   * failed to verify, so writing them down would be recording an unproven claim in the one place
+   * that is supposed to be believed. What is recorded is what is known: that a call was attempted,
+   * which tool it named, and why it was refused.
+   */
+  "mcp.callback_refused",
+  /*
    * An administrator registered this deployment's OAuth client with a vendor.
    *
    * Recorded because it decides what every subsequent consent screen belongs to. If a client is

--- a/server/tests/agent-callback-token.test.ts
+++ b/server/tests/agent-callback-token.test.ts
@@ -186,3 +186,72 @@ describe("who may call a tool back, and as whom", () => {
     });
   });
 });
+
+/**
+ * A refused callback leaves a row, because it is a boundary being held.
+ *
+ * The three MCP call outcomes are all written inside `callTool`, which is reached only once the
+ * caller has proved which Bot it is. A caller that fails that check never gets there, so this
+ * refusal used to leave nothing behind at all: no row, no log, nothing to count.
+ *
+ * Which made the product's most confusing failure silent. A Bot holding a token the deployment no
+ * longer accepts — a secret rotated, a container not recreated with it — has every call refused
+ * here, returns nothing to its own model, and the model tells the person "no files were found". A
+ * false negative delivered as an answer, with every place somebody would check agreeing that
+ * nothing had happened. That is how it was found: by driving Drive and getting "no results" from a
+ * Drive that had them.
+ *
+ * These assert the shape the row must keep. `authoriseAgentCall` is the decision the route acts on,
+ * so a verdict that stops being a refusal is the thing that would silently drop the row again.
+ */
+describe("a callback that cannot prove which Bot it is", () => {
+  test("is refused, with a reason and a status to record", async () => {
+    const verdict = await authoriseAgentCall({
+      presented: "obot_agt_not_a_token_this_deployment_issued",
+      run: await mintRunAssertion(RUN, KEY),
+      encryptionKey: KEY,
+      legacyToken: "the-deployment-secret",
+      lookup: async () => null,
+    });
+
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    // Both are written onto the audit row, so both have to exist.
+    expect(typeof verdict.reason).toBe("string");
+    expect(verdict.reason.length).toBeGreaterThan(0);
+    expect(verdict.status).toBeGreaterThanOrEqual(400);
+  });
+
+  test("is refused when the token is right and the run assertion is not", async () => {
+    // The other half of the pair. A shared secret alone must not be enough to spend a Bot's grants:
+    // without a run this deployment signed, there is no statement of who it is acting for.
+    const verdict = await authoriseAgentCall({
+      presented: "the-deployment-secret",
+      run: "not-an-assertion-this-deployment-signed",
+      encryptionKey: KEY,
+      legacyToken: "the-deployment-secret",
+      lookup: async () => null,
+    });
+
+    expect(verdict.ok).toBe(false);
+  });
+
+  test("carries no Bot or actor to record, which is why the row names neither", async () => {
+    /*
+     * The row deliberately records no bot and no actor. Both arrive inside the credential that just
+     * failed to verify, so writing them down would put an unproven claim in the one place that is
+     * supposed to be believed. This holds that there is nothing trustworthy to write.
+     */
+    const verdict = await authoriseAgentCall({
+      presented: "",
+      run: undefined,
+      encryptionKey: KEY,
+      legacyToken: "the-deployment-secret",
+      lookup: async () => null,
+    });
+
+    expect(verdict.ok).toBe(false);
+    expect(verdict).not.toHaveProperty("botId");
+    expect(verdict).not.toHaveProperty("actorId");
+  });
+});


### PR DESCRIPTION
Closes #135.

## The hole

`/api/agent-tools/call` did this and nothing else:

```ts
if (!verdict.ok) {
  return context.json({ error: verdict.reason }, verdict.status);
}
```

401, and no row. It is the only refusal in the product that left no trace. The three MCP outcomes — `call_succeeded`, `call_failed`, `call_rejected` — are all written inside `callTool`, which is reached **only after** the caller has proved which Bot it is. A caller that fails that check never gets there.

## Why it matters more than a missing log line

A Bot holding a token this deployment no longer accepts has every call refused at that line. It returns nothing to its own model, and the model says:

> No files were returned from Google Drive for the search query "PRD."

A **false negative delivered as an answer**, about a Drive that contains three matching files. Ask "do we have a PRD for this?" and you are told no.

And every place somebody would check agreed. No audit row. No server log. The Bot did not report an error, it reported an absence.

That is how it was found: a Bot said Drive was empty while the same tool called directly returned

```
OpenBot PRD: Knowledge, Cloud, and Per-User Access
OpenBot PRD: Knowledge, Cloud, and Per-User Access
OpenBot PRD: Knowledge, Cloud, and Per-User Access
```

It is also a **security** row. This endpoint is how a Bot spends its grants. An unauthenticated caller probing it generated no evidence whatsoever.

## What the row does and does not say

It names **no Bot and no actor**. Both arrive inside the credential that just failed to verify, so writing them down would put an unproven claim in the one place that is supposed to be believed.

What it records is what is known:

```json
{
  "eventType": "mcp.callback_refused",
  "targetId": "mcp__google-drive__search_files",
  "payload": {
    "refusal": "Not authorised.",
    "status": 401,
    "note": "A caller could not prove which Bot it was, so no grant was consulted."
  }
}
```

The tool name comes from the body, so it is capped — untrusted input, kept because "which tool was being reached for" is the useful half.

## Admin had to change too, and this was the sharper half

Adding the type alone made it **worse**. The decision column falls through to `"Allowed"` for anything it does not recognise, so the first version rendered a refusal as **Allowed**, in the neutral colour. A trail that is confidently wrong is more dangerous than one that is silent, because it is used to rule things out — the codebase already says so about `call_succeeded` being written before the network call.

So: it counts as a refusal (colour and treatment), it has its own wording, and it is in the Blocked filter.

Deliberately **not** the word "Blocked". Nothing about the Bot was judged, because nothing established which Bot it was. It reads **"Could not prove which Bot it was"**, with the vendor-free reason underneath.

## Proof

Driven in Chrome against a real deployment, after forcing the exact failure with a wrong token:

```
$ curl -X POST /api/agent-tools/call -H 'x-openbot-agent-token: not-the-right-token' …
{"error":"Not authorised."}   http=401
```

Row written:

```
mcp.callback_refused
target: mcp__google-drive__search_files
{ "refusal": "Not authorised.", "status": 401, "note": "A caller could not prove which Bot it was…" }
```

`/admin/audit`, **Everything**: red, **"Could not prove which Bot it was"**, "Not authorised." beneath it.
`/admin/audit`, **Blocked**: top of the list, beside the policy refusals.

Before this change that request produced nothing at all in either view.

| | result |
| --- | --- |
| `bun run test` | **1140 pass, 8 skip, 0 fail**, 1148 across 102 files |
| `bun run typecheck` | clean, all four packages |
| `bun run format:check` | clean |
| `bunx biome lint .` | 1 info, identical to `main` |
| `bun run build` | clean |

## Tests

Three, on `authoriseAgentCall`, which is the decision the route acts on — a verdict that stops being a refusal is what would silently drop the row again:

- a token this deployment never issued is refused, with a reason and a status to record
- a valid shared secret with an unsigned run assertion is still refused
- a refused verdict carries no `botId` and no `actorId`, which is why the row names neither

## Not fixed here

The container drift that produced it. `start.sh` writes `AGENT_TOOL_TOKEN` to `.env` but does not recreate `agent-langgraph`, so a rotated secret leaves a running Bot holding the old one. This change makes that state **visible** rather than silent, which is the part that belongs in the audit trail. Making the drift impossible is a separate change to `start.sh`, and worth its own review.