### PR TITLE
Read a thread nobody has run yet as empty, not as broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,19 @@ stays a decision somebody makes rather than a side effect of a vendor's bad afte
 Nothing changes for a connector whose grants all match its tool list, which is the normal case — the
 section is not drawn and no row is written.
 
+### Opening a new chat no longer logs a server error
+
+A thread id is minted before the thread exists — the platform creates it on the first run — so reading
+history on a brand-new conversation asks about a thread nothing has heard of yet. The platform answered
+404, the runtime reported that as `500 Failed to fetch thread messages`, and every new chat left one in
+the log with a stack trace behind it. Nothing was visibly broken, because the browser only reads a
+history it got a 200 for; what was missing was any way to tell a thread that does not exist yet from a
+history store that is down.
+
+A thread the platform does not have now reads as having no messages. A 404 and only a 404: a 500 stays
+a 500, because an outage answered with an empty history would tell the browser the conversation is gone
+and invite somebody to start it over.
+
 ## 0.0.4
 
 ### A click citing a ref this deployment cannot resolve is refused

--- a/server/src/copilot.ts
+++ b/server/src/copilot.ts
@@ -839,6 +839,75 @@ export function createRequestAgents(
  * reachable on the next request. Resolving once at boot would mean every new Bot needed a restart,
  * which is not a property you can explain to somebody who just created one.
  */
+/**
+ * Whether this failure means "the platform has never heard of that thread".
+ *
+ * A thread id is minted before the thread exists — the platform creates it on the first run — so
+ * reading history on a brand-new conversation is the normal opening move, and the platform answers
+ * `THREAD_NOT_FOUND` with a 404. The runtime's own handler catches everything and returns a bare 500,
+ * so every new chat produced one, with a stack trace behind it.
+ *
+ * Matched on the shape rather than with `instanceof`. The class is `PlatformRequestError` and it
+ * carries `.status` for exactly this — its own documentation gives `error.status === 404` as the
+ * example — but it is not re-exported from `@copilotkit/runtime/v2`, and the package's `exports` map
+ * offers no subpath that reaches it, so there is no type to test against. The name is set by the
+ * constructor and the status is a number on the instance; both are checked, so an unrelated error
+ * carrying a `status` of 404 does not qualify.
+ *
+ * 404 ONLY, and nothing wider. A 500 from the platform means an outage or a bad key, and answering
+ * that with an empty history would tell the browser the conversation is gone and invite somebody to
+ * start it over. That is the failure this must not introduce while removing the noisy one.
+ */
+export function isMissingThread(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.name === "PlatformRequestError" &&
+    (error as { status?: unknown }).status === 404
+  );
+}
+
+/**
+ * Read a thread's history, treating a thread the platform does not know about as having none.
+ *
+ * Takes the read as a function rather than being folded into the class below, so the decision can be
+ * exercised against a function that really throws. The previous attempt at this fix
+ * (#71) was tested by re-implementing its middleware inside the test file, which passes with the real
+ * code deleted; this is the actual code path in both places.
+ */
+export async function historyOrEmpty<T>(
+  read: () => Promise<T>,
+  whenMissing: T,
+): Promise<T> {
+  try {
+    return await read();
+  } catch (error) {
+    if (isMissingThread(error)) return whenMissing;
+    throw error;
+  }
+}
+
+/**
+ * The platform client, with one answer corrected.
+ *
+ * A subclass rather than a wrapper. The runtime is handed this object and calls many methods on it,
+ * and the base class keeps its state in `#private` fields — which a `Proxy` cannot forward, because a
+ * method invoked with the proxy as `this` cannot reach them. Extending keeps every other method
+ * exactly as it was, on the instance that owns those fields.
+ *
+ * `getThreadMessages` is the only override. `handleGetThreadMessages` in the runtime calls it and
+ * returns `Response.json` of whatever comes back, so an empty history here is the `{ messages: [] }`
+ * the browser expects and a 200 instead of a 500.
+ */
+class IntelligenceKnowingANewThread extends CopilotKitIntelligence {
+  override getThreadMessages(
+    params: Parameters<CopilotKitIntelligence["getThreadMessages"]>[0],
+  ) {
+    return historyOrEmpty(() => super.getThreadMessages(params), {
+      messages: [],
+    });
+  }
+}
+
 export function mountCopilotRuntime(
   config: DeploymentConfig,
   model: RuntimeModel,
@@ -869,7 +938,9 @@ export function mountCopilotRuntime(
     // returns, so omitting it puts every person in the deployment in the same thread space and one
     // person's conversations become another's.
     identifyUser,
-    intelligence: new CopilotKitIntelligence({
+    // The subclass, not the base: a thread nobody has run yet reads as empty rather than as a 500.
+    // See IntelligenceKnowingANewThread.
+    intelligence: new IntelligenceKnowingANewThread({
       apiUrl: intelligence.apiUrl,
       wsUrl: intelligence.gatewayWsUrl,
       apiKey: intelligence.apiKey,

--- a/server/tests/thread-history.test.ts
+++ b/server/tests/thread-history.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { historyOrEmpty, isMissingThread } from "../src/copilot";
+
+/**
+ * Reading history on a thread the platform has never seen.
+ *
+ * A thread id is minted before the thread exists, so this is the opening move of every new
+ * conversation and it was answering 500. The decision is the whole of the change, and it is tested
+ * here against the real functions rather than a copy of them: the previous attempt (#71) tested a
+ * re-implementation of its own middleware, which passes with the shipped code deleted.
+ */
+
+/**
+ * A `PlatformRequestError` as the platform client constructs one.
+ *
+ * Built by hand because the class is not re-exported from `@copilotkit/runtime/v2` and the package's
+ * `exports` map reaches nothing that holds it — which is also why the code under test matches on the
+ * shape. The constructor sets the message, then `status`, then `name`, so this is the same object.
+ */
+function platformError(status: number): Error {
+  const error = new Error(`Intelligence platform error ${status}`);
+  error.name = "PlatformRequestError";
+  (error as Error & { status: number }).status = status;
+  return error;
+}
+
+describe("recognising a thread the platform does not have", () => {
+  test("a 404 from the platform is a missing thread", () => {
+    expect(isMissingThread(platformError(404))).toBe(true);
+  });
+
+  test("a 500 from the platform is not", () => {
+    // The one that matters. An outage answered with an empty history tells the browser the
+    // conversation is gone and invites somebody to start it over.
+    expect(isMissingThread(platformError(500))).toBe(false);
+  });
+
+  test("a 403 from the platform is not", () => {
+    // A bad key is not an absent thread, and reading it as one would hide a misconfiguration behind
+    // a conversation that looks new.
+    expect(isMissingThread(platformError(403))).toBe(false);
+  });
+
+  test("an unrelated error carrying a 404 is not", () => {
+    /*
+     * Both halves are checked, so something else with a `status` of 404 on it — a fetch wrapper, a
+     * vendor SDK — does not get a thread's history replaced with nothing.
+     */
+    const other = new Error("some other failure");
+    (other as Error & { status: number }).status = 404;
+    expect(isMissingThread(other)).toBe(false);
+  });
+
+  test("a plain object shaped like one is not", () => {
+    expect(isMissingThread({ name: "PlatformRequestError", status: 404 })).toBe(
+      false,
+    );
+  });
+
+  test("nothing thrown at all is not", () => {
+    expect(isMissingThread(undefined)).toBe(false);
+    expect(isMissingThread(null)).toBe(false);
+  });
+});
+
+describe("reading a history that may not exist yet", () => {
+  const empty = { messages: [] as string[] };
+
+  test("a thread with history returns it", async () => {
+    const history = { messages: ["hello"] };
+    expect(await historyOrEmpty(async () => history, empty)).toBe(history);
+  });
+
+  test("a thread the platform does not have reads as empty", async () => {
+    expect(
+      await historyOrEmpty(async () => {
+        throw platformError(404);
+      }, empty),
+    ).toEqual({ messages: [] });
+  });
+
+  test("a platform outage still throws", async () => {
+    // Not swallowed, not turned into an empty conversation. This is the assertion that would fail if
+    // the branch were widened to any failure.
+    await expect(
+      historyOrEmpty(async () => {
+        throw platformError(500);
+      }, empty),
+    ).rejects.toThrow("Intelligence platform error 500");
+  });
+
+  test("an error that is not the platform's still throws", async () => {
+    await expect(
+      historyOrEmpty(async () => {
+        throw new Error("the network went away");
+      }, empty),
+    ).rejects.toThrow("the network went away");
+  });
+});


### PR DESCRIPTION
## What this changes

Closes #72. This is the fix you described when closing #71:

> The correct fix is small and sitting unused: `PlatformRequestError` carries `.status`, so branch on
> `error.status === 404` for an exact answer in one call.

`handleGetThreadMessages` calls `runtime.intelligence.getThreadMessages` and returns `Response.json`
of whatever comes back. That object is the one `mountCopilotRuntime` constructs — so the answer is
corrected where it is produced rather than guessed at afterwards, and there is no second call and no
listing to be paginated past.

Four things about it, each of which is a way it could have been wrong:

**404 only.** A 500 stays a 500. An outage answered with an empty history tells the browser the
conversation is gone and invites somebody to start it over, which is the failure worth avoiding while
removing the noisy one. 403 is not a missing thread either — a bad key read as an absent thread hides a
misconfiguration behind a conversation that looks new.

**Matched on the shape, not with `instanceof`.** The class is not re-exported from
`@copilotkit/runtime/v2`, and the package's `exports` map lists only `.`, `./langgraph`, `./v2`,
`./v2/express`, `./v2/hono` and `./v2/node` — none of which reaches
`runtime/intelligence-platform/client`. So there is no type to test against. The constructor sets
`name` and `status`, and both are checked, so an unrelated error carrying a `status` of 404 does not
qualify. If you would rather this waited for the class to be exported, say so — the alternative is a
deep import through a path the package does not offer.

**A subclass, not a wrapper.** The base class keeps its state in `#private` fields, and a `Proxy`
cannot forward those: a method invoked with the proxy as `this` cannot reach them at all. Extending
leaves every other method on the instance that owns those fields. `getThreadMessages` is the only
override.

**The decision is exported so the tests exercise it.** You noted that #71's tests re-implemented its
middleware inline and so would pass with the real code deleted. `isMissingThread` and `historyOrEmpty`
are the shipped code path, called by the subclass and called directly by the tests. Deleting either
one fails the suite.

I also kept the `telemetryProperties: { accessibility_title }` block, which you flagged #71 as silently
reverting — verified it is still there after the change.

## Where it runs

- **New state that outlives a request?** None. One `try`/`catch` around one call.
- **What happens on the second replica?** Identical. Every replica constructs its own client and
  answers the same way; nothing is held or shared.
- **Anything serialised?** No writes.
- **Anything fanned out to a browser?** No. The same endpoint answers the same request, with 200 and
  `{ messages: [] }` where it used to answer 500.
- **New listener, port, or schedule?** No.

## Boundary and audit

- No boundary moves. This is a read of a thread's own history, already scoped to the person by
  `identifyUser` — unchanged, and the 404 is the platform's answer to that scoped question.
- **No refusal is turned into a success.** A 403 stays a 403 and a 500 stays a 500; only "there is no
  such thread" becomes "there is no history". There is a test for each.
- No new audit event. Nothing was decided and nothing acted: a thread that does not exist yet has no
  history, and the trail already records the run that creates it.
- Nothing new is trusted from the client. The thread id was already the caller's; what changed is how
  the platform's own answer is read.

## Changelog

Added under `Unreleased`: opening a new chat no longer logs a server error, a 404 reads as no messages,
and a 500 stays a 500.

## Proof

Ten tests in `server/tests/thread-history.test.ts`, against the exported functions the subclass uses:

```
bun test server/tests/thread-history.test.ts    10 pass, 0 fail, 11 expect() calls
server typecheck                                exit 0
biome format + lint                             clean, checked against the committed tree
```

Recognising the error: a 404 qualifies; a 500, a 403, an unrelated `Error` carrying `status: 404`, a
plain object with the right fields, `undefined` and `null` all do not.

Reading: history comes back unchanged; a 404 reads as `{ messages: [] }`; a 500 rethrows; a transport
failure rethrows.

**What I have not run.** I have not reproduced this against a live Intelligence deployment — I have no
Intelligence key or platform access here, so I could not repeat the two-thread comparison in the issue.
The 404 path is asserted against an error built exactly as the client's constructor builds one
(`message`, then `status`, then `name`), which is the shape the code branches on, but the end-to-end
"open a new chat and watch the log stay quiet" is yours to see. Worth knowing before merge rather than
after.

## What is not covered

- **The subclass's delegation to `super` is not unit-tested**, only the decision it delegates with.
  Constructing the base class needs an Intelligence key and a reachable platform, so a test around it
  would be an integration test against a live service. The override is a single expression and the
  branch inside it is covered; I would rather say that than add a test that mocks the base class into
  something that is not it.
- **Nothing else that swallows a status is touched.** `handleGetThread`, `handleDeleteThread` and the
  rest of `threads.mjs` have the same catch-all shape, and a 404 there is likely just as
  distinguishable. That is the library's code rather than ours, and a fix for it belongs upstream or
  in a change that says it is doing more than one thing.
