### PR TITLE
Narrow a Bot's tools in the query, not after reading every one

### DIFF
--- a/server/src/plugins/store.ts
+++ b/server/src/plugins/store.ts
@@ -1050,12 +1050,34 @@ export function createPluginStore(options: PluginStoreOptions) {
         .filter((row) => row.kind === "skill")
         .map((row) => row.ref);
 
+      /*
+       * Narrowed in the query to the servers this Bot is actually granted something from, the same way
+       * `knownToolRefs` does it and for the same reason: a deployment aiming at a thousand tools should
+       * not read all of them to offer a handful. This is the run-time path, so it ran on every run of
+       * every Bot, selected every row in `mcp_tools`, and then discarded almost all of them here — and
+       * it sits underneath tool selection, so its cost is paid before the narrowing that was added to
+       * make large catalogues work.
+       *
+       * The exact ref is still matched below rather than in the query. Narrowing by server is a
+       * predicate the composite primary key can use; naming every (server, tool) pair would be exact
+       * and is not worth a clause per grant, because a server's own tool list is the bound on what
+       * comes back.
+       */
+      const grantedServers = [
+        ...new Set(toolRefs.map((ref) => ref.split("/")[0] ?? "")),
+      ];
       const toolRows =
-        toolRefs.length === 0
+        grantedServers.length === 0
           ? []
-          : await database.select().from(mcpTools).orderBy(asc(mcpTools.name));
+          : await database
+              .select()
+              .from(mcpTools)
+              .where(inArray(mcpTools.serverId, grantedServers))
+              .orderBy(asc(mcpTools.name));
+      // A set, so this is a lookup per row rather than a walk of the grants per row.
+      const granted = new Set(toolRefs);
       const grantedTools = toolRows
-        .filter((row) => toolRefs.includes(`${row.serverId}/${row.name}`))
+        .filter((row) => granted.has(`${row.serverId}/${row.name}`))
         .map((row) => {
           const ref = `${row.serverId}/${row.name}`;
           return {

--- a/server/tests/plugin-store.integration.test.ts
+++ b/server/tests/plugin-store.integration.test.ts
@@ -35,6 +35,8 @@ const strangerId = `agent_plugin_stranger_${suite}`;
 const serverId = "google-drive";
 const toolName = "search_files";
 const ref = `${serverId}/${toolName}`;
+/** A tool on the same server that nobody is granted. Suite-scoped, so it is never a real one. */
+const siblingToolName = `not_granted_${suite}`;
 
 let policy: ActionPolicy = { mode: "enforce", deny: [], allow: ["true"] };
 
@@ -136,6 +138,22 @@ beforeAll(async () => {
     .insert(mcpTools)
     .values({ serverId, name: toolName, description: "Search files." })
     .onConflictDoNothing();
+  /*
+   * A second tool on the SAME server, granted to nobody.
+   *
+   * `listForAgent` narrows to the servers a Bot holds something from and then matches the exact ref,
+   * and this is what makes the second half load-bearing: without it, holding one tool from a server
+   * would offer every tool that server has. Suite-scoped, so it is unambiguously a fixture and
+   * cannot collide with a name the vendor really advertises.
+   */
+  await database
+    .insert(mcpTools)
+    .values({
+      serverId,
+      name: siblingToolName,
+      description: "A tool on the same server that nobody was granted.",
+    })
+    .onConflictDoNothing();
 });
 
 afterAll(async () => {
@@ -156,6 +174,12 @@ afterAll(async () => {
         eq(pluginGrants.ref, ref),
         inArray(pluginGrants.agentId, [holderId, strangerId]),
       ),
+    );
+  // Suite-scoped, so it is this suite's whatever else is true of the server.
+  await database
+    .delete(mcpTools)
+    .where(
+      and(eq(mcpTools.serverId, serverId), eq(mcpTools.name, siblingToolName)),
     );
   // A server row is deployment configuration, so it belongs to the deployment rather than here.
   // The fixture tool goes whether or not this suite owns the server, but only if it put it there.
@@ -218,6 +242,22 @@ describe("a grant is the permission", () => {
     const nothing = await store.listForAgent(strangerId);
     expect(nothing.tools).toEqual([]);
     expect(nothing.skills).toEqual([]);
+  });
+
+  test("holding one tool from a server does not offer that server's others", async () => {
+    /*
+     * The property the exact-ref match protects, now that the query narrows by server rather than
+     * reading the whole catalogue. Widening this to "every tool on a server you hold anything from"
+     * would pass every other test in this file: the Bot would still be offered what it holds, and the
+     * stranger would still be offered nothing.
+     */
+    await store.grant("mcp", ref, holderId, "admin@openbot.local");
+    const held = await store.listForAgent(holderId);
+
+    expect(held.tools.map((tool) => tool.ref)).toEqual([ref]);
+    expect(held.tools.map((tool) => tool.ref)).not.toContain(
+      `${serverId}/${siblingToolName}`,
+    );
   });
 });
 


### PR DESCRIPTION
## What this changes

The one I flagged on #119 and said I would send separately.

`listForAgent` selected every row in `mcp_tools` and then dropped the ones the Bot was not granted:

```ts
const toolRows =
  toolRefs.length === 0
    ? []
    : await database.select().from(mcpTools).orderBy(asc(mcpTools.name));
const grantedTools = toolRows
  .filter((row) => toolRefs.includes(`${row.serverId}/${row.name}`))
```

It is the run-time path. It runs on every run of every Bot, and it sits underneath the selection added
in #178 — so its cost is paid before the narrowing that exists to make large catalogues work, on
exactly the deployments that have one. At the thousand tools #119 names as the target that is a
thousand rows across the wire, plus a linear `includes` over the grant list per row, to offer a handful.

The query now names the servers the Bot holds something from, which is a predicate the
`(server_id, name)` primary key can use, and the grant list is a `Set` rather than an array.

`knownToolRefs`, forty lines up in the same file, already did exactly this, with the reasoning already
written above it:

> Narrowed in the query to the servers actually named, rather than reading the whole catalogue and
> filtering here. A deployment aiming at a thousand tools should not scan all of them to check three.

So this is the run-time half catching up with the save-time half, in that half's own idiom rather than
a new one.

**Narrowing by server rather than by exact pair, on purpose.** A clause per grant would be exact, but a
server's own tool list is already the bound on what comes back, so it buys little for a `where` that
grows with the number of grants. The exact ref is still matched after the read — and that match is now
load-bearing in a way it was not before: narrowing by server alone would offer every tool of any server
the Bot holds anything from, which is a grant it never had.

Behaviour is unchanged. Same tools, same order, same refusals.

## Where it runs

- **New state that outlives a request?** None. One query became a narrower query.
- **What happens on the second replica?** Identical, and cheaper on each. Nothing is cached or held.
- **Anything serialised?** No writes.
- **Anything fanned out to a browser?** No.
- **New listener, port, or schedule?** No.

## Boundary and audit

- No boundary moves. The grant rows are still what decides, read exactly as before; this changes which
  rows of the *catalogue* are fetched to describe them.
- **Strictly harder to widen a Bot than it was.** The offered set is still `grants ∩ catalogue`. What
  changed is that the intersection's second half now also decides what is read.
- No new refusal, no new audit event. A ref whose tool row is absent — the window where a refresh has
  deleted and not yet rewritten a server's tools — still yields nothing for that ref, which is the
  behaviour `knownToolRefs` documents as deliberate.

## Changelog

No line. A deployment behaves no differently afterwards: the same Bots are offered the same tools in
the same order. This is the same query answered without reading rows it then threw away.

## Proof

One test added to `server/tests/plugin-store.integration.test.ts`: a second tool on the *same* server,
granted to nobody, and holding one tool from that server must not offer it.

That test is the point of the PR rather than decoration. Widening the narrowing to "every tool on a
server you hold anything from" passes every other test in the file — the Bot is still offered what it
holds, and the stranger is still offered nothing — so nothing there would have caught it.

```
server typecheck   exit 0
biome format + lint   clean on both files, checked against the committed tree
```

**What I have not run.** This is the integration suite and I have no local PostgreSQL — Docker Desktop
is on this machine but its engine will not come up, so I could not stand one up this time either. CI
is where these first execute. The rest of that file's assertions are untouched, and the one I added
uses the fixtures already there plus one row, cleaned up suite-scoped the way that file is careful
about — `google-drive/search_files` is a real ref, so the new fixture is named `not_granted_<suite>`
and deleted by exact name rather than by server.

Say the word if you would rather see it green on a live database before it reaches you and I will get
one up rather than have you find out from CI.

## What is not covered

- **No measurement.** I am claiming a smaller query, not a number: I have no deployment with a thousand
  tools to time, and I would rather say that than quote a microbenchmark of my own fixtures.
- `knownToolRefs` is left alone. It is the save-time path, called once when a skill is written, and its
  looser narrowing is fine there for the reason its own comment gives.
