### PR TITLE
Stop a migration stamped in the future eating the next one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,18 @@ Sessions survive and nobody signs in again.
   is unavailable never blocks a sign-in.
 
 ### Fixed
+- **A migration stamped in the future silently swallowed the next one.** Drizzle runs a migration only
+  when its journal timestamp is later than the newest one the database has recorded, so a migration
+  stamped ahead of real time raises that ceiling and every migration written after it is skipped
+  until the clock catches up. `drizzle-kit migrate` reports success the whole time. One migration was
+  hand-written a day into the future and did exactly that to the next one to arrive: the table was
+  never created, and the only sign was an integration test failing on a relation that did not exist.
+  The timestamps are corrected, an older inversion between two earlier migrations is corrected with
+  them, and the journal is now checked by a test, because nothing else in the build would notice.
+  **If you ran a build between these, your database has the wrong ceiling recorded and will skip the
+  next migration.** Repair it with
+  `update drizzle.__drizzle_migrations set created_at = 1787359000000 where created_at = 1787444747113;`
+  or start from a fresh database, where migrations all run in one pass and ordering cannot bite.
 - **A Bot named after a deployment route was served without its guard.** The computer router steps
   aside for `/policy` and `/fleet`, which are its own paths and not about a Bot, because Hono matches
   `/*` against zero segments and a single-segment path arrives as a Bot id. It stepped aside on the

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -40,7 +40,7 @@
     {
       "idx": 5,
       "version": "7",
-      "when": 1787322944029,
+      "when": 1787324600000,
       "tag": "0005_computer_snapshot",
       "breakpoints": true
     },
@@ -89,7 +89,7 @@
     {
       "idx": 12,
       "version": "7",
-      "when": 1787444747113,
+      "when": 1787359000000,
       "tag": "0012_truncate_is_not_a_way_around_append_only",
       "breakpoints": true
     }

--- a/server/tests/migration-journal.test.ts
+++ b/server/tests/migration-journal.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { readdir, readFile } from "node:fs/promises";
+
+/**
+ * The migration journal, which decides what actually runs.
+ *
+ * Drizzle applies a migration when its journal `when` is later than the newest one the database has
+ * recorded, so the ordering that matters is the timestamps, not the file names. A migration stamped
+ * ahead of real time therefore does not merely sort oddly: it silently swallows every migration
+ * authored after it until the clock catches up, and `drizzle-kit migrate` reports success while
+ * doing it.
+ *
+ * That happened here. `0012` was hand-written with `when = previous + 86_400_000`, a day into the
+ * future, and the next migration to arrive carried a real timestamp, so it was older by comparison.
+ * `migrate` said "migrations applied successfully!", the table it should have created did not exist,
+ * and the only symptom was an integration test failing with `relation "skill_tools" does not exist`.
+ *
+ * Nothing else in the build would have caught that, which is why this is a test rather than a note.
+ */
+describe("the migration journal", () => {
+  test("stamps every migration later than the one before it", async () => {
+    const journal = JSON.parse(
+      await readFile(
+        new URL("../drizzle/meta/_journal.json", import.meta.url),
+        "utf8",
+      ),
+    ) as { entries: { idx: number; tag: string; when: number }[] };
+
+    const outOfOrder = journal.entries
+      .map((entry, index) => ({ entry, previous: journal.entries[index - 1] }))
+      .filter(({ entry, previous }) => previous && entry.when <= previous.when)
+      .map(
+        ({ entry, previous }) =>
+          `${entry.tag} (${entry.when}) is not after ${previous?.tag} (${previous?.when})`,
+      );
+
+    expect(outOfOrder).toEqual([]);
+  });
+
+  test("stamps nothing in the future", async () => {
+    /*
+     * The specific mistake, named. A timestamp ahead of now passes the ordering check above on its
+     * own, and then eats the next migration somebody writes. A day of slack absorbs a machine whose
+     * clock is a little fast without absorbing a hand-typed "tomorrow".
+     */
+    const journal = JSON.parse(
+      await readFile(
+        new URL("../drizzle/meta/_journal.json", import.meta.url),
+        "utf8",
+      ),
+    ) as { entries: { tag: string; when: number }[] };
+
+    const limit = Date.now() + 86_400_000;
+    const ahead = journal.entries
+      .filter((entry) => entry.when > limit)
+      .map((entry) => `${entry.tag} is stamped ${entry.when}, in the future`);
+
+    expect(ahead).toEqual([]);
+  });
+
+  test("has an entry for every migration file, and a file for every entry", async () => {
+    // A journal and a directory that disagree is the other way this goes wrong quietly: a file with
+    // no entry never runs, and an entry with no file stops `migrate` dead.
+    const directory = new URL("../drizzle/", import.meta.url);
+    const files = (await readdir(directory))
+      .filter((name) => name.endsWith(".sql"))
+      .map((name) => name.replace(/\.sql$/, ""))
+      .sort();
+
+    const journal = JSON.parse(
+      await readFile(new URL("meta/_journal.json", directory), "utf8"),
+    ) as { entries: { tag: string }[] };
+
+    expect(journal.entries.map((entry) => entry.tag).sort()).toEqual(files);
+  });
+});


### PR DESCRIPTION
Found while testing #157, which appeared to apply cleanly and did not.

## What happens

Drizzle runs a migration only when its journal timestamp is later than the newest one the database has recorded — `pg-core/dialect.js`:

```js
const lastDbMigration = dbMigrations[0];   // order by created_at desc limit 1
for (const migration of migrations) {
  if (!lastDbMigration || Number(lastDbMigration.created_at) < migration.folderMillis) {
```

`lastDbMigration` is the single newest row, read **once** before the loop. So a migration stamped ahead of real time does not merely sort oddly: it **raises the ceiling**, and every migration written after it is skipped until the clock catches up — with `drizzle-kit migrate` printing `migrations applied successfully!` each time.

`0012` was hand-written with `when = previous + 86_400_000`, a day into the future. **I wrote it**, in #148.

| migration | when |
|---|---|
| 0011 | 1787358347113 |
| **0012** (mine) | **1787444747113** ← a day ahead |
| 0013 (#157) | 1787380044372 ← real, and now "older" |

#157's `skill_tools` table was never created. `migrate` said it succeeded. The only symptom anywhere was its integration test failing with `relation "skill_tools" does not exist` — which reads like a broken PR rather than a broken journal.

## What changes

- **0012 is restamped** to a real moment after 0011.
- **0005 is restamped too.** It sat 27 minutes *before* 0004. That was harmless only because both ran in the same pass on a fresh database, where `lastDbMigration` is undefined and ordering cannot bite. On an incremental upgrade — the normal path for anyone already running OpenBot — it would have skipped 0005.
- **A test holds the journal**: every entry later than the one before it, nothing stamped in the future, and an entry for every file and a file for every entry. Nothing else in the build would catch this, which is why it is a test and not a note.

## For a database that already recorded the bad ceiling

Correcting the journal does not correct what a deployment already wrote down. The changelog carries the repair:

```sql
update drizzle.__drizzle_migrations set created_at = 1787359000000 where created_at = 1787444747113;
```

Or start from a fresh database, where every migration runs in one pass.

## Verified

Applied the repair to a real database, then ran #157's migration against it: `skill_tools` created, its 11 integration tests went from 10 failing to passing. `drizzle-kit check` clean. Full suite 1202 passing.

The journal test fails on the unfixed journal, naming the offending pair.