### PR TITLE
Stop an unanswered request for the wheel outliving its run

### DIFF
--- a/agent-computer/src/control.ts
+++ b/agent-computer/src/control.ts
@@ -22,6 +22,15 @@ export type ControlState = {
   /** True once the Bot has asked for help and no person has taken the wheel yet. */
   requested: boolean;
   /**
+   * When the Bot asked, so an unanswered request can stop being shown.
+   *
+   * A request nobody answers used to last forever. The run that made it had already ended, but the
+   * prompt stayed on the computer, and control belongs to the computer rather than to a conversation
+   * — so every later conversation with that Bot showed a live "Take control" for work it was not
+   * doing, with the reason the Bot gave, written for whoever asked and rendered to whoever looked.
+   */
+  requestedAt?: string;
+  /**
    * A secret the Bot is waiting for, described by its label only.
    *
    * Secret entry is scoped rather than a full takeover. The Bot names the field, says what it needs,
@@ -57,6 +66,16 @@ export class ControlRequestError extends Error {
 }
 
 export const NO_SECRET_PENDING = "Nothing is waiting for a secret.";
+/**
+ * How long an unanswered request to take the wheel is shown for.
+ *
+ * Long enough that somebody who stepped away can still act on it, short enough that it does not
+ * follow the Bot into tomorrow's conversations. The run that made it is already over either way:
+ * nothing resumes when a person takes the wheel this late, so the value trades "still useful" against
+ * "still on screen" and nothing else.
+ */
+export const HELP_REQUEST_TTL_MS = 10 * 60 * 1000;
+
 export const HUMAN_HAS_CONTROL =
   "A person has control of the computer right now. Wait for them to hand it back before acting.";
 export const TAKE_CONTROL_FIRST =
@@ -79,8 +98,27 @@ export function createControl(
   };
 
   return {
-    /** The current state, as the surface polls it. A copy, so a caller cannot mutate the machine. */
+    /**
+     * The current state, as the surface polls it. A copy, so a caller cannot mutate the machine.
+     *
+     * An unanswered request is dropped once it is older than {@link HELP_REQUEST_TTL_MS}. It is
+     * expired on read rather than on a timer because there is nothing to wake: the run that asked
+     * has ended, and the only thing that cares is whoever looks next.
+     *
+     * Only ever the ASK. A person actually holding the wheel is never timed out from under them:
+     * they may be halfway through typing a code, and taking the browser back mid-sign-in is worse
+     * than any stale prompt.
+     */
     get(): ControlState {
+      if (
+        state.requested &&
+        state.holder === "bot" &&
+        state.requestedAt &&
+        Date.parse(now()) - Date.parse(state.requestedAt) > HELP_REQUEST_TTL_MS
+      ) {
+        const { reason: _reason, requestedAt: _at, ...rest } = state;
+        state = { ...rest, requested: false };
+      }
       return { ...state };
     },
 
@@ -94,6 +132,7 @@ export function createControl(
       state = {
         ...state,
         requested: true,
+        requestedAt: now(),
         reason:
           typeof reason === "string" && reason.trim()
             ? reason.trim()

--- a/agent-computer/tests/control.test.ts
+++ b/agent-computer/tests/control.test.ts
@@ -236,3 +236,55 @@ describe("the crappy paths: secrets", () => {
     ).toEqual(["secretRef", "secretSnapshotId", "secretWanted"]);
   });
 });
+
+/**
+ * A request nobody answered does not outlive the run that made it.
+ *
+ * Control belongs to the computer, not to a conversation, and an unanswered request used to sit on
+ * it forever. The run that asked had ended, but every later conversation with that Bot showed a live
+ * "Take control" for work it was not doing — and showed the reason the Bot gave, which is written
+ * for whoever asked and was being rendered to whoever looked.
+ *
+ * Seen in the product: a brand new channel, on an unrelated question, displaying "Google Docs is
+ * asking for sign-in before I can read the PRD document" from a conversation minutes earlier.
+ */
+describe("an unanswered request to take the wheel", () => {
+  const at = (iso: string) => () => iso;
+
+  test("is still shown inside the window", () => {
+    let clock = "2026-08-22T03:00:00.000Z";
+    const control = createControl(() => clock);
+    control.requestHelp("sign in to Drive");
+
+    clock = "2026-08-22T03:05:00.000Z";
+    const state = control.get();
+    expect(state.requested).toBe(true);
+    expect(state.reason).toBe("sign in to Drive");
+  });
+
+  test("stops being shown once it is stale, and takes its reason with it", () => {
+    let clock = "2026-08-22T03:00:00.000Z";
+    const control = createControl(() => clock);
+    control.requestHelp("sign in to Drive");
+
+    clock = "2026-08-22T03:20:00.000Z";
+    const state = control.get();
+    expect(state.requested).toBe(false);
+    // The reason is the part that leaked between conversations, so it goes too.
+    expect(state.reason).toBeUndefined();
+  });
+
+  test("never takes the wheel back off a person who holds it", () => {
+    /*
+     * The one case that must not expire. Somebody may be halfway through typing a code, and pulling
+     * the browser back mid-sign-in is worse than any stale prompt. Only the ASK times out.
+     */
+    let clock = "2026-08-22T03:00:00.000Z";
+    const control = createControl(() => clock);
+    control.requestHelp("sign in to Drive");
+    control.take();
+
+    clock = "2026-08-22T04:00:00.000Z";
+    expect(control.get().holder).toBe("human");
+  });
+});

--- a/agent-computer/tests/control.test.ts
+++ b/agent-computer/tests/control.test.ts
@@ -249,8 +249,6 @@ describe("the crappy paths: secrets", () => {
  * asking for sign-in before I can read the PRD document" from a conversation minutes earlier.
  */
 describe("an unanswered request to take the wheel", () => {
-  const at = (iso: string) => () => iso;
-
   test("is still shown inside the window", () => {
     let clock = "2026-08-22T03:00:00.000Z";
     const control = createControl(() => clock);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -659,6 +659,25 @@ export function createApp(
           intentRouter,
           requireUser,
           auditStore,
+          /*
+           * Which vendors each coworker holds tools for, so the router weighs what a coworker can
+           * reach and not only what somebody wrote it was for. Only when there is a plugin store to
+           * ask: a deployment with no connectors routes exactly as it did.
+           */
+          pluginStore
+            ? async (agentId) => {
+                const granted = await pluginStore.listForAgent(agentId);
+                return [
+                  ...new Set(
+                    granted.tools.map(
+                      (tool) =>
+                        tool.toolName.replace(/^mcp__/, "").split("__")[0] ??
+                        tool.toolName,
+                    ),
+                  ),
+                ];
+              }
+            : undefined,
         ),
       );
     }

--- a/server/src/copilot.ts
+++ b/server/src/copilot.ts
@@ -8,6 +8,7 @@ import {
 import { createCopilotHonoHandler } from "@copilotkit/runtime/v2/hono";
 import { z } from "zod";
 import { COMPUTER_GUIDANCE } from "../../shared/bot-prompt";
+import { grantedToolGuidance } from "./plugins/tools";
 import type { AgentActor } from "./agents/profile-types";
 import type { StallGuard } from "./channels/stall-guard";
 import type { DeploymentConfig } from "./config";
@@ -200,9 +201,18 @@ export function builtInAgentConfiguration(
 
   return {
     model: `${model.provider}/${model.defaultModel}`,
-    prompt: computerGuidance
-      ? `${agent.systemPrompt}\n\n${computerGuidance}`
-      : agent.systemPrompt,
+    /*
+     * The package's role, then what this Bot actually holds, then the computer.
+     *
+     * The grants go BEFORE the computer prose on purpose. That prose is long and emphatic about the
+     * browser and mentions connectors nowhere, so a Bot that read it last reached for the browser
+     * even when it held a tool for the exact system being asked about.
+     */
+    prompt: [
+      agent.systemPrompt,
+      ...(grantedToolGuidance(tools) ? [grantedToolGuidance(tools)] : []),
+      ...(computerGuidance ? [computerGuidance] : []),
+    ].join("\n\n"),
     apiKey,
     /*
      * A run stops after one step unless told otherwise, which for a Bot with tools means it calls
@@ -327,13 +337,37 @@ function remoteAgentWithStandingRole(
       ? { fetch: stallGuard.watch({ id: agent.id, name: agent.name }) }
       : {}),
   });
+  /*
+   * What this Bot holds, as a second standing message.
+   *
+   * Beside the role rather than inside it, because the role comes from the package and this comes
+   * from the grants: they change for different reasons and at different times. Sent on every run for
+   * the same reason the tools are, so switching a connector on reaches the next run.
+   *
+   * The remote path needs this more than the built-in one, not less. A framework Bot is handed the
+   * tools as an offer and decides for itself what to call, with `COMPUTER_GUIDANCE` as its whole
+   * prompt — a page about the browser that mentions connectors nowhere. That is the Bot that browsed
+   * to drive.google.com holding four Drive tools.
+   */
+  const holdings = grantedToolGuidance(tools);
+  const holdingsMessage = holdings
+    ? {
+        id: `granted-tools:${agent.id}`,
+        role: "system" as const,
+        content: holdings,
+      }
+    : null;
+
   remote.use((input, next) =>
     next.run({
       ...input,
       messages: [
         agent.standingMessage,
+        ...(holdingsMessage ? [holdingsMessage] : []),
         ...input.messages.filter(
-          (message) => message.id !== agent.standingMessage.id,
+          (message) =>
+            message.id !== agent.standingMessage.id &&
+            message.id !== holdingsMessage?.id,
         ),
       ],
       /*

--- a/server/src/plugins/tools.ts
+++ b/server/src/plugins/tools.ts
@@ -49,6 +49,48 @@ export function parametersFor(inputSchema: Record<string, unknown>): z.ZodType {
 }
 
 /**
+ * What this Bot holds, said in its instructions rather than left to be inferred from a tool list.
+ *
+ * A tool array tells a model a tool exists. It does not tell it that the tool is the right way to
+ * reach that system, and it competes with a page of prose about the browser that every Bot is given
+ * whether or not it has any connectors at all. The browser prose wins: it is emphatic, it is about
+ * capability, and it says "never claim you cannot browse".
+ *
+ * So a Bot holding four Google Drive tools browsed to drive.google.com, met a sign-in page its
+ * container could never satisfy, and asked its person to sign in to a vendor that person had already
+ * connected. The tools were there the whole time.
+ *
+ * Generated from the grants rather than written down, because the point is that it tracks them. An
+ * administrator switching a connector on, or granting one more of its tools, changes what the Bot is
+ * told on its next run with nothing else to remember and nothing to keep in step.
+ *
+ * Empty when the Bot holds nothing, so a deployment with no connectors says nothing about them.
+ */
+export function grantedToolGuidance(tools: GrantedTool[]): string {
+  if (tools.length === 0) return "";
+
+  const bySystem = new Map<string, string[]>();
+  for (const tool of tools) {
+    // `mcp__server__tool`, which is the shape the model is offered.
+    const parts = tool.name.replace(/^mcp__/, "").split("__");
+    const system = parts.length > 1 ? (parts[0] as string) : "this deployment";
+    const rest = parts.length > 1 ? parts.slice(1).join("__") : tool.name;
+    bySystem.set(system, [...(bySystem.get(system) ?? []), rest]);
+  }
+
+  return [
+    "You can reach these systems directly, as the person asking, with their own access:",
+    ...[...bySystem.entries()].map(
+      ([system, names]) => `- ${system}: ${names.join(", ")}`,
+    ),
+    "Use them for anything about those systems. Do NOT browse to one of their websites instead: your",
+    "browser is signed in as nobody, so it sees less than these tools do and will meet a sign-in wall",
+    "that connecting an account has already solved. If one of these systems is involved but no tool",
+    "above covers the part you need, say which part is missing rather than going around it.",
+  ].join("\n");
+}
+
+/**
  * Every MCP tool granted to one Bot, ready to hand to the runtime.
  *
  * A refusal is returned as the tool's result rather than thrown. The model is mid-run and the person

--- a/server/src/routing/classify.ts
+++ b/server/src/routing/classify.ts
@@ -18,6 +18,20 @@ export type RoutingCandidate = {
   name: string;
   /** What this coworker is for. The one line an operator wrote to say when to reach them. */
   roleDescription: string;
+  /**
+   * The systems this coworker can actually reach, by name.
+   *
+   * Routing on the role description alone routes on what somebody wrote a coworker was for, which is
+   * not the same as what it can do. A question about a document in Google Drive went to the coworker
+   * whose description says "company knowledge" and which held no Drive grants at all, so it browsed
+   * to the vendor, met a sign-in wall and asked the person to sign in to an account they had already
+   * connected. The coworker that could have answered was one line further down the roster.
+   *
+   * Empty for a coworker holding nothing, which is most of them in most deployments. It is a hint
+   * rather than a filter: a specialist with no connectors is still the right answer to a question
+   * about its specialism.
+   */
+  reaches?: readonly string[];
 };
 
 export type RoutingDecision = {
@@ -37,7 +51,16 @@ export function routingPrompt(
   candidates: readonly RoutingCandidate[],
 ): string {
   const roster = candidates
-    .map((c) => `- id: ${c.id}\n  name: ${c.name}\n  for: ${c.roleDescription}`)
+    .map((c) =>
+      [
+        `- id: ${c.id}`,
+        `  name: ${c.name}`,
+        `  for: ${c.roleDescription}`,
+        ...(c.reaches && c.reaches.length > 0
+          ? [`  can reach: ${c.reaches.join(", ")}`]
+          : []),
+      ].join("\n"),
+    )
     .join("\n");
   return [
     "You route a person's message to the one coworker best suited to it.",
@@ -46,6 +69,18 @@ export function routingPrompt(
     "",
     'Reply with only JSON: {"agentId": "<one id from the list>", "reason": "<short, names the fit>", "confidence": <0..1>}.',
     "Pick the specialist whose purpose matches the message. If none clearly fits, use the most general coworker and give it a low confidence.",
+    /*
+     * Only when somebody on the roster can actually reach something.
+     *
+     * A deployment with no connectors would otherwise carry a rule about systems none of its
+     * coworkers have, in every routing prompt it ever sends. Same principle as the guidance a Bot
+     * gets about its own grants: say nothing about what is not there.
+     */
+    ...(candidates.some((c) => c.reaches && c.reaches.length > 0)
+      ? [
+          "When the message names a system a coworker can reach, prefer that coworker: one that cannot reach it has no way to answer and will fall back to a browser that is signed in as nobody. Purpose still comes first — a specialist with no systems listed is right for a question about its specialism.",
+        ]
+      : []),
     "",
     `Message: ${text}`,
   ].join("\n");

--- a/server/src/routing/routes.ts
+++ b/server/src/routing/routes.ts
@@ -21,6 +21,14 @@ export function createRoutingRoutes(
   router: IntentRouter,
   requireUser: MiddlewareHandler<{ Variables: AppVariables }>,
   auditStore?: AuditStore,
+  /**
+   * Which systems a coworker can reach, for the router to weigh alongside what it is for.
+   *
+   * Optional, and absent leaves routing exactly as it was: a deployment with no connectors has
+   * nothing to add here, and one that cannot answer the question should not have routing fail over
+   * it. Asked per request rather than held, because a grant added a minute ago has to count.
+   */
+  reachableSystems?: (agentId: string) => Promise<readonly string[]>,
 ) {
   const routes = new Hono<{ Variables: AppVariables }>();
 
@@ -39,11 +47,25 @@ export function createRoutingRoutes(
     if (!preferred) {
       return context.json({ error: "No coworker is available." }, 409);
     }
-    const candidates: RoutingCandidate[] = roster.map((a) => ({
-      id: a.id,
-      name: a.name,
-      roleDescription: a.roleDescription,
-    }));
+    const candidates: RoutingCandidate[] = await Promise.all(
+      roster.map(async (a) => ({
+        id: a.id,
+        name: a.name,
+        roleDescription: a.roleDescription,
+        /*
+         * Never allowed to break routing. A connector store that is slow or unhappy must not turn
+         * "who is this for" into an error, so a failure here is the same as holding nothing: the
+         * router falls back to matching on purpose alone, which is what it did before.
+         */
+        ...(reachableSystems
+          ? {
+              reaches: await reachableSystems(a.id).catch(
+                () => [] as readonly string[],
+              ),
+            }
+          : {}),
+      })),
+    );
 
     const decision = await router.route(text, candidates, preferred.id);
 

--- a/server/tests/copilot.test.ts
+++ b/server/tests/copilot.test.ts
@@ -9,6 +9,7 @@ import {
   resolveRuntimeAgents,
   standingRoleMessage,
 } from "../src/copilot";
+import { grantedToolGuidance } from "../src/plugins/tools";
 
 // Every agent row now joins its profile, so the row a coworker is built from always names it.
 const assistantRow = {
@@ -502,3 +503,63 @@ function fakeAgUiEndpoint() {
     [Symbol.asyncDispose]: () => server.stop(true),
   };
 }
+
+/**
+ * A Bot is told what it holds, not only handed it.
+ *
+ * A tool array tells a model a tool exists. It does not say the tool is the right way to reach that
+ * system, and it competes with `COMPUTER_GUIDANCE`: a page of emphatic prose about the browser that
+ * every Bot gets whether or not it has a single connector, and that mentions connectors nowhere.
+ *
+ * The browser prose won. A Bot holding four Google Drive tools browsed to drive.google.com, met a
+ * sign-in page its container could never satisfy, and asked its person to sign in to a vendor that
+ * person had already connected. Asked a question with no tool for it, another went reading a
+ * government website and looped on its 404 page.
+ *
+ * Both kinds are asserted because they are built by different functions, and the remote one is the
+ * one that failed in the product.
+ */
+describe("what a Bot is told it holds", () => {
+  const drive = [
+    { name: "mcp__google-drive__search_files" },
+    { name: "mcp__google-drive__read_file_content" },
+  ] as never[];
+
+  test("names the system and its tools", () => {
+    const guidance = grantedToolGuidance(drive);
+    expect(guidance).toContain("google-drive");
+    expect(guidance).toContain("search_files");
+    expect(guidance).toContain("read_file_content");
+  });
+
+  test("says not to browse to a vendor it has a tool for", () => {
+    // The whole point. Without this line the tool list is inert beside the browser prose.
+    expect(grantedToolGuidance(drive).toLowerCase()).toContain("do not browse");
+  });
+
+  test("says nothing at all when the Bot holds nothing", () => {
+    // A deployment with no connectors must not be told about connectors it does not have.
+    expect(grantedToolGuidance([])).toBe("");
+  });
+
+  test("a built-in Bot is told before it is told about the browser", () => {
+    const prompt = builtInAgentConfiguration(
+      {
+        id: "risk-analyst",
+        name: "Risk Analyst",
+        type: "built_in",
+        systemPrompt: "Investigate policies.",
+      },
+      { provider: "openai", defaultModel: "gpt-4.1" },
+      "openai-secret",
+      drive,
+      "BROWSER GUIDANCE HERE",
+    ).prompt as string;
+
+    // Order is the fix, not merely presence: the grants have to land before the browser prose.
+    expect(prompt.indexOf("google-drive")).toBeGreaterThan(-1);
+    expect(prompt.indexOf("google-drive")).toBeLessThan(
+      prompt.indexOf("BROWSER GUIDANCE HERE"),
+    );
+  });
+});

--- a/server/tests/routing-classify.test.ts
+++ b/server/tests/routing-classify.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   createIntentRouter,
+  routingPrompt,
   type RoutingCandidate,
 } from "../src/routing/classify";
 
@@ -98,5 +99,64 @@ describe("routing a message with no @mention", () => {
     expect(called).toBe(false);
     expect(r.agentId).toBe("general-assistant");
     expect(r.fallback).toBe(true);
+  });
+});
+
+/**
+ * The router is told what each coworker can reach, not only what it is for.
+ *
+ * Routing on the role description alone routes on what somebody wrote a coworker was for, which is
+ * not the same as what it can do. A question about a document in Google Drive went to the coworker
+ * whose description says "company knowledge" and which held no Drive grants at all. It browsed to
+ * the vendor, met a sign-in wall, and asked the person to sign in to an account they had already
+ * connected. The coworker that could have answered was one line further down the roster.
+ */
+describe("routing on what a coworker can reach", () => {
+  const withReach: RoutingCandidate[] = [
+    {
+      id: "knowledge",
+      name: "Knowledge",
+      roleDescription: "company knowledge questions",
+    },
+    {
+      id: "risk-analyst",
+      name: "Risk Analyst",
+      roleDescription: "risk and compliance",
+      reaches: ["google-drive"],
+    },
+  ];
+
+  test("names the systems in the roster the model is given", () => {
+    const prompt = routingPrompt("what is in my Drive doc?", withReach);
+    expect(prompt).toContain("can reach: google-drive");
+  });
+
+  test("says nothing about reach for a coworker that holds nothing", () => {
+    // Most coworkers in most deployments. An empty line here would be noise in every prompt.
+    const prompt = routingPrompt("anything", withReach);
+    const knowledgeBlock = prompt.slice(
+      prompt.indexOf("id: knowledge"),
+      prompt.indexOf("id: risk-analyst"),
+    );
+    expect(knowledgeBlock).not.toContain("can reach");
+  });
+
+  test("tells the model to prefer reach without letting it override purpose", () => {
+    /*
+     * Both halves matter. Preferring a coworker that can reach the system is the fix; letting that
+     * outrank purpose would send every question to whichever coworker happens to hold a connector,
+     * which is a different bug with the same shape.
+     */
+    const prompt = routingPrompt("anything", withReach);
+    expect(prompt).toContain("prefer that coworker");
+    expect(prompt).toContain("Purpose still comes first");
+  });
+
+  test("a roster with no reach at all reads exactly as it did before", () => {
+    // A deployment with no connectors must not have its routing prompt changed by this.
+    const plain = routingPrompt("anything", [
+      { id: "a", name: "A", roleDescription: "alpha" },
+    ]);
+    expect(plain).not.toContain("can reach");
   });
 });


### PR DESCRIPTION
The cross-conversation half of #140.

## What it looked like

A brand new channel, on a completely unrelated question, showing:

> **The assistant needs you.** Google Docs is asking for sign-in before I can read the PRD document. **[Take control]**

with a live button. The request came from a different conversation, minutes earlier, about a document that thread had never mentioned. The audit trail agreed it was still outstanding:

```
02:54:29  computer.help_requested
01:57:36  computer.control_released
01:56:43  computer.control_taken
```

A `help_requested` with nothing after it.

## Why

Control is a property of the Bot's **computer**, not of the conversation that asked. So an unanswered request sits on the computer and is shown to anybody looking at that Bot's screen, in any channel, indefinitely. The run that made it ended long before.

The part to care about is not the stale button. It is the **reason**: written for the person who asked, and rendered to whoever looks. In a deployment with more than one person that is somebody else's context on your screen — here, the existence and subject of a document.

## The change

An unanswered ask stops being shown after ten minutes, and its reason is dropped with it, because the reason is the part that leaked.

**Expired on read, not on a timer.** There is nothing to wake: the asking run is over, and the only thing that cares is whoever looks next. A timer would be a scheduler for a value nobody is waiting on.

**A person holding the wheel is never timed out.** They may be halfway through typing a code, and taking the browser back mid-sign-in is worse than any stale prompt. Only the *ask* expires, never the holding, and there is a test pinning that.

Ten minutes is long enough that somebody who stepped away can still act on it, and short enough that it does not follow the Bot into tomorrow. The run does not resume either way, so the value trades "still useful" against "still on screen" and nothing else.

## Tests

Three, on the state machine with an injected clock — the module has no Playwright import, so this needs no browser:

- inside the window, the request and its reason are still shown
- past it, `requested` is false **and** the reason is gone
- a person who took the wheel still holds it an hour later

| | result |
| --- | --- |
| `bun run test` | **1156 pass, 8 skip, 0 fail**, 1164 across 103 files |
| `bun run typecheck` | clean, all four packages plus `agent-computer` |
| `bun run format:check` | clean |

## What this does not fix

The other half of #140, and the worse one for the person it happens to: an unanswered handover leaves a `tool_calls` message with no matching result, so the **asking thread** is permanently unusable —

```
400 An assistant message with 'tool_calls' must be followed by tool messages responding to
each 'tool_call_id'.
```

Every later message in that conversation fails, and the only way out is New chat, which loses it. That needs the run to write a result when it ends without one — "the person did not take the wheel" is an outcome the model can act on, and it keeps the history valid. Separate change; #140 stays open for it.

These are worth separating because they fail differently. This one shows one person's context to another. That one destroys a conversation.