### PR TITLE
Report a missing grant as a missing grant

### DIFF
--- a/server/src/plugins/tools.ts
+++ b/server/src/plugins/tools.ts
@@ -85,8 +85,12 @@ export function grantedToolGuidance(tools: GrantedTool[]): string {
     ),
     "Use them for anything about those systems. Do NOT browse to one of their websites instead: your",
     "browser is signed in as nobody, so it sees less than these tools do and will meet a sign-in wall",
-    "that connecting an account has already solved. If one of these systems is involved but no tool",
-    "above covers the part you need, say which part is missing rather than going around it.",
+    "that connecting an account has already solved.",
+    "If one of these systems is involved and no tool above covers the part you need, that is a",
+    "missing grant and not something to work around. Say so plainly, name the capability you would",
+    "need, and say an administrator can grant it on that connector. Do not reach for the browser, do",
+    "not ask the person to sign in, and do not ask them to fetch it for you: they already have the",
+    "access, and the thing that is missing is yours, not theirs.",
   ].join("\n");
 }
 

--- a/server/tests/copilot.test.ts
+++ b/server/tests/copilot.test.ts
@@ -537,6 +537,29 @@ describe("what a Bot is told it holds", () => {
     expect(grantedToolGuidance(drive).toLowerCase()).toContain("do not browse");
   });
 
+  test("says a gap in what it holds is a grant to ask for, not a wall to climb", () => {
+    /*
+     * The half of the Drive failure the "do not browse" line does not cover.
+     *
+     * Only `search_files` was granted. The Bot found the document, had no way to read it, and
+     * surfaced that as an authentication problem on `docs.google.com`: it opened the vendor, met
+     * Google's sign-in page and asked its person to take the wheel and sign in. They already had
+     * access. The Bot lacked a grant, and nothing on screen said so.
+     *
+     * A sentence naming the missing capability points at the screen that fixes it. A sign-in box
+     * does not, and asking the person to fetch it instead is the same mistake wearing a hat.
+     */
+    // Whitespace-normalised: the guidance is assembled line by line, so a sentence spans a newline
+    // wherever the source happened to wrap, which is not a fact about what the Bot is told.
+    const guidance = grantedToolGuidance(drive)
+      .toLowerCase()
+      .replace(/\s+/g, " ");
+    expect(guidance).toContain("missing grant");
+    expect(guidance).toContain("name the capability");
+    expect(guidance).toContain("administrator can grant it");
+    expect(guidance).toContain("do not ask the person to sign in");
+  });
+
   test("says nothing at all when the Bot holds nothing", () => {
     // A deployment with no connectors must not be told about connectors it does not have.
     expect(grantedToolGuidance([])).toBe("");


### PR DESCRIPTION
Closes #141.

## What happened

A person asked what was in a PRD the Bot had just found in their Drive. Instead of reading it, the Bot opened `docs.google.com` in its own container, hit Google's sign-in page, and asked them to take the wheel and sign in.

Only `search_files` was granted. `read_file_content` was not. So the Bot could find the document and had no way to read it — and rather than say that, it fell back to the browser, and a gap in what it holds surfaced as an authentication problem somewhere else entirely.

The person already had access. What was missing was the Bot's, not theirs, and nothing on screen said so. Their reaction was the correct one: *"this is wrong, it should tell me what's in the PRD, not sign me in"*.

## The fix

The guidance a Bot gets about its grants already told it not to browse to a vendor it holds tools for — that was the other half of this issue, fixed earlier. It now also covers the case where it holds *some* of a vendor's tools and not the one it needs:

> If one of these systems is involved and no tool above covers the part you need, that is a missing grant and not something to work around. Say so plainly, name the capability you would need, and say an administrator can grant it on that connector. Do not reach for the browser, do not ask the person to sign in, and do not ask them to fetch it for you: they already have the access, and the thing that is missing is yours, not theirs.

The last clause is there because "could you paste it in for me" is the same mistake wearing a hat.

## Driven in Chrome, on the real repro

Revoked `read_file_content` from Risk Analyst on `/admin/plugins/google-drive`, leaving `search_files` and `get_file_metadata` — the exact state from the issue. Then asked, through the `@` picker:

> Find my OpenBot PRD in Google Drive and tell me what is in it.

It called `search_files` and `get_file_metadata` (visible as tool pills), found the document, reported its title, type, modified time, owner, size and link, noted the two earlier copies, and then:

> I can find the files and metadata, but this Google Drive connector does **not** currently expose a capability to read/export the body text of a Google Doc. To tell you what is inside the PRD, I'd need a Drive/Docs capability such as **read document contents** or **export Google Doc as text/Markdown/PDF** granted on the connector.

No browser. No sign-in wall. No asking the person to fetch it. It named what it would need and where it would be granted.

It says "read document contents" rather than `read_file_content` because the tool is not in its list at all — it can only describe the capability, not name a tool it was never told about. That is the honest version, and it still points at the screen that fixes it.

The grant was restored afterwards.

## Tests

One added to the existing `what a Bot is told it holds` suite, asserting the guidance names a gap as a grant to ask for, names the capability, says an administrator can grant it, and does not send the person to a sign-in box. Whitespace-normalised, because the guidance is assembled line by line and a sentence spans a newline wherever the source happened to wrap.