### PR TITLE
Read back only the turns that parse, and say how many did not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,24 @@ points at the token field instead.
 
 A deployment that reaches its MCP servers by ordinary vendor hostnames sees no difference.
 
+### One unreadable turn no longer takes a whole conversation down
+
+Restoring a thread cast whatever the history store held straight to messages and handed it to the
+transcript. A turn stored in a different shape — a tool call written `{id, name, args}` rather than
+AG-UI's `{id, type: "function", function: …}`, which interrupted runs have produced — reached a
+renderer that read `toolCall.function.arguments` and threw, so a single bad turn made the whole
+conversation unopenable rather than that one message unreadable.
+
+Each stored turn is now parsed against the schema AG-UI ships, and one that does not parse is left
+out instead of being drawn. Checked where history enters the app rather than in one renderer, so
+every surface that reads a transcript is covered by the same check.
+
+**A turn that is left out is said out loud.** The conversation shows a line above it naming how many
+earlier messages could not be read, because a record people read back must not have a hole in it that
+nothing accounts for — a turn that silently disappears reads as one that was never sent. Multimodal
+content and every well-formed tool call are unaffected, and a history that cannot be read at all
+still opens the composer rather than blocking it.
+
 ## 0.0.4
 
 ### A click citing a ref this deployment cannot resolve is refused

--- a/app/src/components/channels/channel-chat.tsx
+++ b/app/src/components/channels/channel-chat.tsx
@@ -115,6 +115,14 @@ export function ChannelChat({
    * already has the message that started it.
    */
   const [restoring, setRestoring] = useState(seed === null);
+  /**
+   * How many stored turns this app could not read.
+   *
+   * Held rather than derived, because the transcript is the running agent's once history is handed
+   * over: `agent.messages` is what was restored, and what was dropped on the way in is not
+   * recoverable from it.
+   */
+  const [unreadable, setUnreadable] = useState(0);
   useEffect(() => {
     if (isReady) openReadyGate.current();
   }, [isReady]);
@@ -146,9 +154,20 @@ export function ChannelChat({
           runtimeAgentId,
         );
         // Never overwrite local messages that arrived while history was loading.
-        if (current && stored.length > 0 && agent.messages.length === 0) {
-          agent.setMessages(stored);
+        if (
+          current &&
+          stored.messages.length > 0 &&
+          agent.messages.length === 0
+        ) {
+          agent.setMessages(stored.messages);
         }
+        /*
+         * Said on screen rather than only counted. A turn the history store holds and this app cannot
+         * parse is left out of the transcript, and a record people read back must not have a hole in
+         * it that nothing accounts for. Set even when nothing was restored: a thread whose every turn
+         * is unreadable is exactly the case where silence would read as "this conversation is empty".
+         */
+        if (current) setUnreadable(stored.unreadable);
       } finally {
         // Cleared on failure too: placeholders over an empty transcript promise messages that are
         // never coming.
@@ -376,12 +395,26 @@ export function ChannelChat({
         disabled={!channel.active}
         messages={transcriptMessages(agent.messages, seed)}
         notice={
-          channel.active ? null : (
-            <p className="pb-2 text-sm text-muted-foreground" role="status">
-              This coworker has been deleted. The conversation stays readable,
-              but it can no longer reply.
-            </p>
-          )
+          /*
+           * Two things can be worth saying at once — a deleted coworker and a history with holes in
+           * it — and they are independent, so neither is an `else` for the other.
+           */
+          <>
+            {unreadable > 0 ? (
+              <p className="pb-2 text-sm text-muted-foreground" role="status">
+                {unreadable === 1
+                  ? "One earlier message could not be read and is not shown."
+                  : `${unreadable} earlier messages could not be read and are not shown.`}{" "}
+                The rest of this conversation is complete.
+              </p>
+            ) : null}
+            {channel.active ? null : (
+              <p className="pb-2 text-sm text-muted-foreground" role="status">
+                This coworker has been deleted. The conversation stays readable,
+                but it can no longer reply.
+              </p>
+            )}
+          </>
         }
         onSubmit={async (draft) => {
           // `draft.agentId` carries the @mentioned coworker, but nothing routes on it yet: this

--- a/app/src/lib/copilot/thread-messages.ts
+++ b/app/src/lib/copilot/thread-messages.ts
@@ -1,4 +1,4 @@
-import type { Message } from "@ag-ui/core";
+import { type Message, MessageSchema } from "@ag-ui/core";
 import { tryClient } from "@/lib/client";
 
 /**
@@ -8,19 +8,72 @@ import { tryClient } from "@/lib/client";
  * then owned by the running agent, so a cached copy would be a second version of the same
  * conversation — and an unreadable history is not a reason to keep somebody from typing. Every
  * failure returns nothing and lets the composer open.
+ *
+ * WHAT ARRIVES HERE IS NOT TRUSTED. This used to end `stored as Message[]`, which is a cast rather
+ * than a check: whatever the history store held was handed to `setMessages` and then to every
+ * projection that reads a transcript. A turn shaped differently — a tool call persisted as
+ * `{id, name, args}` instead of AG-UI's `{id, type: "function", function: {…}}`, which interrupted
+ * runs have produced — reached a renderer that dereferenced `toolCall.function.arguments` and took
+ * the whole conversation down with it. One bad turn made a thread unreadable.
+ *
+ * So each turn is parsed against the schema AG-UI ships, and one that does not parse is left out.
+ * Checked here rather than in a projection because there are several projections and one history:
+ * fixing it in the reader that is closest to the wire is what makes every consumer safe at once.
  */
+
+/**
+ * What a read gives back: the turns that parsed, and how many did not.
+ *
+ * The count is returned rather than logged. A turn quietly missing from a record people read back is
+ * worse than a visible failure — it is a conversation that reads as though it never had that message,
+ * with nothing to say otherwise. The caller is expected to say so on screen.
+ */
+export type StoredThread = {
+  messages: Message[];
+  /** Zero on every ordinary read. Above zero means the history store holds something unreadable. */
+  unreadable: number;
+};
+
+const NOTHING: StoredThread = { messages: [], unreadable: 0 };
+
+/**
+ * The turns that parse, kept in order, and a count of the ones that did not.
+ *
+ * Exported so it can be tested against real stored shapes without a server. Takes `unknown[]`
+ * because that is honestly what the wire gives.
+ *
+ * THE ORIGINAL OBJECT IS KEPT, not `parsed.data`. Zod strips keys a schema does not name, so
+ * returning the parsed copy would quietly drop anything the runtime carries and this file has not
+ * heard of — turning a validation step into a silent rewrite of every message that passed. The parse
+ * is asked whether the turn is well formed; it is not asked to decide what the turn contains.
+ */
+export function readableTurns(stored: readonly unknown[]): StoredThread {
+  const messages: Message[] = [];
+  let unreadable = 0;
+
+  for (const turn of stored) {
+    if (MessageSchema.safeParse(turn).success) {
+      messages.push(turn as Message);
+    } else {
+      unreadable += 1;
+    }
+  }
+
+  return { messages, unreadable };
+}
+
 export async function readThreadMessages(
   threadId: string,
   agentId: string,
-): Promise<Message[]> {
+): Promise<StoredThread> {
   try {
     const response = await tryClient(
       `/api/copilotkit/threads/${encodeURIComponent(threadId)}/messages?agentId=${encodeURIComponent(agentId)}`,
     );
-    if (!response.ok) return [];
+    if (!response.ok) return NOTHING;
     const stored = (await response.json())?.messages;
-    return Array.isArray(stored) ? (stored as Message[]) : [];
+    return Array.isArray(stored) ? readableTurns(stored) : NOTHING;
   } catch {
-    return [];
+    return NOTHING;
   }
 }

--- a/app/tests/thread-messages.test.ts
+++ b/app/tests/thread-messages.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import { readableTurns } from "@/lib/copilot/thread-messages";
+
+/**
+ * What comes back out of the history store, and what is refused at the door.
+ *
+ * The old reader cast whatever it was given to `Message[]`, so a turn the store held in some other
+ * shape reached every projection that draws a transcript — and one of them dereferenced
+ * `toolCall.function.arguments`, which took the conversation down rather than the turn.
+ *
+ * These are the shapes that have actually been seen, not invented ones: the tool call persisted as
+ * `{id, name, args}` comes from #199, which found seventeen of them in one thread after interrupted
+ * runs, and the content shapes come from the tests on #43.
+ */
+
+const userTurn = { id: "m1", role: "user", content: "What did I miss?" };
+
+const assistantTurn = {
+  id: "m2",
+  role: "assistant",
+  content: "Here is the summary.",
+};
+
+/** As AG-UI defines a tool call: a literal `function` type, with the call nested under it. */
+const wellFormedToolCall = {
+  id: "m3",
+  role: "assistant",
+  toolCalls: [
+    {
+      id: "call_1",
+      type: "function",
+      function: { name: "search_files", arguments: "{}" },
+    },
+  ],
+};
+
+describe("reading back a stored thread", () => {
+  test("an ordinary conversation comes back whole, with nothing counted", () => {
+    const { messages, unreadable } = readableTurns([userTurn, assistantTurn]);
+    expect(messages).toHaveLength(2);
+    expect(unreadable).toBe(0);
+  });
+
+  test("a well-formed tool call survives", () => {
+    // The shape the transcript knows how to draw. If validation rejected this, the fix would have
+    // traded a crash for an empty conversation.
+    const { messages, unreadable } = readableTurns([wellFormedToolCall]);
+    expect(messages).toHaveLength(1);
+    expect(unreadable).toBe(0);
+  });
+
+  test("a tool call stored the LangChain way is dropped and counted", () => {
+    /*
+     * The turn from #199: `{id, name, args}` rather than `{id, type: "function", function: {…}}`.
+     * This is the one that crashed a renderer reading `toolCall.function.arguments`, so the whole
+     * turn has to not arrive — and the count is what stops it vanishing quietly.
+     */
+    const langChainShaped = {
+      id: "m4",
+      role: "assistant",
+      toolCalls: [{ id: "call_2", name: "search_files", args: {} }],
+    };
+
+    const { messages, unreadable } = readableTurns([
+      userTurn,
+      langChainShaped,
+      assistantTurn,
+    ]);
+
+    expect(messages.map((message) => message.id)).toEqual(["m1", "m2"]);
+    expect(unreadable).toBe(1);
+  });
+
+  test("multimodal content is not mistaken for a malformed turn", () => {
+    // AG-UI allows content as typed parts as well as a string, so a turn carrying an image is
+    // ordinary. Rejecting it would lose real messages in the name of safety.
+    const withParts = {
+      id: "m5",
+      role: "user",
+      content: [{ type: "text", text: "What is in this?" }],
+    };
+    const { messages, unreadable } = readableTurns([withParts]);
+    expect(messages).toHaveLength(1);
+    expect(unreadable).toBe(0);
+  });
+
+  test("content that is not content is dropped rather than drawn as empty", () => {
+    /*
+     * From the #43 cases. These used to reach a projection and resolve to an empty message, so the
+     * transcript showed a turn that said nothing and read as though somebody had sent a blank line.
+     * Refused here instead, and reported.
+     */
+    const shapes = [
+      { id: "a", role: "user" },
+      { id: "b", role: "user", content: null },
+      { id: "c", role: "user", content: 42 },
+      { id: "d", role: "user", content: [null, "text", 7] },
+    ];
+
+    const { messages, unreadable } = readableTurns(shapes);
+    expect(messages).toEqual([]);
+    expect(unreadable).toBe(4);
+  });
+
+  test("a turn that is not an object at all is dropped", () => {
+    const { messages, unreadable } = readableTurns([
+      null,
+      "a string",
+      7,
+      userTurn,
+    ]);
+    expect(messages.map((message) => message.id)).toEqual(["m1"]);
+    expect(unreadable).toBe(3);
+  });
+
+  test("a turn with no recognised role is dropped", () => {
+    // The schema is a union on `role`, so an unknown one matches no member.
+    const { messages, unreadable } = readableTurns([
+      { id: "x", role: "narrator", content: "once upon a time" },
+    ]);
+    expect(messages).toEqual([]);
+    expect(unreadable).toBe(1);
+  });
+
+  test("order is the stored order, so a dropped turn does not reshuffle the rest", () => {
+    const { messages } = readableTurns([
+      assistantTurn,
+      { id: "bad", role: "assistant", toolCalls: [{ id: "c", name: "n" }] },
+      userTurn,
+    ]);
+    expect(messages.map((message) => message.id)).toEqual(["m2", "m1"]);
+  });
+
+  test("a turn that parses keeps the fields the schema does not name", () => {
+    /*
+     * The reason the original object is returned rather than `parsed.data`. Zod strips unknown keys,
+     * so handing back the parsed copy would make this a silent rewrite of every message that passed
+     * — dropping whatever the runtime carries that this file has not heard of.
+     */
+    const carrying = { ...userTurn, somethingTheRuntimeAdded: "keep me" };
+    const { messages } = readableTurns([carrying]);
+    expect(
+      (messages[0] as unknown as { somethingTheRuntimeAdded?: string })
+        .somethingTheRuntimeAdded,
+    ).toBe("keep me");
+  });
+
+  test("an empty history is not a failure", () => {
+    expect(readableTurns([])).toEqual({ messages: [], unreadable: 0 });
+  });
+
+  test("a thread where nothing parses reports every turn", () => {
+    // The case that must not read as "this conversation is empty": the transcript has nothing to
+    // draw, so the count is the only thing that tells the person their history is still there.
+    const { messages, unreadable } = readableTurns([{ nope: true }, 1, null]);
+    expect(messages).toEqual([]);
+    expect(unreadable).toBe(3);
+  });
+});


### PR DESCRIPTION
## What this changes

`readThreadMessages` ended with a cast rather than a check:

```ts
const stored = (await response.json())?.messages;
return Array.isArray(stored) ? (stored as Message[]) : [];
```

So whatever the history store held went to `setMessages` and then to every projection that draws a
transcript. A turn in another shape took the conversation down rather than itself: a tool call written
`{id, name, args}` instead of AG-UI's `{id, type: "function", function: …}` reached a renderer that
dereferenced `toolCall.function.arguments`, and one bad turn made a thread unopenable.

Each turn is now parsed with `MessageSchema` from `@ag-ui/core`, and one that does not parse is left
out. Checked where history enters the app rather than in a projection, because there are several
projections and one history.

Three decisions, each of which is a way this could have been wrong:

**A dropped turn is counted and shown.** `readThreadMessages` returns the count beside the messages,
and the conversation draws a line above the transcript naming it. This is the whole point rather than a
nicety: the earlier attempt at this was closed because it traded a loud crash for a silent one, and a
turn that quietly disappears from a record people read back is a message that reads as never sent.

**The original object is returned, not `parsed.data`.** Zod strips keys a schema does not name, so
handing back the parsed copy would make this a silent rewrite of every message that passed — dropping
whatever the runtime carries that this file has not heard of. The parse decides whether a turn is well
formed; it does not decide what the turn contains. There is a test pinning that.

**Multimodal content is not treated as malformed.** AG-UI allows `content` as typed parts as well as a
string, so a turn carrying an image is ordinary. Rejecting those would have lost real messages in the
name of safety, and it is the failure mode a stricter guess would have shipped with.

Failing closed to an open composer is unchanged: an unreadable history still lets somebody type.

Closes #44

## Where it runs

- **New state that outlives a request?** None. One `useState` holding a count for the life of a mount.
- **What happens on the second replica?** Identical. This is a read in the browser and a parse in the
  browser; nothing is stored or shared.
- **Anything serialised?** No writes.
- **Anything fanned out to a browser?** No.
- **New listener, port, or schedule?** No.

## Boundary and audit

- No boundary touched. This is a projection of history a person has already been authorised to read;
  the endpoint and its authorisation are unchanged.
- No new refusal, and nothing new is trusted from the server — strictly less is. What used to be cast
  is now checked.
- Nothing to audit: no action is taken, and a malformed row in a history store is a data fault rather
  than an attempt at anything.

## Changelog

Added under `Unreleased`: one unreadable turn no longer takes a whole conversation down, and a turn
that is left out is said out loud.

## Proof

`app/tests/thread-messages.test.ts`, eleven tests against `readableTurns`, the pure half — the shapes
are the ones actually observed rather than invented:

```
bun test app/tests/thread-messages.test.ts    11 pass, 0 fail, 19 expect() calls
bun test app                                 153 pass, 0 fail, 229 expect() calls
```

The one worth naming: `a tool call stored the LangChain way is dropped and counted` feeds the exact
`{id, name, args}` shape #199 found seventeen of in one thread, and asserts the turn does not arrive
and the count does. That the schema rejects it is what the whole change rests on, so it is asserted
rather than reasoned about.

Also pinned: a well-formed tool call survives, multimodal parts survive, order is preserved across a
drop, a turn keeps fields the schema does not name, and a thread where nothing parses reports every
turn rather than reading as empty.

`app typecheck` exits 0. `biome format` and `biome lint` clean on all four changed files.

**What I have not done, stated rather than implied:** I have no browser-driven run of the notice — no
screenshot of the line above a transcript with a seeded bad turn. The parsing is under test and the
notice is one `<p>` in the existing `notice` slot beside the deleted-coworker line, but I have not
watched it draw. Say so if you want that before it lands.

## Credit

The diagnosis and the original test cases are @arpan7sarkar's, from #43 and #44. The content shapes
asserted here — absent, null, primitive, and an array with holes in it — are that file's; what changed
is where they are caught. Their PR was closed with the fix specified rather than the problem dismissed,
and I picked it up after saying so on #44.

## What is not covered

- **The server half of #199 is untouched.** That report also finds server-side run validation rejecting
  a whole run with `400 invalid_literal, expected "function"` on a thread holding these tool calls,
  which makes the thread unusable for sending as well as reading. This fixes what the browser draws,
  not what the server accepts, and #199 should not be read as closed by it.
- **Nothing repairs existing rows.** A thread already holding malformed turns reads correctly from now
  on and keeps holding them; normalising history in place is a migration and a separate decision.
- **No count is surfaced outside the channel.** `readThreadMessages` has one caller today, so the line
  appears there. A second surface reading history would need to draw its own.
