### PR TITLE
Fix grammar: correct 'PydanticAI' product name (no space)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ More at [copilotkit.ai/openbot](https://copilotkit.ai/openbot).
 
 ## Built on AG-UI
 
-A Bot is any endpoint speaking [AG-UI](https://github.com/ag-ui-protocol/ag-ui), the open protocol for agent-to-user interaction, so OpenBot is not tied to a framework and neither are you. Agents built with LangGraph, Mastra, CrewAI, Pydantic AI, Google ADK or written by hand all arrive the same way, and the governance rides the protocol rather than the framework.
+A Bot is any endpoint speaking [AG-UI](https://github.com/ag-ui-protocol/ag-ui), the open protocol for agent-to-user interaction, so OpenBot is not tied to a framework and neither are you. Agents built with LangGraph, Mastra, CrewAI, PydanticAI, Google ADK or written by hand all arrive the same way, and the governance rides the protocol rather than the framework.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/architecture-dark.svg">


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 44).

## Problem

"Pydantic AI" should be "PydanticAI" (one word). The official product name as used in their documentation and PyPI package has no space.

## Fix

Changed:
```
Pydantic AI
```
To:
```
PydanticAI
```

## Type of Change

- [x] Documentation fix (grammar, spelling)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text
