### PR TITLE
Refuse the MCP server addresses this check already means to refuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,28 @@ without a word, because the input path looks for a viewer before it looks for an
 
 A close now stops casting only when the socket closing is the one that was casting.
 
+### An MCP server address that points inside the deployment is refused in three more spellings
+
+Adding an MCP server by URL is checked before the address is stored, because that form is otherwise a
+way to point the deployment at its own network. The check compared the literal hostname, and three
+spellings of an address it means to refuse were getting through.
+
+A trailing dot is the root-anchored form of the same name and reaches the same place, but it changed
+the string enough that every rule missed it, so `https://localhost./`, `https://printer.local./` and
+`https://metadata.google.internal./` were all accepted. `kubernetes.default.svc`, which is how a
+service is addressed from inside a cluster, carries dots and none of the listed suffixes, so it read
+as an ordinary vendor name.
+
+The third is worth acting on rather than just noting. A credential typed into the address itself,
+`https://user:token@vendor.example/mcp`, was accepted, and the address is stored and named in the
+trail as given. Audit redaction works on field names and `url` is not one of the sensitive ones, so
+the token was written to `mcp_servers` and to an audit row in clear text. The trail is append-only by
+design, so that row cannot be deleted afterwards: **a deployment where somebody has done this should
+treat that credential as disclosed and rotate it.** The address field now refuses a credential and
+points at the token field instead.
+
+A deployment that reaches its MCP servers by ordinary vendor hostnames sees no difference.
+
 ## 0.0.4
 
 ### A click citing a ref this deployment cannot resolve is refused

--- a/server/src/plugins/catalogue.ts
+++ b/server/src/plugins/catalogue.ts
@@ -276,6 +276,15 @@ export function customUrlRefusal(raw: string): string | null {
     return "An MCP server must be reached over https.";
   }
 
+  // Userinfo is not part of the host, so none of the host rules below would look at it, and what is
+  // typed here is stored verbatim: addCustomServer writes the string into mcp_servers.url and into
+  // the configuration.changed audit payload, whose redaction keys on the field name rather than the
+  // value. A secret written this way would sit in the trail in clear text. The refusal deliberately
+  // does not echo the URL back.
+  if (url.username || url.password) {
+    return "Put the credential in the token field rather than in the address.";
+  }
+
   // A trailing dot is the root-anchored spelling of the same name and resolves to the same place, so
   // they are stripped here rather than added to each comparison below. Without it "localhost."
   // misses the equality test, "vault.internal." misses the suffix tests, and "database." picks up

--- a/server/src/plugins/catalogue.ts
+++ b/server/src/plugins/catalogue.ts
@@ -276,7 +276,12 @@ export function customUrlRefusal(raw: string): string | null {
     return "An MCP server must be reached over https.";
   }
 
-  const host = url.hostname.toLowerCase();
+  // A trailing dot is the root-anchored spelling of the same name and resolves to the same place, so
+  // they are stripped here rather than added to each comparison below. Without it "localhost."
+  // misses the equality test, "vault.internal." misses the suffix tests, and "database." picks up
+  // the dot that the single-label test keys on, so the fully qualified form of every name this
+  // function refuses walks straight through it.
+  const host = url.hostname.toLowerCase().replace(/\.+$/, "");
 
   // Bracketed IPv6 arrives with the brackets already stripped by URL, so the colon test catches it.
   if (host.includes(":") || /^[0-9.]+$/.test(host)) {
@@ -289,6 +294,9 @@ export function customUrlRefusal(raw: string): string | null {
     host.endsWith(".internal") ||
     host.endsWith(".local") ||
     host.endsWith(".localdomain") ||
+    // How a Kubernetes service is addressed from inside the cluster. It carries dots and none of
+    // the suffixes above, so without this it reads as an ordinary vendor name.
+    host.endsWith(".svc") ||
     !host.includes(".")
   ) {
     return "That address is not reachable from outside this network.";

--- a/server/tests/plugin-catalogue.test.ts
+++ b/server/tests/plugin-catalogue.test.ts
@@ -232,6 +232,34 @@ describe("a URL an administrator typed", () => {
     expect(customUrlRefusal("https://printer.local/mcp")).not.toBeNull();
   });
 
+  test("the fully qualified spelling of those names is refused too", () => {
+    // A trailing dot is the root-anchored form of the same name and resolves to the same place, so
+    // every rule above has to see through it. It defeats them in two different ways: the suffix
+    // tests stop matching because the string now ends in the dot, and "database." acquires the dot
+    // that the single-label test keys on.
+    expect(customUrlRefusal("https://localhost./mcp")).not.toBeNull();
+    expect(customUrlRefusal("https://database./mcp")).not.toBeNull();
+    expect(customUrlRefusal("https://vault.internal./mcp")).not.toBeNull();
+    expect(customUrlRefusal("https://printer.local./mcp")).not.toBeNull();
+    expect(
+      customUrlRefusal("https://metadata.google.internal./computeMetadata/v1/"),
+    ).not.toBeNull();
+    // More than one, because stripping a single dot leaves a string that still misses every rule.
+    expect(customUrlRefusal("https://localhost../mcp")).not.toBeNull();
+    expect(customUrlRefusal("https://vault.internal.../mcp")).not.toBeNull();
+  });
+
+  test("an in-cluster service name is refused", () => {
+    // .svc is how a Kubernetes service is addressed from inside the cluster. It has dots and none
+    // of the other suffixes, so it reads as an ordinary vendor name.
+    expect(
+      customUrlRefusal("https://kubernetes.default.svc/mcp"),
+    ).not.toBeNull();
+    expect(
+      customUrlRefusal("https://kubernetes.default.svc.cluster.local/mcp"),
+    ).not.toBeNull();
+  });
+
   test("nonsense is refused rather than thrown", () => {
     expect(customUrlRefusal("not a url")).toBe("That is not a URL.");
   });

--- a/server/tests/plugin-catalogue.test.ts
+++ b/server/tests/plugin-catalogue.test.ts
@@ -260,6 +260,30 @@ describe("a URL an administrator typed", () => {
     ).not.toBeNull();
   });
 
+  test("a credential in the URL is refused", () => {
+    // Userinfo is not part of the host, so every rule above passes it, and addCustomServer then
+    // writes the string it was given into mcp_servers.url and into the configuration.changed audit
+    // payload. Audit redaction keys on the field name and "url" is not sensitive, so the secret
+    // would sit in the trail in clear text.
+    expect(
+      customUrlRefusal("https://oauth:s3cret@mcp.example.com/mcp"),
+    ).not.toBeNull();
+    expect(
+      customUrlRefusal("https://token@mcp.example.com/mcp"),
+    ).not.toBeNull();
+  });
+
+  test("refusing a credential in the URL does not repeat the credential", () => {
+    // The refusal is rendered to the administrator and can reach a log, so it must not carry the
+    // thing it exists to reject.
+    const refusal = customUrlRefusal(
+      "https://oauth:s3cret@mcp.example.com/mcp",
+    );
+    expect(refusal).not.toBeNull();
+    expect(refusal).not.toContain("s3cret");
+    expect(refusal).not.toContain("oauth");
+  });
+
   test("nonsense is refused rather than thrown", () => {
     expect(customUrlRefusal("not a url")).toBe("That is not a URL.");
   });


### PR DESCRIPTION
Closes #205.

## What this changes

`customUrlRefusal` is the floor for a URL an administrator types into "add an MCP server", and it
compares the literal hostname. Three spellings of an address it means to refuse were getting past it.

A **trailing dot** is the root-anchored form of the same name and resolves to the same place, but it
changes the string, so every rule missed it: `"localhost."` is not `"localhost"`,
`"vault.internal."` does not end in `".internal"`, and `"database."` picks up the dot that the
single-label test keys on. The fully qualified spelling of every address this function refuses went
through, `metadata.google.internal.` included. It is stripped where the host is read rather than
added to each comparison, so a rule added later inherits it, and all trailing dots rather than the
last one, because taking a single dot off `"localhost.."` leaves a string that still matches nothing.

**`.svc`** joins the suffix list. It is how a Kubernetes service is addressed from inside the
cluster, and it carries dots and none of the other suffixes, so it read as an ordinary vendor name.
`.cluster.local` was already caught by the `.local` rule.

A **credential in the address** is now refused. Userinfo is not part of the host, so no host rule
looked at it, and what is typed there does not stay in the form: `addCustomServer` writes the string
it was given into `mcp_servers.url` and into the `configuration.changed` audit payload, and audit
redaction keys on the field name rather than the value, so `url` is not sensitive and the secret is
stored verbatim. Refused rather than stripped, because stripping would quietly accept an address
somebody typed a credential into and leave them believing it was used; there is a token field for
this and the message points at it. The refusal does not echo the URL back, since it is rendered to
the administrator and can reach a log, and there is a test holding that.

Two commits, the host checks and the credential separately, because the second one is a different
question about a different part of the URL and has an audit consequence the first does not.

`addCustomServer` is the only path that takes a URL from a caller; the catalogue path resolves its
own and checks a per-instance host against an anchored pattern, so this function is the whole
surface. A DNS name whose A record points inside the network still passes, which the docblock scopes
out on purpose and which is a different change.

## Where it runs

- [x] **New state that outlives a request?** None. `customUrlRefusal` is a pure function of the
      string it is handed, called before anything is written.
- [x] **What happens on the second replica?** Identical. No shared state, no ordering, no cache; the
      decision depends only on the argument.
- [x] **Anything serialised?** No. Nothing is written by this path; it only decides whether the
      existing write proceeds.
- [x] **Anything fanned out to a browser?** No. The refusal is the return value of the call the
      administrator's own request made.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: resolve, decide, audit, then act. Untouched;
      this sits in front of a configuration write, not an acting call.
- [x] New refusals and new failures each write a row. The refusal throws `CustomServerRefusedError`
      before the insert, the same shape the existing refusals in this function already take, so a
      rejected address is reported to the caller and no `configuration.changed` row is written for a
      server that was never added. That is the behaviour being restored: the row that used to be
      written here is the one carrying the leaked credential.
- [x] Nothing new is trusted from the client that the server can resolve itself. This removes trust
      rather than adding it.

## Changelog

- [x] A line in `CHANGELOG.md` under `Unreleased`. It names the credential case specifically, because
      the trail is append-only and a token already written there cannot be deleted, so a deployment
      where somebody has done this has to rotate rather than clean up.

## Proof

Against a migrated Postgres, driving the real `addCustomServer` and then reading the rows back with
SQL. Five cases, the last one a control so that "no row" means refused rather than a broken harness:

```
PASS  https://oauth:SECRET@mcp.example.com/mcp  -> refused (CustomServerRefusedError)   mcp_servers rows: 0
PASS  https://localhost./mcp                    -> refused, local to the deployment     mcp_servers rows: 0
PASS  https://vault.internal../mcp              -> refused, not reachable               mcp_servers rows: 0
PASS  https://kubernetes.default.svc/mcp        -> refused, not reachable               mcp_servers rows: 0
PASS  https://mcp.vendor.example/mcp            -> ACCEPTED                             mcp_servers rows: 1

audit_events rows containing the secret : 0
mcp_servers rows containing the secret  : 0
```

The same probe with this branch's `catalogue.ts` reverted to `main`, which is what makes the zeros
mean something:

```
audit_events rows containing the secret : 1
mcp_servers rows containing the secret  : 1

  configuration.changed  {"url":"https://oauth:SECRET@mcp.example.com/mcp","change":"mcp_server_added",...}
  mcp_servers            https://oauth:SECRET@mcp.example.com/mcp
```

Deleting that audit row is refused by `prevent_audit_event_mutation()`, which is the append-only
trigger doing its job and is why the changelog says rotate.

Unit side: 5 new tests, each RED before its fix. Each of the three parts is separately load-bearing
by mutation, and each turns exactly its own test red and nothing else: reverting the multi-dot strip
to a single dot reds the FQDN case, dropping `.svc` reds the cluster case, dropping the userinfo
branch reds both credential cases. A 22-case matrix covers uppercase spellings, `.svc` with a
trailing dot, password-only and percent-encoded userinfo, and the decimal, hex and octal IP forms,
alongside five ordinary vendor URLs with ports, paths, queries and subdomains that must still pass,
and they do.

Suite: 789 non-integration server tests and 185 integration tests, 0 failures, plus 199 across
`agent-computer`, `supervisor` and `shared`. Typecheck clean on all four workspaces, lint and format
clean.
