### PR TITLE
docs: fix grammar issue in docs/deployment.md

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -123,7 +123,7 @@ in ECR, and is what AWS points App Runner users at now that App Runner takes no 
 Plain ECS on Fargate behind an ALB is the answer if you want task definitions and fine-grained IAM.
 No shared-memory configuration is needed or possible.
 
-**Azure Container Apps.** Managed ingress with TLS and custom domains. Note the **240 second request
+**Azure Container Apps.** Managed ingress with TLS and custom domains. Note the **240-second request
 timeout**: the live screen holds a long connection, so expect it to reconnect. Concurrent WebSockets
 are capped at 350 per instance on the basic tier.
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `docs/deployment.md` (line 126).

## Problem

Missing hyphen in compound adjective. "240 second" modifies "request timeout" and should be hyphenated as "240-second" per standard style guides.

The problematic text:

```markdown
Note the **240 second request
timeout**
```

## Fix

Replaced with:

```markdown
Note the **240-second request
timeout**
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change
