### PR TITLE
Record a failed action the same way it was decided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,21 @@ the admin screen, which mints a token and points at the one it just made. If a d
 custom server pointing at a credential of another kind, adding it again will now be refused, and the
 answer is to give the server its own token.
 
+### A failed action is recorded the same way it was decided
+
+An action the policy allowed and the computer then failed is recorded twice, once for the decision
+and once for the outcome, so the trail can tell an action that happened from one that was permitted
+and did not. The second row was leaving out the command and the key that the first one carried.
+
+A shell command that failed part-way therefore said a Bot had run something without saying what, in
+the row somebody reading an incident reaches for first. The same omission picked the wrong element
+branch, so that row also claimed the command had been looked for in the page snapshot and not found
+— a page element a shell call never had. A failed file write kept its path throughout and is
+unchanged.
+
+Both rows now carry the same subject. Nothing about the boundary moves: the policy decided on a
+complete context before and after, and no action is permitted that was not permitted before.
+
 ### Upgrading
 
 **A deployment that sets `AGENT_COMPUTER_ALLOW_PRIVATE_HOSTS=true` with `NODE_ENV=production` no

--- a/server/src/computer/gateway.ts
+++ b/server/src/computer/gateway.ts
@@ -534,6 +534,13 @@ export function createComputerGateway(
        * Writing the decision before acting is still right, because an allowed action may have partial
        * effects before failing. The failure row records the outcome separately from the policy
        * decision.
+       *
+       * It carries the same subject the decision row did, and for the same reasons: a shell call
+       * that failed part-way is the row somebody most needs to name the command from, and a keypress
+       * that failed is still the difference between a submitted form and a typed letter. Leaving
+       * them off also chose the wrong element branch below, because "this action never had an
+       * element" is decided by the command and the file path — so a failed command claimed a
+       * snapshot lookup that never happened.
        */
       await write(auditStore, {
         toolName,
@@ -541,6 +548,8 @@ export function createComputerGateway(
         actor,
         element,
         ref,
+        ...(subject.key ? { key: subject.key } : {}),
+        ...(subject.command ? { command: subject.command } : {}),
         filePath,
         pageUrl,
         decision,

--- a/server/tests/computer-gateway.test.ts
+++ b/server/tests/computer-gateway.test.ts
@@ -201,6 +201,11 @@ async function gatewayWith(
     resetResult?: { cleared: boolean };
     locations?: ComputerLocation[];
     token?: string;
+    /** Endpoints the computer answers differently, for the calls that have to fail. */
+    routes?: Record<
+      string,
+      (init?: RequestInit) => Response | Promise<Response>
+    >;
   },
 ) {
   const { provider, fetchImpl, calls, addressedAs, requests } =
@@ -442,6 +447,68 @@ describe("the computer gateway", () => {
     expect(calls).toEqual([]);
     expect(rows[0]?.eventType).toBe("computer.action_refused");
     expect(rows[0]?.payload.command).toBe("cat secrets.txt");
+  });
+
+  /**
+   * The two rows describe one action, so they have to describe the same one.
+   *
+   * Asserted as agreement rather than field by field on purpose: the failure row is a second
+   * hand-maintained argument list, and what goes wrong with one of those is not a particular field
+   * being wrong, it is a field being added to one and not the other. Comparing the payloads catches
+   * the next one too.
+   */
+  test("a permitted action that fails is recorded the same way it was decided", async () => {
+    const failing = () =>
+      Response.json({ error: "device or resource busy" }, { status: 500 });
+
+    for (const action of [
+      {
+        what: "a command",
+        route: "/exec",
+        run: (gateway: Awaited<ReturnType<typeof gatewayWith>>["gateway"]) =>
+          gateway.runCommand("bot-1", ACTOR, {
+            command: "rm -rf /workspace/build",
+          }),
+      },
+      {
+        what: "a keypress",
+        route: "/key",
+        run: (gateway: Awaited<ReturnType<typeof gatewayWith>>["gateway"]) =>
+          gateway.key("bot-1", ACTOR, {
+            ref: "e1",
+            snapshotId: 7,
+            key: "Enter",
+          }),
+      },
+      {
+        what: "a file write",
+        route: "/files/write",
+        run: (gateway: Awaited<ReturnType<typeof gatewayWith>>["gateway"]) =>
+          gateway.writeFile("bot-1", ACTOR, { path: "notes.md", text: "kept" }),
+      },
+    ]) {
+      const { gateway, rows } = await gatewayWith(PERMISSIVE, {
+        routes: { [action.route]: failing },
+      });
+      rows.length = 0;
+
+      await expect(action.run(gateway)).rejects.toThrow();
+
+      const allowed = rows.find(
+        (row) => row.eventType === "computer.action_allowed",
+      );
+      const failed = rows.find(
+        (row) => row.eventType === "computer.action_failed",
+      );
+      expect(allowed, action.what).toBeDefined();
+      expect(failed, action.what).toBeDefined();
+
+      // The outcome is the only thing the failure row adds. Everything describing what was attempted
+      // is the same action and reads the same on both rows.
+      const { failure, ...attempted } = failed?.payload ?? {};
+      expect(failure, action.what).toBeString();
+      expect(attempted, action.what).toEqual(allowed?.payload ?? {});
+    }
   });
 
   test("the computer is told WHICH Bot is asking", async () => {


### PR DESCRIPTION
Fixes #210.

## What was open

The gateway records a permitted action twice: once for the policy decision, and again if the action
was allowed and then failed. The second row exists so a reader can tell an action that happened from
one that was allowed and did not — without it the allowed row reads as "it happened".

The two rows are written by separate calls to the same `write` helper, and the argument lists had
drifted: the failure row was never passed `key` or `command`. So a `computer_run_command` that failed
part-way was recorded without the command — the row an incident opens first, saying a Bot ran
something and not what.

The same drop fabricated an element. The element fallback reads "this action never had an element"
off `command` and `filePath`, so with `command` gone a shell call fell through to the branch meant for
a browser action whose ref did not resolve, and the row claimed `"element": "not in the current
snapshot"` — a lookup that never happened for an element a shell call never has. That is the half
that is wrong on its own terms rather than merely missing.

## The fix

The failure row is passed the same `key` and `command` the decision row already spreads in. That is
the whole change: two conditional spreads, three lines. Restoring `command` also settles the element
fallback, since the fallback keys on it. A failed file write was already correct and is untouched.

No boundary moves. The policy still decides on a fully populated context — `key` and `command` were
always bound into it correctly; only the record of the outcome was short. Nothing is permitted that
was not before, no refusal or failure path changes, and no new value is trusted from the client.

## Proof

The new test fails on `main` and passes with the fix. Reverting only the two spreads:

```
(fail) the computer gateway > a permitted action that fails is recorded the same way it was decided
error: a command
- Expected  - 2
+ Received  + 1
```

It asserts the two rows agree rather than checking `command` by name — the fault is drift between two
argument lists, so a test naming one field would miss the next field added to one row and not the
other. It strips `failure` off the failed row and compares the remainder to the allowed row, across a
command, a keypress and a file write, the write being the control that was already right.

`server/tests/computer-gateway.test.ts`: 56 pass. `bun run typecheck`, `lint`, `format:check`: clean.
`bun test`: 1355 pass, with the same 10 failures an untouched `main` shows at this commit — the
credential and OAuth tests want a Postgres database, and `agent-langgraph`'s history test cannot
resolve `@langchain/core/messages`. A `CHANGELOG.md` line under `Unreleased`. No surface, so nothing
to screenshot.

## Out of scope

Building the entry once before the policy call and spreading `failure` into a copy for the second
write would make this drift structurally impossible instead of fixing the one instance of it. It is a
larger edit to a deliberately explicit file, so it is left as the maintainers' call — happy to do it
here instead if that is preferred.
