### PR TITLE
Give the in-memory snapshot store the guard the table has

### DIFF
--- a/server/src/computer/snapshot-store.ts
+++ b/server/src/computer/snapshot-store.ts
@@ -145,6 +145,13 @@ export function createInMemorySnapshotStore(): SnapshotStore {
   const snapshots = new Map<string, StoredSnapshot>();
   return {
     save: async (computerId, snapshot) => {
+      // Only ever forward, the same rule the table's `setWhere` applies, because the two stores have
+      // to agree about when a save wins. Two snapshots of one computer can complete out of order in a
+      // single process as easily as across two, and a test that reaches for this store because it has
+      // no database would otherwise be told a different story about what the gateway resolves
+      // against: the older page here, the newer one in a deployment.
+      const held = snapshots.get(computerId);
+      if (held && held.snapshotId >= snapshot.snapshotId) return;
       snapshots.set(computerId, snapshot);
     },
     load: async (computerId) => snapshots.get(computerId),

--- a/server/tests/computer-snapshot-store.test.ts
+++ b/server/tests/computer-snapshot-store.test.ts
@@ -67,6 +67,35 @@ describe("the in-memory snapshot store", () => {
     expect(loaded?.elements.get("e9")?.name).toBe("Cancel");
   });
 
+  test("an older snapshot arriving late does not overwrite the newer one", async () => {
+    // The property #46 established, asked of this store rather than of the table. A test that reaches
+    // for the in-memory store because it has no database must not be told a different story about
+    // when a save wins: two snapshots of one computer can complete out of order here too, and the
+    // generation is what decides between them in both implementations.
+    const store = createInMemorySnapshotStore();
+    await store.save(
+      "default",
+      snapshot(8, [{ ref: "e9", role: "button", name: "Cancel" }]),
+    );
+
+    await store.save(
+      "default",
+      snapshot(7, [{ ref: "e9", role: "button", name: "Submit order" }]),
+    );
+
+    // A save of the generation already held loses too, the way `setWhere`'s `lt` refuses it: the
+    // stored snapshot is the one that generation named, and a second delivery of it carries nothing
+    // newer to say.
+    await store.save(
+      "default",
+      snapshot(8, [{ ref: "e9", role: "button", name: "Submit order" }]),
+    );
+
+    const loaded = await store.load("default");
+    expect(loaded?.snapshotId).toBe(8);
+    expect(loaded?.elements.get("e9")?.name).toBe("Cancel");
+  });
+
   test("clearing forgets the snapshot, so nothing resolves against a wiped computer", async () => {
     const store = createInMemorySnapshotStore();
     await store.save(


### PR DESCRIPTION
## What this changes

`createInMemorySnapshotStore` now applies the same only-ever-forward rule the table does.

Part (c) of #158. Thanks @beardthelion — the line references are exact throughout, and noticing that the two store implementations disagree about the property #46 established is the kind of thing that stays hidden until a test quietly proves the wrong thing.

`save` was a bare `snapshots.set(...)`. The database store expresses the rule as `setWhere: lt(computerSnapshot.snapshotId, values.snapshotId)`; the memory store expressed nothing. Two snapshots of one computer can complete out of order inside a single process as easily as across two, so a test that reaches for this store because it has no database was told a different story about which save wins than a deployment gets.

The guard is `>=` rather than `>` so it matches `lt(stored, incoming)` exactly: a second delivery of the generation already held carries nothing newer to say. The new test asserts both the older-arriving-late case and the equal-generation case, since `>` would pass the first and fail the second.

### Why `>=` and not `>`

Worth stating, because it is the one line a reviewer would reasonably push back on.

Generations increase by one per snapshot within a session (`agent-computer/src/index.ts:259`, and again on navigate at `:709`), so an equal generation cannot occur inside one session. It only happens when the counter has restarted and climbed back to a number the store still holds from a dead session — and in that case the two generation-7s describe different pages.

`>` would keep the fresh page there, which is the better outcome in isolation. It is not what the table does: `lt(7, 7)` is false, so Postgres holds the dead page. Taking `>` here would make the fake safer than the deployment, which is the exact failure part (c) exists to correct — a gateway test would prove a boundary property that is false in production.

So this matches the table, including where the table is wrong, and the wrongness is called out below rather than papered over in the fake.

### The equal-generation case is a live wrong-element resolution, and it is not this PR's to fix

Following the operator question to its end turns up something worse than a dropped save, and it is a property of the Postgres path rather than of this change.

`gateway.snapshot` (`gateway.ts:313`) awaits `snapshots.save(...)` and returns `result` to the model regardless of whether the row moved. `resolve` (`gateway.ts:345`) is `stored.snapshotId !== snapshotId` → `undefined`. Put those together on a restarted computer whose counter has climbed back to a generation the row still holds:

1. The row holds generation 7 from a wiped session — say a transfer page, `e9` = "Confirm transfer".
2. The restarted computer reaches generation 7 on a different page, `e9` = "Table of contents".
3. The save is refused, so the row keeps the dead page.
4. The model is shown the fresh page and cites generation 7.
5. `resolve` compares 7 against 7, matches, and returns **the dead page's element**.

The policy then decides against an element from a page that no longer exists, and the audit row names it. That is the precise outcome `clear()`'s comment at `snapshot-store.ts:60-64` says the row is deleted to prevent, reached through the equal-generation door instead.

It is not fixed by either operator here, because it is the table's behaviour and the fake is only following it. It is also not fixed by an epoch on the insert path. Ordering on `(session, generation)` does fix it, which is one more argument for that design over a narrower patch. Raised on #158 rather than folded in.

## Part (a) is not fixed here, and should not be fixed the way the issue proposes

The issue's mechanism is right: `setWhere` qualifies the `DO UPDATE` branch only, so with no row to conflict with the insert is unconditional, and a save in flight across `clear()` re-creates the row.

The premise underneath the proposed shape does not hold, though, and it is worth writing down because two comments in this repo state it as fact — `snapshot-store.ts:61` and `gateway.ts:576` both say *"a fresh computer counts generations from one again."*

Whether it does depends on which provider is deployed:

| Reset path | What happens to the counter |
| --- | --- |
| `provider.ts:181`, posting straight to the container | `agent-computer/src/index.ts:684` calls `profiles.reset(botId)`, then releases control, and never touches `sessions`. `session.snapshotId` is written only at `:148` (0 at creation), `:259` and `:709`. The session outlives the wipe, so the fresh browser's first snapshot is usually the **next** generation — unless `forgetIdleSessions` (`:137-144`) has since evicted the session, which it may, because the profile is no longer live after a reset. Either 1 or 8 is reachable here |
| `supervisor.ts:188` → `supervisor/src/docker.ts:519` | The container is removed with `remove({ force: true })`, so a new one starts with an empty session map and the counter restarts at **1** |

So after wiping a row that held generation 7, the store can be handed generation 8 meaning *the old session's in-flight save* or generation 8 meaning *the fresh page*, with only the page contents differing — which is the thing the store cannot judge. Eviction makes it worse rather than better: both 1 and the next generation are reachable on either path, so the generation carries no information about which case this is. Every generation-keyed guard on the insert path fails one way or the other:

- `>= wiped generation` blocks the resurrection and also blocks the fresh browser's every subsequent snapshot on the direct path, permanently. No row inserts again, refs never resolve, and the boundary decides with no element. Worse than today, where the next snapshot supersedes the dead page.
- `< wiped generation only` — the rule the issue's two supplied tests specify — is the same rule with the same effect on a real reset.
- `!= wiped generation` passes both supplied tests while leaving the realistic case untouched.

The design that does fix (a) inside `server/` is a server-owned epoch per computer, bumped by `clear` in the same transaction as the delete, captured by `gateway.snapshot` before the `/snapshot` call and carried into `save`, with the write conditional in SQL on the captured epoch still being current. That is optimistic concurrency decided by Postgres in one statement rather than a check-then-write, and it is generation-independent so it holds whichever provider is deployed. It costs a table, a migration, a `save` signature change and a gateway change.

It is also a near neighbour of the session-identity design @beardthelion deliberately left to a maintainer, and it would be replaced by it: ordering on `(session, generation)` subsumes (a) entirely. That argues for doing the two together rather than landing an epoch and then removing it. Happy to take either once somebody decides where session identity lives.

## Where it runs

- **New state that outlives a request?** None. The `Map` was already there; this only decides when it is written.
- **What happens on the second replica?** Unchanged, and deliberately so. The in-memory store is still unreadable from another replica, which is why a deployment is passed the database-backed one. `createDatabase` (`server/src/db/client.ts:11`) takes a non-optional string and always returns a `Database`, so `createSnapshotStore(database)` never falls through to memory in a deployment and `gateway.ts:228`'s default is overridden at `index.ts:254`. What changes is that a property proved against this store is no longer quietly false against the table.
- **One consequence worth stating rather than leaving to be discovered.** Parity runs in both directions: the memory store now also reproduces the half of #158 that is *not* fixed. A gateway test against a computer whose counter restarted will see the stale generation retained, `resolve` (`gateway.ts:345`) find no matching element, and the boundary decide with nothing — exactly as a deployment would. That is the correct behaviour to model, and it means a unit test can now demonstrate the boundary disengaging. Reviewers deciding whether to land this before the ordering fix should have that in view.
- **Anything serialised?** Nothing new. The database store is untouched: one row per computer keyed on `computer_id`, `INSERT … ON CONFLICT (computer_id) DO UPDATE … WHERE snapshot_id < excluded`. Postgres's row lock on the conflicting key is the mechanism and the conditional update is what decides, not a read followed by a write. The memory store's guard is confined to one process by construction and does not claim otherwise.
- **Anything fanned out to a browser?** No.
- **New listener, port, or schedule?** No.

## Boundary and audit

- Untouched. `clear()`'s delete semantics, the gateway, the schema and every migration are unchanged.

## Changelog

No entry. A deployment runs the Postgres store and behaves identically; only the no-database path changes.

## Proof

One test added, in `server/tests/computer-snapshot-store.test.ts`. **It needs no database and was executed** — red first (`Expected: 8, Received: 7`), green after.

The two tests the issue supplies for `computer-snapshot-store.integration.test.ts` are **not** included. They specify the `< wiped generation only` rule, which cannot be correct for the reason above, and they would be red in CI. Banking a test that encodes behaviour that has to be undone is worse than leaving the case uncovered and saying so.

Mutations, each applied alone and reverted:

| Mutation | Result |
| --- | --- |
| Both guard lines removed, back to a bare `set` | test fails |
| `>=` weakened to `>` | test fails, on the equal-generation assertion |
| Condition neutered to `if (!held && false) return;` | test fails |

Measured by stashing in the same worktree, so the comparison isolates the change rather than the checkout:

| | baseline | with the change |
| --- | --- | --- |
| `bun run test` | 1138 tests, 120 fail | **1139 tests, 120 fail** |

Exactly one more test, one more pass, failure count unchanged. The failures are the Postgres integration set, which needs a database this machine does not have; the CI `tests` job runs pgvector for them. The one error is the pre-existing `agent-langgraph/tests/history.test.ts` → `Cannot find module '@langchain/core/messages'`.

- `bunx biome lint .` — 0 warnings, 1 info, exit 0.
- `bun run format:check`, `bun run typecheck`, `bun run build` — clean.

## Also worth a separate change

`snapshot-store.ts:61` and `gateway.ts:576` both explain the reset in terms of a fresh computer counting from one. On the direct provider path it does not, so both comments are describing behaviour the code does not have. Left alone here rather than folded in, since correcting them properly belongs with whichever fix settles the ordering.
