### PR TITLE
Say what a strict content-security-policy has to allow

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -135,3 +135,9 @@ which makes them the shortest path from nothing to a running deployment.
 **The image is 5.3 GB**, most of it the Playwright base, which ships Firefox and WebKit alongside the
 Chromium we use. Deleting them afterwards does not help, because the bytes still ship in the layer
 below. Building Chromium-only onto a slim base would cut this substantially and is not done yet.
+
+**A strict content-security-policy needs a hash or a nonce.** `app/index.html` runs a small inline
+script that decides the theme before the first paint. Nothing in this repo sends a CSP header, so it
+works as shipped; a deployment that adds one at its proxy has to allow that script explicitly, or
+`script-src` blocks it and the page renders with the wrong theme until the app boots. A `'sha256-'`
+hash of the script body is the version that survives a rebuild without a per-request nonce.


### PR DESCRIPTION
## What this changes

The review on #204 asked for this: the inline theme script in `app/index.html` is correct as
shipped, but a deployment that puts a strict content-security-policy in front of it has to allow
that script, and nothing said so.

One paragraph in `docs/deployment.md` under `Known costs`, which is already where the traps that are
not visible from the code live. It names what actually breaks — `script-src` blocks the script, the
pre-paint decision never runs, and the flash #204 removed comes back on the first frame — and names
the `'sha256-'` hash as the form that survives a rebuild without a per-request nonce.

## Where it runs

Documentation. No code ships.

- **New state that outlives a request?** None.
- **What happens on the second replica?** Nothing. No code changed.
- **Anything serialised?** None.
- **Anything fanned out to a browser?** None.
- **New listener, port, or schedule?** None.

## Boundary and audit

- No acting call is added or changed.
- No new refusal or failure path.
- Nothing new is trusted from the client.

## Changelog

No line. A deployment behaves no differently afterwards: this adds a paragraph to
`docs/deployment.md` and ships nothing that runs.

## Proof

`bunx biome format .` and `bunx biome lint --error-on-warnings .` both clean. Added lines wrap at
100 columns, matching the file. No source file is touched, so the app and gateway suites are
unaffected by this diff.
