### PR TITLE
Let a person take the wheel without being offered it

### DIFF
--- a/app/src/components/computer/computer-view.tsx
+++ b/app/src/components/computer/computer-view.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { LiveScreen } from "./live-screen";
-import { ComputerPlaceholder } from "./placeholder";
 import {
+  type ControlState,
   readControl,
   releaseControl,
   supplySecret,
   takeControl,
-  type ControlState,
 } from "@/lib/computers/control";
 import { readScreenshot, type Screenshot } from "@/lib/computers/screen";
+import { LiveScreen } from "./live-screen";
+import { ComputerPlaceholder } from "./placeholder";
 
 /** Explicit blank-browser URLs use placeholder artwork; missing URL fields are treated as real pages. */
 function isBlankBrowser(shot: Screenshot): boolean {
@@ -312,11 +312,37 @@ export function ComputerView({
           </div>
         ) : null}
 
-        {control?.requested && !driving ? (
-          <div className="flex items-start justify-between gap-3 border-t bg-amber-500/10 px-3 py-2 text-sm">
+        {/*
+         * The wheel is offered whether or not the Bot asked for it.
+         *
+         * It only used to appear once the Bot called `computer_request_help`, which made the button
+         * depend on the Bot getting one instruction right. It does not always: asked to open a page
+         * behind a sign-in, a Bot answered "If you'd like, I can prompt you to take control … would
+         * you like to proceed with signing in?" and called nothing. The person was told to take
+         * control, and there was no control to take. The prompt already forbids that sentence in as
+         * many words, so the answer is not more prose: it is that a person who wants their own
+         * browser should not have to be offered it first.
+         *
+         * The amber row stays the Bot ASKING, which is a different thing and still worth its own
+         * colour and its reason. Without a request this is a quiet control that says who is driving.
+         */}
+        {!driving ? (
+          <div
+            className={`flex items-start justify-between gap-3 border-t px-3 py-2 text-sm ${
+              control?.requested ? "bg-amber-500/10" : "bg-muted/40"
+            }`}
+          >
             <span>
-              <strong className="font-medium">The assistant needs you.</strong>{" "}
-              {control.reason}
+              {control?.requested ? (
+                <>
+                  <strong className="font-medium">
+                    The assistant needs you.
+                  </strong>{" "}
+                  {control.reason}
+                </>
+              ) : (
+                "The assistant is driving. You can take over whenever you want."
+              )}
             </span>
             <button
               type="button"
@@ -325,7 +351,11 @@ export function ComputerView({
                 if (state) setControl(state);
                 setExpanded(true);
               }}
-              className="shrink-0 rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground"
+              className={`shrink-0 rounded-md px-3 py-1 text-xs font-medium ${
+                control?.requested
+                  ? "bg-primary text-primary-foreground"
+                  : "border"
+              }`}
             >
               Take control
             </button>
@@ -377,7 +407,8 @@ export function ComputerView({
                     >
                       Hand back to the assistant
                     </button>
-                  ) : control?.requested ? (
+                  ) : (
+                    /* Offered here too, and for the same reason: see the inline card above. */
                     <button
                       type="button"
                       onClick={async () => {
@@ -388,7 +419,7 @@ export function ComputerView({
                     >
                       Take control
                     </button>
-                  ) : null}
+                  )}
                   <span className="pointer-events-none text-white/70">
                     {driving
                       ? "Press Escape to close"


### PR DESCRIPTION
Found while testing the four open PRs against latest main, and separate from all of them.

## What was wrong

**Take control** only appeared once a Bot had called `computer_request_help`. So the button a person needs depended on the Bot getting one instruction right — and it does not always.

Asked, in a fresh channel, a completely neutral question:

> Open drive.google.com and tell me the name of the first file listed in my Drive.

the built-in General Assistant answered:

> "I cannot access your Google Drive directly right now because you need to be signed in. Please sign in to your Google account… **Let me know if you would like me to prompt you to sign in.**"

Three times out of three. `control.requested` stayed `false`, so the computer panel offered nothing. The person is told to take control, and there is no control to take — **a dead end reached by following the Bot's own instruction.**

## Why not fix the prompt

`COMPUTER_GUIDANCE` already forbids this in as many words, and names three example sentences it must never write:

> Calling it IS how you ask. Words in your answer are not… So NEVER write "please sign in and let me know", "would you like to proceed", or "once you have signed in, tell me" instead of calling it. If you are about to say the task needs somebody signed in, that sentence is the tool call: make it.

The Bot wrote "would you like me to prompt you to sign in" anyway. More prose is not the answer to prose that is already being ignored.

The answer is that somebody who wants their own browser should not have to be offered it first. That makes the Bot's failure an annoyance rather than a dead end — which is what it should always have been.

## What changes

The button is there whenever the Bot holds the wheel, in the inline card and in the full-size view.

The amber row stays the Bot **asking** — a different thing, and it keeps its colour and its reason. Without a request the row is quiet and simply says who is driving: *"The assistant is driving. You can take over whenever you want."*

## Driven in Chrome

1. Reproduced the prose answer on a fresh channel (three times, neutral prompt).
2. Pressed the new **Take control** from that state. `GET /control` → `{"holder":"human","requested":false}` — a person holding a wheel the Bot never offered.
3. The full-size view showed the live Google sign-in page, typeable, with "You have control. Click and type on the page as you normally would."
4. **Hand back to the assistant** returned `holder: bot` and the row went back to the quiet offer.
5. The control survives a page reload.

## What this does not do

It leaves the Bot's behaviour alone. It should still call `computer_request_help`, and a prompt that cannot reliably make it do so is worth its own change — this one just stops that failure from trapping anybody.