### PR TITLE
Stop the live screen only for the socket that is showing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,19 @@ A thread the platform does not have now reads as having no messages. A 404 and o
 a 500, because an outage answered with an empty history would tell the browser the conversation is gone
 and invite somebody to start it over.
 
+### Reconnecting a live screen no longer stops the screen you just reconnected
+
+A Bot's screen allows one viewer, and opening a second `/stream` replaces the first. The replaced
+socket is left open, because it belongs to a client that may still be using it, so on an ordinary
+reconnect, where the browser opens the new connection before dropping the old one, the old socket
+closed after the new one was already casting. Closing it stopped the session's viewer without asking
+whether the closing socket was the one casting, so it stopped the replacement.
+
+Both halves were silent. The screen stopped updating, and anything typed afterwards was dropped
+without a word, because the input path looks for a viewer before it looks for anything it can report.
+
+A close now stops casting only when the socket closing is the one that was casting.
+
 ## 0.0.4
 
 ### A click citing a ref this deployment cannot resolve is refused

--- a/agent-computer/src/index.ts
+++ b/agent-computer/src/index.ts
@@ -19,6 +19,7 @@ import {
   startScreencast,
 } from "./screencast";
 import { createShell } from "./shell";
+import { isCurrentViewer } from "./viewer";
 import {
   createWorkspace,
   WorkspaceFileError,
@@ -441,7 +442,11 @@ serve<StreamData>({
     },
 
     async close(ws) {
-      await stopViewer(sessionFor(ws.data.botId));
+      const session = sessionFor(ws.data.botId);
+      // Only the socket that is casting. A superseded one closing after its replacement has started
+      // would otherwise stop the new viewer; see viewer.ts.
+      if (!isCurrentViewer(session.viewer, ws)) return;
+      await stopViewer(session);
     },
   },
   async fetch(request, server) {

--- a/agent-computer/src/viewer.ts
+++ b/agent-computer/src/viewer.ts
@@ -1,0 +1,33 @@
+/**
+ * Which socket is allowed to stop the live screen.
+ *
+ * A Bot's screen has one viewer, and a second `/stream` replaces the first rather than being
+ * refused: `open` stops whatever was casting and puts the new socket in the session. What it does
+ * not do is close the socket it replaced, because that socket belongs to a client that may still be
+ * using it. So the superseded socket closes on its own schedule, and on an ordinary reconnect, where
+ * a client opens the new connection before dropping the old one, that is after the replacement is
+ * already casting.
+ *
+ * A `close` handler that stops the session's viewer without asking whether the closing socket is the
+ * one casting therefore stops the wrong viewer. The screen the person just reconnected to goes quiet,
+ * and their input is dropped without a word, because the input path checks for a viewer before it
+ * checks anything it could report. Both failures are silent; the browser is fine, the Bot is fine,
+ * and the person is looking at a still image.
+ *
+ * It lives in its own file for the reason `bot-id.ts` and `authorisation.ts` do: `index.ts` imports
+ * Playwright at module scope, so anything left in it needs Chrome merely to be imported by a test.
+ * The decision is here and the stopping stays there, the same split `browser-eviction.ts` makes.
+ */
+
+/**
+ * Is this socket the one currently casting?
+ *
+ * By identity, never by value. Two sockets are distinct objects however alike they look, and an
+ * equality that compared their contents would put the bug back for any pair that happened to match.
+ */
+export function isCurrentViewer(
+  current: { socket: unknown } | undefined,
+  socket: unknown,
+): boolean {
+  return current?.socket === socket;
+}

--- a/agent-computer/tests/viewer.test.ts
+++ b/agent-computer/tests/viewer.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { isCurrentViewer } from "../src/viewer";
+
+/**
+ * Which socket is allowed to stop the live screen.
+ *
+ * One viewer per Bot, and a second `/stream` replaces the first: `open` stops whatever was casting
+ * and puts the new socket in the session. The old socket is not closed by that, so its `close`
+ * arrives whenever the client gets round to it, which on an ordinary make-before-break reconnect is
+ * after the replacement is already running. A close that stops the current viewer without asking
+ * whether it owns it stops the wrong one, and the person who just reconnected gets a screen that
+ * never updates and input that goes nowhere.
+ *
+ * The decision rather than the stopping. Stopping a cast is Playwright's job and is not where the
+ * wrong answer was; `browser-eviction.ts` splits the same way and for the same reason.
+ */
+describe("deciding whether a closing socket stops the live screen", () => {
+  const socket = { id: "a" };
+  const other = { id: "b" };
+
+  test("the socket that is casting stops it", () => {
+    expect(isCurrentViewer({ socket }, socket)).toBe(true);
+  });
+
+  test("a socket that was replaced stops nothing", () => {
+    // The bug this exists for. The old socket closes after the new one has taken over, and without
+    // this the new viewer is the one that gets stopped.
+    expect(isCurrentViewer({ socket: other }, socket)).toBe(false);
+  });
+
+  test("a close with no viewer at all stops nothing", () => {
+    // Both sockets gone, or the cast never started. There is nothing to stop and nothing to get wrong.
+    expect(isCurrentViewer(undefined, socket)).toBe(false);
+  });
+
+  test("identity, not shape", () => {
+    // Two sockets are never equal by value, and comparing them that way would put the bug back for
+    // any pair that happened to look alike.
+    expect(isCurrentViewer({ socket: { id: "a" } }, { id: "a" })).toBe(false);
+  });
+});


### PR DESCRIPTION
## What this changes

A Bot's screen allows one viewer, and a second `/stream` replaces the first: `open` stops whatever was casting and puts the new socket in the session. It does not close the socket it replaced, because that socket belongs to a client that may still be using it. So the superseded socket closes on its own schedule, and on an ordinary reconnect, where a client opens the new connection before dropping the old one, that is after the replacement is already casting.

`close` then stopped the session's viewer without asking whether the closing socket was the one casting, so it stopped the replacement. Both halves of the failure are silent. The screen stops updating, and the person's input is dropped without a word, because the input path checks for a viewer before it checks anything it can report.

The decision goes in its own file for the reason `bot-id.ts` and `authorisation.ts` are separate, which the repo states outright: `index.ts` imports Playwright at module scope, so anything left in it needs Chrome merely to be imported by a test. `browser-eviction.ts` makes the same split with the same reasoning. The tests cover the socket that is casting, the socket that was replaced, no viewer at all, and identity rather than value equality, that last one because two sockets are never equal by value and comparing them that way would put the bug back for any pair that happened to look alike.

## Where it runs

- [x] **New state that outlives a request?** None added. The viewer a session is casting to is already held in `agent-computer`, in the process that owns the browser, and this change reads it rather than adding to it. It is in-process by necessity: it holds an open WebSocket and a Chromium page, neither of which is shareable through Postgres. Which socket that should be is what #190 is about.
- [x] **What happens on the second replica?** Nothing differs, because the state is not the API server's. A Bot's browser lives in one `agent-computer` process, and every API replica proxies to that same one, so two replicas do not hold two views of who is watching. With the supervisor there is one computer per Bot, so a Bot's viewer is decided in exactly one place either way.
- [x] **Anything serialised?** None. The two sockets involved are compared by identity inside the process that holds both of them, so there is nothing for a second process to race on.
- [x] **Anything fanned out to a browser?** Yes, and it reaches the socket the same way it did before this change. The live screen is proxied rather than fanned out: the browser upgrades against the API server, whichever replica answers dials the Bot's computer and relays that one stream, so frames travel along the connection that asked for them and never have to find a socket held elsewhere. This change narrows which socket a close stops; it moves nothing between processes.
- [x] **New listener, port, or schedule?** None. No new route, no new port, nothing on a timer.

## Boundary and audit

- [x] Every acting call still goes through the gateway. Untouched. This is the viewer's lifecycle inside the computer, not an acting path.
- [x] New refusals and new failures each write a row. None are introduced. The behaviour being fixed is a silent stop, and it becomes a stream that keeps running rather than a new refusal.
- [x] Nothing new is trusted from the client that the server can resolve itself. Nothing new is read from a client. The fix turns on socket identity, which the process holds itself, deliberately rather than on any value a client could supply.

## Changelog

- [x] `CHANGELOG.md` under `Unreleased`: reconnecting a live screen stops killing the reconnection, and both halves of the old failure were silent.

## Proof

Verified against a real browser rather than argued. Opening A, opening B, then closing A left B with zero frames and a keystroke that never landed; the same sequence with nothing closed left B receiving frames, so the close is what did it. With the guard, B keeps its frames and its typing arrives. The other direction is checked too: when the current viewer closes it still stops, observed by stopping the browser afterwards and confirming nothing relaunches it, against a held-open viewer that does.

Quality checks: `format:check`, `lint` and `typecheck` clean, `agent-computer` typechecked on its own since the root script does not reach it and CI checks it in the `deployables` matrix. The suite's failing set matches `main`.

## What this does not close

This is the narrow fix for the ordering that is reachable without a race. #190 covers the rest of what follows from tracking the viewer per Bot instead of per socket, including two failures that predate this change and are not addressed here.