### PR TITLE
Say which of a connector's granted tools it no longer offers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,23 @@ Refusals are now on the audit trail as `agent.dial_refused`, with the address an
 refused run already told the person what happened; nothing told the deployment, and an agent that
 has quietly started redirecting somewhere it should not is worth being able to count.
 
+### A connector says which of its granted tools it no longer offers
+
+A grant names `serverId/toolName`, and a Bot is told about a tool only when the grant and the vendor's
+current tool list agree — so a grant on a tool the vendor has stopped listing reaches no model. That
+is a property of what the vendor advertises today rather than of the grant, and nothing said it was
+happening: the plugins page built its grant list from the advertised tools, so such a grant appeared
+nowhere at all. The one screen an administrator reads to answer "what may this Bot do" was quietly
+leaving some of the answer out.
+
+A connector's page now has a "Held but not offered" section listing them, with how many Bots hold
+each, and a refresh that leaves any behind writes an audit row naming the refs and the Bots. The
+grants themselves are untouched: a tool the vendor starts listing again is offered again, and revoking
+stays a decision somebody makes rather than a side effect of a vendor's bad afternoon.
+
+Nothing changes for a connector whose grants all match its tool list, which is the normal case — the
+section is not drawn and no row is written.
+
 ## 0.0.4
 
 ### A click citing a ref this deployment cannot resolve is refused
@@ -102,7 +119,6 @@ the decision row is written, so an action somebody tried to take still appears o
 **A deployment may see refusals it did not see before.** That is the point: those are the actions that
 were being carried out without the boundary seeing what they touched. A Bot that meets one takes a
 fresh snapshot and continues.
-
 ### A package ships its skills, so tool selection works on a clone
 
 Tool selection narrows a Bot's tools to the ones its matching skills declare, and a deployment starts

--- a/app/src/lib/plugins/queries.ts
+++ b/app/src/lib/plugins/queries.ts
@@ -14,6 +14,21 @@ export type PluginTool = {
   grantedTo: string[];
 };
 
+/**
+ * A grant on a tool this server does not currently advertise.
+ *
+ * Held and not offered: nothing reaches a model, because a Bot is told about a tool only when the
+ * grant and the tool list agree. That is a fact about what the vendor advertises today, not about the
+ * grant, so it is reported rather than quietly dropped — a connector that starts advertising the name
+ * again offers it again.
+ */
+export type WithdrawnGrant = {
+  /** `<serverId>/<toolName>`. What a grant names, and what an administrator revokes. */
+  ref: string;
+  name: string;
+  grantedTo: string[];
+};
+
 export type PluginServer = {
   id: string;
   title: string;
@@ -28,6 +43,8 @@ export type PluginServer = {
   lastError: string | null;
   addedBy: string | null;
   tools: PluginTool[];
+  /** Empty for a healthy connector. See {@link WithdrawnGrant}. */
+  withdrawn: WithdrawnGrant[];
 };
 
 export type PluginSkill = {

--- a/app/src/routes/_authed/admin/plugins/$key.tsx
+++ b/app/src/routes/_authed/admin/plugins/$key.tsx
@@ -519,6 +519,46 @@ function RouteComponent() {
         </PageSection>
       ) : null}
 
+      {/*
+       * Only when there is something to say. An empty section here would teach a reader to scroll past
+       * a heading that is usually blank, which is the opposite of the point.
+       *
+       * Its own section rather than rows inside Tools, because these are not tools: they are not
+       * listed by the vendor, there is no page to open for one, and putting them in the same list
+       * would make the count above it wrong.
+       */}
+      {server && server.withdrawn.length > 0 ? (
+        <PageSection
+          description="This vendor no longer lists these, so no Bot is told about them and no model can call one. The grant is still recorded, and the tool would be offered again if the vendor started listing it. Revoke from the Bot's own page if that is not what you want."
+          title="Held but not offered"
+        >
+          <PageRows>
+            {server.withdrawn.map((held, index) => (
+              <React.Fragment key={held.ref}>
+                <Item size="sm">
+                  <ItemContent>
+                    <ItemTitle className="font-mono text-xs">
+                      {held.name}
+                    </ItemTitle>
+                    <ItemDescription>
+                      Not listed by {title}
+                      {server.toolsRefreshedAt ? ` as of the last refresh` : ""}
+                      .
+                    </ItemDescription>
+                  </ItemContent>
+                  <ItemActions>
+                    <span className="text-muted-foreground text-xs">
+                      {grantSummary(held.grantedTo.length, bots.length)}
+                    </span>
+                  </ItemActions>
+                </Item>
+                {index !== server.withdrawn.length - 1 && <Separator />}
+              </React.Fragment>
+            ))}
+          </PageRows>
+        </PageSection>
+      ) : null}
+
       <Dialog
         onOpenChange={(open) => setDialog(open ? dialog : null)}
         open={dialog !== null}

--- a/server/src/plugins/store.ts
+++ b/server/src/plugins/store.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, isNull, or } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import { type AuditStore, recordAuditEvent } from "../audit";
 import {
   type ActionPolicy,
@@ -57,6 +57,28 @@ export type ToolRecord = {
   grantedTo: string[];
 };
 
+/**
+ * A grant naming a tool this server does not currently advertise.
+ *
+ * Held and not offered. `listForAgent` reads the grant against the tool list, so nothing reaches a
+ * model — but that is a property of what the vendor is advertising today rather than of the grant, and
+ * it changes the moment the vendor advertises the name again. Google's Drive entry says so in its own
+ * comment: the REST transport is one line from being swapped back to MCP, and "tool names match
+ * Google's MCP server exactly, so grants survive the swap in either direction".
+ *
+ * So it is reported rather than pruned. A grant is the record of a decision somebody made, and the
+ * refresh that would have deleted it is not a safe place to decide from: the tool list is replaced by
+ * a `delete` and then an `insert`, and a vendor answering with an empty list is a success, so one bad
+ * answer would revoke every grant on that server and stamp the refresh as healthy.
+ */
+export type WithdrawnGrant = {
+  /** `<serverId>/<toolName>`, exactly as the grant is stored. */
+  ref: string;
+  /** The tool half, for a screen that already has the server. */
+  name: string;
+  grantedTo: string[];
+};
+
 export type ServerRecord = {
   id: string;
   title: string;
@@ -71,6 +93,13 @@ export type ServerRecord = {
   lastError: string | null;
   addedBy: string | null;
   tools: ToolRecord[];
+  /**
+   * Grants on tools this server no longer advertises.
+   *
+   * Empty for a healthy connector. Non-empty is the discrepancy an administrator should be reading
+   * about, which is why it is here rather than inferred by a screen comparing two lists.
+   */
+  withdrawn: WithdrawnGrant[];
 };
 
 export type SkillRecord = {
@@ -327,6 +356,35 @@ export function createPluginStore(options: PluginStoreOptions) {
       .select()
       .from(pluginGrants)
       .where(and(eq(pluginGrants.kind, kind), inArray(pluginGrants.ref, refs)));
+    const byRef = new Map<string, string[]>();
+    for (const row of rows) {
+      byRef.set(row.ref, [...(byRef.get(row.ref) ?? []), row.agentId]);
+    }
+    return byRef;
+  }
+
+  /**
+   * Every MCP grant belonging to these servers, whether or not the tool is still advertised.
+   *
+   * {@link grantsFor} asks about refs somebody already has, which is the wrong question when the
+   * point is to find the ones nothing else knows about: called with the advertised refs it can only
+   * ever return a subset of them, so a grant on a withdrawn tool is invisible by construction.
+   *
+   * Matched on the server half in the query rather than by reading every grant and splitting here.
+   * `split_part` rather than a `LIKE` prefix, because a server id is text a person can choose for a
+   * custom server and `%` in one would silently widen the match.
+   */
+  async function mcpGrantsForServers(serverIds: string[]) {
+    if (serverIds.length === 0) return new Map<string, string[]>();
+    const rows = await database
+      .select({ ref: pluginGrants.ref, agentId: pluginGrants.agentId })
+      .from(pluginGrants)
+      .where(
+        and(
+          eq(pluginGrants.kind, "mcp"),
+          inArray(sql`split_part(${pluginGrants.ref}, '/', 1)`, serverIds),
+        ),
+      );
     const byRef = new Map<string, string[]>();
     for (const row of rows) {
       byRef.set(row.ref, [...(byRef.get(row.ref) ?? []), row.agentId]);
@@ -739,6 +797,41 @@ export function createPluginStore(options: PluginStoreOptions) {
           })
           .where(eq(mcpServers.id, serverId));
 
+        /*
+         * A grant left pointing at nothing goes in the trail, at the moment it starts pointing at
+         * nothing.
+         *
+         * Reporting it on a screen answers "what is true now", which somebody has to go and look at.
+         * This answers "when did it stop being offered, and what was holding it" — the question asked
+         * after a transport is swapped back and a name starts resolving again. Without the row, the
+         * only record of the gap is its absence.
+         *
+         * Not a refusal and not an error, so `configuration.changed` rather than a new event type:
+         * nothing was denied and the refresh succeeded. Written after the tool list is replaced, so
+         * what it names is what is actually left over.
+         */
+        const advertised = new Set(tools.map((tool) => tool.name));
+        const stranded = [...(await mcpGrantsForServers([serverId])).entries()]
+          .filter(([ref]) => !advertised.has(ref.slice(serverId.length + 1)))
+          .sort(([left], [right]) => left.localeCompare(right));
+
+        if (stranded.length > 0) {
+          await recordAuditEvent(auditStore, {
+            eventType: "configuration.changed",
+            targetType: "mcp_server",
+            targetId: serverId,
+            payload: {
+              actor: actorId,
+              change: "grants_not_advertised",
+              server: serverId,
+              // The refs, because that is what a grant is keyed on and what an administrator revokes.
+              refs: stranded.map(([ref]) => ref),
+              bots: [...new Set(stranded.flatMap(([, agents]) => agents))],
+              note: "Held by a Bot and not offered to any model, because this server no longer advertises the tool. Offered again if it starts.",
+            },
+          });
+        }
+
         return { tools: tools.length };
       } catch (error) {
         const message =
@@ -775,8 +868,13 @@ export function createPluginStore(options: PluginStoreOptions) {
         )
         .orderBy(asc(mcpTools.name));
 
-      const grants = await grantsFor(
-        "mcp",
+      /*
+       * Every grant on these servers, not only the ones matching a tool that is still advertised.
+       * Asking about the advertised refs answers "who holds what is offered", which cannot report the
+       * grants that are the point here — see `mcpGrantsForServers`.
+       */
+      const grants = await mcpGrantsForServers(rows.map((row) => row.id));
+      const advertised = new Set(
         tools.map((tool) => `${tool.serverId}/${tool.name}`),
       );
 
@@ -808,6 +906,21 @@ export function createPluginStore(options: PluginStoreOptions) {
                 grantedTo: grants.get(ref) ?? [],
               };
             }),
+          /*
+           * Sorted by ref so the list is stable between reads, which matters because this is the one
+           * place a discrepancy is reported and a reader comparing two visits should see the same
+           * order.
+           */
+          withdrawn: [...grants.entries()]
+            .filter(
+              ([ref]) => ref.startsWith(`${row.id}/`) && !advertised.has(ref),
+            )
+            .sort(([left], [right]) => left.localeCompare(right))
+            .map(([ref, grantedTo]) => ({
+              ref,
+              name: ref.slice(row.id.length + 1),
+              grantedTo,
+            })),
         };
       });
     },

--- a/server/tests/plugin-store.integration.test.ts
+++ b/server/tests/plugin-store.integration.test.ts
@@ -443,3 +443,79 @@ describe("the trail can be read by a second reader", () => {
     expect(row?.bot).toBeTruthy();
   });
 });
+
+/**
+ * A grant outliving the tool it names.
+ *
+ * The runtime already handles it: `listForAgent` reads the grant against the tool list, so a tool the
+ * vendor has stopped advertising reaches no model. What was missing is that nothing said so — the
+ * plugins page derives its grant list from the advertised refs, so a grant on a withdrawn tool was
+ * invisible on the one screen an administrator reads to answer "what may this Bot do".
+ */
+describe("a grant on a tool the vendor no longer lists", () => {
+  const withdrawnName = `withdrawn_${suite}`;
+  const withdrawnRef = `${serverId}/${withdrawnName}`;
+
+  afterAll(async () => {
+    await database
+      .delete(pluginGrants)
+      .where(
+        and(
+          eq(pluginGrants.ref, withdrawnRef),
+          eq(pluginGrants.agentId, holderId),
+        ),
+      );
+    await database
+      .delete(mcpTools)
+      .where(
+        and(eq(mcpTools.serverId, serverId), eq(mcpTools.name, withdrawnName)),
+      );
+  });
+
+  test("is reported as held and not offered, and still reaches no model", async () => {
+    // Advertised once, which is how a grant comes to exist against it.
+    await database
+      .insert(mcpTools)
+      .values({
+        serverId,
+        name: withdrawnName,
+        description: "Listed by the vendor when the grant was made.",
+      })
+      .onConflictDoNothing();
+    await store.grant("mcp", withdrawnRef, holderId, "admin@openbot.local");
+
+    // Then withdrawn. A refresh replaces the tool list wholesale, so this is what one does to a name
+    // the vendor has stopped offering.
+    await database
+      .delete(mcpTools)
+      .where(
+        and(eq(mcpTools.serverId, serverId), eq(mcpTools.name, withdrawnName)),
+      );
+
+    const drive = (await store.listServers()).find(
+      (server) => server.id === serverId,
+    );
+
+    // Not a tool: it is not in the list the vendor gave, so it must not be counted as one.
+    expect(drive?.tools.map((tool) => tool.ref)).not.toContain(withdrawnRef);
+    // But it is reported, with who holds it, which is the whole point.
+    expect(drive?.withdrawn.map((held) => held.ref)).toContain(withdrawnRef);
+    const held = drive?.withdrawn.find((row) => row.ref === withdrawnRef);
+    expect(held?.name).toBe(withdrawnName);
+    expect(held?.grantedTo).toContain(holderId);
+
+    // And the property that made it inert in the first place is unchanged. This is the assertion that
+    // would fail if reporting a grant had turned into honouring one.
+    const offered = await store.listForAgent(holderId);
+    expect(offered.tools.map((tool) => tool.ref)).not.toContain(withdrawnRef);
+  });
+
+  test("a healthy connector reports nothing withdrawn", async () => {
+    // The empty case, because a field that is only ever exercised non-empty is a field whose empty
+    // shape nobody has checked — and this one is read by a screen that hides itself when it is empty.
+    const drive = (await store.listServers()).find(
+      (server) => server.id === serverId,
+    );
+    expect(drive?.withdrawn.map((row) => row.ref)).not.toContain(ref);
+  });
+});


### PR DESCRIPTION
## What this changes

Closes #106.

A grant names `serverId/toolName`, and `listForAgent` reads it against the tool list, so a grant on a
tool the vendor has stopped advertising reaches no model. As #106 says, that is a property of the
transport rather than of the grant — and `google-drive` is one line from proving it. The entry's own
comment:

> This host has been generally available since 2015. The MCP entry is one line away: set `transport`
> back to `mcp` and restore the host and path above. Tool names match Google's MCP server exactly, so
> grants survive the swap in either direction.

Nothing said it was happening. `listServers` asked `grantsFor` about the refs of the tools it had just
listed, which can only ever return a subset of those — so a grant on a withdrawn tool appeared
nowhere at all, on the one screen an administrator reads to answer what a Bot may do.

### Reported, not pruned

You asked for this to be decided deliberately. Pruning is the wrong answer, and the reason is stronger
than "don't delete somebody's decision": `refreshTools` is the only place the prune could go, and it is
not a safe place to decide from.

The tool list is replaced by a bare `delete` and then an `insert`, so a failure between them already
leaves a server with no tools. Worse, the bad case is not a failure at all — a vendor answering
successfully with an empty list deletes every tool row, sets `lastError` to `null`, and stamps
`toolsRefreshedAt`. So with pruning, one empty answer from Google silently revokes every Drive grant in
the deployment and the trail records a healthy refresh. That converts a visible, inert discrepancy into
an invisible, destructive one.

So, three parts:

1. **`listServers` reports them.** A new `mcpGrantsForServers` asks for every MCP grant belonging to
   these servers, matched on the server half in the query (`split_part`, not a `LIKE` prefix — a custom
   server's id is text a person chooses, and a `%` in one would widen the match). Advertised refs stay
   `grantedTo` on the tool; the rest become `withdrawn`.
2. **The connector's page draws them**, under "Held but not offered", with how many Bots hold each. Its
   own section rather than rows in Tools, because these are not tools the vendor listed and folding
   them in would make the count above wrong. Not drawn at all when empty, which is the normal case.
3. **A refresh that leaves any behind writes a row.** This is the part that answers the transport-swap
   worry rather than only displaying it: the discrepancy enters the trail when it arises, so flipping
   `transport` back to `mcp` is preceded by a record that those grants were sitting there, instead of
   the only record of the gap being its absence. `configuration.changed` against the server, naming the
   refs and the Bots — nothing was denied and the refresh succeeded, so it did not seem worth minting an
   event type. Say the word if you would rather it were its own so it is filterable.

An explicit "drop these" action for an administrator is now cheap, and deliberately left undone:
revoking should stay something somebody decided.

## Where it runs

- **New state that outlives a request?** None. No schema change, no migration.
- **What happens on the second replica?** Identical. Two reads and, on a refresh that finds strays, one
  audit insert. Nothing held.
- **Anything serialised?** No. The audit row is a plain insert and duplicates are harmless — two
  administrators refreshing at once leave two rows saying the same true thing, which is what the trail
  is for.
- **Anything fanned out to a browser?** No. The page reads it on load like the rest of the payload.
- **New listener, port, or schedule?** No.

## Boundary and audit

- **No boundary moves, and no grant is honoured that was not before.** The offered set is still
  `grants ∩ advertised tools`; this reports the difference rather than changing it. There is a test
  asserting exactly that, because "reporting a grant" turning into "honouring one" is the way this
  change could go wrong.
- **New row, new type of fact:** `configuration.changed` with `change: "grants_not_advertised"`. It is
  not a refusal — nothing was denied — which is why it is not one.
- Nothing new is trusted from the client. This is all server-derived; the page renders what it is told.

## Changelog

Added under `Unreleased`: a connector says which of its granted tools it no longer offers, the grants
are untouched, and nothing changes for a connector whose grants all match its tool list.

## Proof

Two tests in `server/tests/plugin-store.integration.test.ts`. A tool is advertised, granted, then
withdrawn the way a refresh withdraws one, and then:

- it is absent from `tools` and present in `withdrawn`, with the holding Bot named;
- **`listForAgent` still does not offer it** — the assertion that fails if this had quietly become a
  grant;
- a connector whose grants all match reports `withdrawn` empty, because a field only ever exercised
  non-empty is one whose empty shape nobody has checked, and a screen keys off it being empty.

```
server typecheck    exit 0
app typecheck       exit 0
biome format + lint clean, checked against the committed tree
```

**What I have not run.** These are integration tests and I still have no local PostgreSQL — Docker
Desktop is installed on this machine but its engine will not start and WSL2 integration is off, so CI
is where they first execute. I also have not driven the new section in a browser; it is an `Item` list
in the same shape as the Tools section directly above it, but I have not seen it draw. Say so if you
want either before it lands and I will get a stack up rather than have you find out from the screen.

## What is not covered

- **The count in #106 is yours, not mine.** I can confirm the mechanism end to end — the REST adapter
  advertises exactly four names, `create_file` and `copy_file` are in `writeTools`, the swap is one
  field — but I have no deployment holding those four grant rows, so I have not seen them.
- **`refreshTools` is still not one transaction.** I found that while arguing against pruning and have
  left it alone: it is a real gap, it is not this issue, and folding it in would bury the decision you
  asked for under a rewrite of that function. Worth its own issue if you want one.
- **Nothing is reported for a server that was removed entirely.** Removing a connector already deletes
  its grants (the switch on this page says so), so there is no stray to report.
- The section is per-connector. A deployment-wide "everything held but not offered" view would be a
  different screen, and I did not invent one.
