### PR TITLE
Release v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+## 0.0.2
+
 ### Upgrading
 
 `AGENT_TOOL_TOKEN` is generated for you on a laptop. `scripts/start.sh` mints one and writes it to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbot",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "private": true,
   "packageManager": "bun@1.3.14",


### PR DESCRIPTION
Cuts v0.0.2. Version bumped and the changelog's `Unreleased` section stamped.

Opened by hand: the release workflow built and pushed the branch, then hit `GitHub Actions is not permitted to create or approve pull requests` on this org. Everything else in the workflow ran.

Merging this publishes.