### PR TITLE
Stop treating a service that answers as a service that is current

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -51,8 +51,16 @@ COMPUTER_TOKEN="$(setting COMPUTER_TOKEN openbot-dev-computer-token)"
 MANAGED_AGENT_AG_UI_URL="$(setting MANAGED_AGENT_AG_UI_URL "http://localhost:${LANGGRAPH_PORT}/ag-ui")"
 export MANAGED_AGENT_AG_UI_URL
 
+# Whether this run minted a secret that something already running may not have.
+#
+# A process that is answering is not necessarily a process holding the current configuration, and
+# the two are easy to confuse because one is observable and the other is not. Everything below that
+# skips work because a service "is already up" has to consult this first.
+SECRETS_ROTATED=false
+
 MANAGED_AGENT_TOKEN="$(setting MANAGED_AGENT_TOKEN "")"
 if [ -z "$MANAGED_AGENT_TOKEN" ]; then
+  SECRETS_ROTATED=true
   MANAGED_AGENT_TOKEN="$(openssl rand -base64 32)"
   if grep -qE '^MANAGED_AGENT_TOKEN=' "$ROOT/.env"; then
     # A present but empty line, which is what .env.example ships.
@@ -80,6 +88,7 @@ export MANAGED_AGENT_TOKEN
 # be recorded.
 AGENT_TOOL_TOKEN="$(setting AGENT_TOOL_TOKEN "")"
 if [ -z "$AGENT_TOOL_TOKEN" ]; then
+  SECRETS_ROTATED=true
   AGENT_TOOL_TOKEN="$(openssl rand -base64 32)"
   if grep -qE '^AGENT_TOOL_TOKEN=' "$ROOT/.env"; then
     # A present but empty line, which is what .env.example ships.
@@ -137,13 +146,24 @@ SERVICES=(postgres)
 if [ "$ONE_COMPUTER_EACH" = "true" ]; then
   SERVICES+=(supervisor)
 fi
-for svc_port in "agent-computer:$COMPUTER_PORT" "agent-bot:$BOT_PORT" "agent-langgraph:$LANGGRAPH_PORT"; do
-  svc="${svc_port%%:*}"; port="${svc_port##*:}"
-  if curl -fsS --max-time 3 "http://localhost:$port/health" >/dev/null 2>&1; then
-    info "  $svc: already answering on $port"
-  else
-    SERVICES+=("$svc")
-  fi
+#
+# Every Bot service, every run, whether or not it is already answering.
+#
+# This used to skip one that answered its health route, which sounds like an optimisation and is
+# actually a correctness bug: answering says the process is alive, not that its environment still
+# matches the deployment's. A skipped service is never handed to `docker compose up`, so compose
+# never compares its configuration and never recreates it.
+#
+# Which is how a Bot ends up holding a secret this deployment no longer accepts. `AGENT_TOOL_TOKEN`
+# is generated above and written to .env; if the container was answering, it kept the previous one,
+# and every tool call it made was refused at the door. It returns nothing to its own model, and the
+# model tells the person there were no results — a false negative delivered as an answer.
+#
+# `docker compose up -d` is declarative and does nothing for a service whose configuration has not
+# changed, so naming them all costs a comparison and buys the guarantee that what is running is what
+# this run configured.
+for svc in agent-computer agent-bot agent-langgraph; do
+  SERVICES+=("$svc")
 done
 
 export SUPERVISOR_TOKEN COMPUTER_TOKEN
@@ -181,6 +201,19 @@ green "  managed coworker endpoint: $MANAGED_AGENT_AG_UI_URL"
 
 info "2/4  Server"
 require_free_or_ours "$SERVER_PORT" server
+#
+# A running server is left alone UNLESS this run minted a secret, because it read its environment
+# once at startup and has no way to notice the file changed underneath it.
+#
+# Skipping it on "already answering" is the same mistake the Bot containers had: answering proves the
+# process is alive, not that it agrees with the deployment. A server holding the previous
+# `AGENT_TOOL_TOKEN` refuses every callback its own Bots make, which reaches a person as "no results"
+# rather than as an error.
+if [ "$SECRETS_ROTATED" = "true" ]; then
+  info "  a secret was generated this run, so the server is restarted to pick it up"
+  pkill -f "bun --env-file=../.env src/index.ts" >/dev/null 2>&1 || true
+  sleep 1
+fi
 if ! curl -fsS --max-time 3 "http://localhost:$SERVER_PORT/api/capabilities" >/dev/null 2>&1; then
   if [ "$ONE_COMPUTER_EACH" = "true" ]; then
     (cd server && PORT="$SERVER_PORT" \


### PR DESCRIPTION
The drift #136 made visible. That change put the failure on the audit trail; this one stops producing it.

## The mistake, twice

`start.sh` skipped work for anything already up:

```bash
if curl -fsS "http://localhost:$port/health"; then
  info "  $svc: already answering on $port"    # ← excluded from `docker compose up`
```

```bash
if ! curl -fsS "http://localhost:$SERVER_PORT/api/capabilities"; then
  … start the server …                          # ← so a running one is never restarted
```

Both read as optimisations. Both are the same error: **answering proves a process is alive and says nothing about whether it still agrees with the deployment.**

A container left out of `compose up` is never compared against its configuration, so compose cannot notice its environment changed. A server that is answering was started earlier and read `.env` once, then.

## What it cost

`AGENT_TOOL_TOKEN` is minted by this script and written to `.env`. On a run where the stack was already up, **neither side got it**: the container kept the previous value because it was healthy, the server kept its own because it had already read the file.

Every callback a Bot made was then refused. Which does not surface as an error — it surfaces as:

> No files were returned from Google Drive for the search query "PRD."

about a Drive containing three matching files. That is how this was found, and it took an hour, because before #136 the refusal left no row anywhere.

## The two fixes

**Bot services always go to compose.** `docker compose up -d` is declarative and is the only thing that can actually compare a container's configuration against the file. Naming them all costs a comparison and buys the guarantee.

**The server is restarted when this run minted a secret.** Nothing can diff a process that read its environment an hour ago, so the trigger is the one fact the script knows for certain: it generated a secret just now. A `SECRETS_ROTATED` flag is set wherever `MANAGED_AGENT_TOKEN` or `AGENT_TOOL_TOKEN` is minted, and the server block consults it before deciding a running server is fine.

Deliberately not "restart the server every run". It is the API; bouncing it when nothing changed is a cost with no reason. The flag is the honest signal.

## Proof

**Rotation, with the whole stack up.** Cleared `AGENT_TOOL_TOKEN`, re-ran `start.sh`:

```
Generated AGENT_TOOL_TOKEN and wrote it to .env.
  a secret was generated this run, so the server is restarted to pick it up
  server ready
  app ready
container in sync
```

Then, in the browser, the same question that had been answered "no files":

```
Exact filenames returned:
OpenBot PRD: Knowledge, Cloud, and Per-User Access
OpenBot PRD: Knowledge, Cloud, and Per-User Access
OpenBot PRD: Knowledge, Cloud, and Per-User Access
```

audited as `mcp.call_succeeded`, `reachedAs` equal to the asking user.

**Drift, before the fix**, reproduced deliberately: rotate the token in `.env` and re-run. The container stayed stale, and the trail showed `mcp.callback_refused | Not authorised.` — which is #136 working, and is what made this diagnosable in seconds rather than an hour.

| | result |
| --- | --- |
| `bun run test` | **1137 pass, 8 skip, 0 fail**, 1145 across 102 files |
| `bun run typecheck` | clean, all four packages |
| `bun run format:check` | clean |

## The cost, stated

Bot containers now go through compose on every run, so a run that rebuilds an image recreates them: about five seconds, and it bounces an idle Bot. `supervisor` already behaved this way, so this makes the three consistent with it rather than introducing something new.

The alternative is what we had: fast re-runs that can leave a Bot holding a secret the deployment has stopped accepting, reporting empty results to whoever asks.

## Tests

None. `start.sh` is a shell entry point with no harness in this repo, and building one is a larger change than this. It is driven above instead, in both directions.