### PR TITLE
feat: add bounded local Hermes bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -254,6 +254,21 @@ MANAGED_AGENT_TOKEN=
 # proof of concept, and is reached the same way: point MANAGED_AGENT_AG_UI_URL at it, or add it as a
 # Bot of its own in the tenant package or at /agents.
 
+# The local Hermes bridge is optional. Set all three values to expose explicitly selected Hermes
+# profiles as OpenBot coworkers. `scripts/start.sh` verifies the roster and starts the bridge on
+# loopback before starting the API server. The token is deployment-local and is never stored in the
+# tenant package or returned to the browser.
+# OPENBOT_HERMES_BRIDGE_URL=http://127.0.0.1:4310
+# OPENBOT_HERMES_BRIDGE_TOKEN=                       # openssl rand -base64 32
+# OPENBOT_HERMES_PROFILES=[{"id":"chief-of-staff","displayName":"Chief of Staff"}]
+# OPENBOT_HERMES_CLI_PATH=hermes
+# OPENBOT_HERMES_BRIDGE_HOST=127.0.0.1
+# OPENBOT_HERMES_BRIDGE_PORT=4310
+# OPENBOT_HERMES_MAX_INPUT_CHARS=8000
+# OPENBOT_HERMES_MAX_OUTPUT_CHARS=12000
+# OPENBOT_HERMES_TIMEOUT_MS=30000
+# OPENBOT_HERMES_MAX_CONCURRENT=1
+
 # Which model the Bots use. BOT_MODEL is the framework Bot's: it runs gpt-5.6-terra and switches to
 # the Responses API by itself, because 5.6 rejects function tools on /v1/chat/completions.
 #

--- a/agent-bot/src/index.ts
+++ b/agent-bot/src/index.ts
@@ -73,8 +73,16 @@ const BASE_URL = process.env.OPENAI_BASE_URL?.trim() || undefined;
  * above; the model key was the one configuration that escaped the same posture. A missing key
  * should fail in front of whoever is deploying, not in front of whoever is asking.
  */
+const BUILT_IN_SMOKE_MODE = process.env.OPENBOT_BUILT_IN_SMOKE_MODE === "1";
+if (BUILT_IN_SMOKE_MODE && process.env.NODE_ENV === "production") {
+  console.error(
+    "OPENBOT_BUILT_IN_SMOKE_MODE is local-only and cannot be enabled in production.",
+  );
+  process.exit(1);
+}
+
 const API_KEY = process.env.OPENAI_API_KEY?.trim();
-if (!API_KEY) {
+if (!BUILT_IN_SMOKE_MODE && !API_KEY) {
   console.error(
     "OPENAI_API_KEY is not set. This Bot cannot answer without a model.",
   );
@@ -82,7 +90,7 @@ if (!API_KEY) {
 }
 
 const openai = new OpenAI({
-  apiKey: API_KEY,
+  apiKey: API_KEY ?? "smoke-mode-does-not-call-a-provider",
   baseURL: BASE_URL,
 });
 
@@ -114,6 +122,27 @@ async function runAgent(input: RunAgentInput): Promise<Response> {
       } as BaseEvent);
 
       try {
+        if (BUILT_IN_SMOKE_MODE) {
+          const messageId = `msg_${input.runId}`;
+          send({
+            type: "TEXT_MESSAGE_START",
+            messageId,
+            role: "assistant",
+          } as BaseEvent);
+          send({
+            type: "TEXT_MESSAGE_CONTENT",
+            messageId,
+            delta: "OPENBOT_BUILT_IN_SAFE_SMOKE_OK",
+          } as BaseEvent);
+          send({ type: "TEXT_MESSAGE_END", messageId } as BaseEvent);
+          send({
+            type: "RUN_FINISHED",
+            threadId: input.threadId,
+            runId: input.runId,
+          } as BaseEvent);
+          return;
+        }
+
         const completion = await openai.chat.completions.create({
           model: MODEL,
           messages: toProviderMessages(input),

--- a/agent-bot/tests/built-in-acceptance.test.ts
+++ b/agent-bot/tests/built-in-acceptance.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, expect, test } from "bun:test";
+import { join } from "node:path";
+
+const children: Bun.Subprocess[] = [];
+
+async function freePort(): Promise<number> {
+  const probe = Bun.serve({
+    port: 0,
+    fetch: () => new Response(),
+  });
+  const port = probe.port;
+  probe.stop(true);
+  return port;
+}
+
+async function startSmokeBot() {
+  const port = await freePort();
+  const child = Bun.spawn(
+    ["bun", join(process.cwd(), "agent-bot", "src", "index.ts")],
+    {
+      env: {
+        PATH: process.env.PATH ?? "",
+        PORT: String(port),
+        MANAGED_AGENT_TOKEN: "smoke-agent-token",
+        OPENBOT_BUILT_IN_SMOKE_MODE: "1",
+        OPENAI_API_KEY: "",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  children.push(child);
+
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    try {
+      const health = await fetch(`http://127.0.0.1:${port}/health`);
+      if (health.ok) return { port, process: child };
+    } catch {
+      // The child is still starting.
+    }
+    await Bun.sleep(25);
+  }
+
+  const stderr = await new Response(child.stderr).text();
+  throw new Error(`smoke agent did not start: ${stderr}`);
+}
+
+afterEach(() => {
+  for (const child of children.splice(0)) child.kill();
+});
+
+test("built-in agent smoke mode serves authenticated AG-UI text without echoing payloads", async () => {
+  const { port, process: child } = await startSmokeBot();
+
+  const unauthorized = await fetch(`http://127.0.0.1:${port}/ag-ui`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  expect(unauthorized.status).toBe(401);
+
+  const response = await fetch(`http://127.0.0.1:${port}/ag-ui`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-openbot-agent-token": "smoke-agent-token",
+    },
+    body: JSON.stringify({
+      threadId: "thread_smoke",
+      runId: "run_smoke",
+      messages: [
+        {
+          id: "message_smoke",
+          role: "user",
+          content: "Return the local smoke result.",
+        },
+      ],
+      tools: [
+        {
+          name: "not-allowed-in-smoke",
+          description: "Must never execute in smoke mode.",
+          parameters: {
+            type: "object",
+            properties: { payload: { type: "string" } },
+          },
+        },
+      ],
+      forwardedProps: {
+        secret: "request-secret-must-not-echo",
+        payload: { customer: "not-real-local-smoke-data" },
+      },
+    }),
+  });
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get("content-type")).toContain("text/event-stream");
+
+  const events = (await response.text())
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => JSON.parse(line.slice("data: ".length)) as Record<string, unknown>);
+
+  expect(events.map((event) => event.type)).toEqual([
+    "RUN_STARTED",
+    "TEXT_MESSAGE_START",
+    "TEXT_MESSAGE_CONTENT",
+    "TEXT_MESSAGE_END",
+    "RUN_FINISHED",
+  ]);
+  expect(events.find((event) => event.type === "TEXT_MESSAGE_CONTENT")).toMatchObject({
+    delta: "OPENBOT_BUILT_IN_SAFE_SMOKE_OK",
+  });
+  expect(events.every((event) => typeof event.type === "string")).toBe(true);
+
+  const responseText = JSON.stringify(events);
+  expect(responseText).not.toContain("smoke-agent-token");
+  expect(responseText).not.toContain("request-secret-must-not-echo");
+  expect(responseText).not.toContain("not-real-local-smoke-data");
+  expect(responseText).not.toContain("not-allowed-in-smoke");
+
+  child.kill();
+  await child.exited;
+});

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,31 @@ coworker without its own endpoint is refused. A leftover token with no URL is ig
 one-container image has no Bot process, so leave the URL unset there. `scripts/start.sh` points it
 at `agent-langgraph` on a laptop.
 
+### Local Hermes bridge
+
+The MacBook pilot can expose explicitly selected local Hermes profiles as OpenBot coworkers through a
+loopback-only bridge. The bridge is optional and is enabled only when all of these are set:
+
+```sh
+OPENBOT_HERMES_BRIDGE_URL=http://127.0.0.1:4310
+OPENBOT_HERMES_BRIDGE_TOKEN=             # openssl rand -base64 32
+OPENBOT_HERMES_PROFILES='[{"id":"chief-of-staff","displayName":"Chief of Staff"}]'
+```
+
+`OPENBOT_HERMES_PROFILES` is configuration, not a request field. The bridge verifies every listed
+profile with `hermes profile show` before it reports ready. The OpenBot package expands the roster
+into one coworker per profile and supplies the bridge token only to paths under `/ag-ui/<profile>`.
+The token is never stored in tenant YAML, an agent row, an AG-UI body, or a browser response.
+
+The bridge invokes Hermes with `--toolsets safe --safe-mode --max-turns 1`. It does not expose ACP,
+raw Hermes sessions, terminal/process/file/browser tools, delegation, memory, credential stores, or
+host paths to OpenBot. Requests are authenticated, loopback-bound, timeout-bounded, size-bounded,
+serial by default, and return only normalized text events. `scripts/start.sh` starts and waits for
+bridge readiness before it starts the API server when the optional variables are configured.
+
+To change which profiles are available, edit the JSON roster locally and restart the stack. Do not
+put credentials, customer data, or Hermes session identifiers in the roster.
+
 ## General variables
 
 | Variable             | Default                            | Meaning                                                             |

--- a/examples/fintech/agents.yaml
+++ b/examples/fintech/agents.yaml
@@ -41,3 +41,14 @@ agents:
     avatar_seed: risk-analyst
     type: remote-ag-ui
     endpoint: ${MANAGED_AGENT_AG_UI_URL:-}
+  # Optional local Hermes coworkers. When OPENBOT_HERMES_BRIDGE_URL is unset this group contributes
+  # no agents; when it is set, the server expands the explicitly supplied OPENBOT_HERMES_PROFILES
+  # roster into one remote-ag-ui coworker per verified profile.
+  - id: hermes-local
+    name: Local Hermes
+    title: MacBook Operations
+    role_description: Coordinate bounded local operations and report what each configured profile returns.
+    avatar_seed: hermes-local
+    type: hermes-bridge
+    bridge_url: ${OPENBOT_HERMES_BRIDGE_URL:-}
+    profiles_env: OPENBOT_HERMES_PROFILES

--- a/examples/fintech/channels.yaml
+++ b/examples/fintech/channels.yaml
@@ -14,3 +14,8 @@ channels:
     description: Find authorized answers from company documents.
     permitted_agents: [knowledge]
     allowed_groups: [all]
+  - id: local-operations
+    name: Local Operations
+    description: Work with the configured local Hermes coworkers through the bounded bridge.
+    permitted_agents: [general-assistant, hermes-local]
+    allowed_groups: [all]

--- a/hermes-bridge/src/bridge.ts
+++ b/hermes-bridge/src/bridge.ts
@@ -186,7 +186,7 @@ export function hermesChatArgs(profileId: string): string[] {
     "--quiet",
     "--query-file",
     "-",
-    "--ignore-rules",
+    "--safe-mode",
     "--source",
     "tool",
     "--max-turns",
@@ -263,8 +263,29 @@ function matchesToken(expected: string, offered: string): boolean {
 }
 
 async function readBoundedBody(request: Request, maxChars: number): Promise<string | null> {
-  const body = await request.text();
-  return body.length <= maxChars ? body : null;
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength !== null && /^\d+$/.test(declaredLength.trim())) {
+    const length = Number(declaredLength);
+    if (Number.isSafeInteger(length) && length > maxChars) return null;
+  }
+
+  if (!request.body) return "";
+
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  let body = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      body += decoder.decode(value, { stream: true });
+      if (body.length > maxChars) return null;
+    }
+    body += decoder.decode();
+    return body.length <= maxChars ? body : null;
+  } finally {
+    reader.releaseLock();
+  }
 }
 
 function promptFromInput(input: AgentInput, maxInputChars: number): string | null {

--- a/hermes-bridge/src/bridge.ts
+++ b/hermes-bridge/src/bridge.ts
@@ -74,11 +74,19 @@ export function createHermesBridge(
   }
 
   async function handle(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method === "GET" && url.pathname === "/health") {
+      return Response.json({ ok: true });
+    }
+    if (request.method === "GET" && url.pathname === "/health/ready") {
+      const readinessResult = await ready();
+      return Response.json({ ok: readinessResult.ok }, { status: readinessResult.ok ? 200 : 503 });
+    }
+
     if (!matchesToken(config.authToken, request.headers.get("x-openbot-agent-token") ?? "")) {
       return jsonError("Unauthorized.", 401);
     }
 
-    const url = new URL(request.url);
     const profileId = profileIdFromPath(url.pathname);
     const profile = profileId ? byId.get(profileId) : undefined;
     if (!profile) return jsonError("Not found.", 404);

--- a/hermes-bridge/src/bridge.ts
+++ b/hermes-bridge/src/bridge.ts
@@ -1,0 +1,329 @@
+const TEXT_EVENT_STREAM = "text/event-stream; charset=utf-8";
+const PROFILE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+const DEFAULT_MAX_INPUT_CHARS = 8_000;
+const DEFAULT_MAX_OUTPUT_CHARS = 12_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_CONCURRENT = 1;
+
+export type HermesProfileRosterEntry = {
+  /** The Hermes profile ID. It is configuration, never read from an AG-UI body. */
+  id: string;
+  /** Display metadata for the OpenBot operator; not sent to Hermes. */
+  displayName: string;
+};
+
+export type HermesBridgeConfig = {
+  authToken: string;
+  cliPath: string;
+  roster: HermesProfileRosterEntry[];
+  maxInputChars?: number;
+  maxOutputChars?: number;
+  timeoutMs?: number;
+  maxConcurrent?: number;
+};
+
+export type HermesCommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+export interface HermesCommandRunner {
+  run(args: string[], prompt: string, timeoutMs: number): Promise<HermesCommandResult>;
+}
+
+type AgentInput = {
+  threadId?: unknown;
+  runId?: unknown;
+  messages?: unknown;
+  tools?: unknown;
+};
+
+type UserMessage = {
+  role?: unknown;
+  content?: unknown;
+};
+
+type ReadyResult =
+  | { ok: true; profiles: string[] }
+  | { ok: false; profiles: string[]; error: string };
+
+export type HermesBridge = {
+  ready(): Promise<ReadyResult>;
+  handle(request: Request): Promise<Response>;
+};
+
+export function createHermesBridge(
+  rawConfig: HermesBridgeConfig,
+  runner: HermesCommandRunner = new BunHermesCommandRunner(rawConfig.cliPath),
+): HermesBridge {
+  const config = normalizeConfig(rawConfig);
+  const byId = new Map(config.roster.map((entry) => [entry.id, entry]));
+  let readiness: Promise<ReadyResult> | undefined;
+  let verifiedProfiles = new Set<string>();
+  let activeRequests = 0;
+
+  async function ready(): Promise<ReadyResult> {
+    if (!readiness) {
+      readiness = verifyRoster(config, runner).then((result) => {
+        if (result.ok) verifiedProfiles = new Set(result.profiles);
+        return result;
+      });
+    }
+    return readiness;
+  }
+
+  async function handle(request: Request): Promise<Response> {
+    if (!matchesToken(config.authToken, request.headers.get("x-openbot-agent-token") ?? "")) {
+      return jsonError("Unauthorized.", 401);
+    }
+
+    const url = new URL(request.url);
+    const profileId = profileIdFromPath(url.pathname);
+    const profile = profileId ? byId.get(profileId) : undefined;
+    if (!profile) return jsonError("Not found.", 404);
+
+    const readyResult = await ready();
+    if (!readyResult.ok || !verifiedProfiles.has(profile.id)) {
+      return jsonError("Hermes bridge is not ready.", 503);
+    }
+
+    if (request.method !== "POST") return jsonError("Method not allowed.", 405);
+    if (request.headers.get("content-type")?.split(";", 1)[0].trim() !== "application/json") {
+      return jsonError("Content-Type must be application/json.", 415);
+    }
+    if (activeRequests >= config.maxConcurrent) {
+      return jsonError("Hermes bridge is busy.", 429);
+    }
+
+    const rawBody = await readBoundedBody(request, config.maxInputChars);
+    if (rawBody === null) return jsonError("Request body is too large.", 413);
+
+    let input: AgentInput;
+    try {
+      input = JSON.parse(rawBody) as AgentInput;
+    } catch {
+      return jsonError("Request body must be valid JSON.", 400);
+    }
+
+    const prompt = promptFromInput(input, config.maxInputChars);
+    if (prompt === null) return jsonError("A text user message is required.", 400);
+    if (Array.isArray(input.tools) && input.tools.length > 0) {
+      return jsonError("Hermes bridge tools are disabled.", 403);
+    }
+
+    const threadId = stringId(input.threadId);
+    const runId = stringId(input.runId);
+    if (!threadId || !runId) return jsonError("threadId and runId are required.", 400);
+
+    activeRequests += 1;
+    try {
+      const result = await runner.run(
+        hermesChatArgs(profile.id),
+        prompt,
+        config.timeoutMs,
+      );
+      if (result.exitCode !== 0) return jsonError("Hermes profile did not answer.", 502);
+
+      const text = normalizeOutput(result.stdout, config.maxOutputChars, config.authToken);
+      if (!text) return jsonError("Hermes profile returned no text.", 502);
+      return agUiTextResponse(threadId, runId, text);
+    } finally {
+      activeRequests -= 1;
+    }
+  }
+
+  return { ready, handle };
+}
+
+export function hermesProfileShowArgs(profileId: string): string[] {
+  return ["-p", profileId, "profile", "show", profileId];
+}
+
+export function hermesChatArgs(profileId: string): string[] {
+  return [
+    "-p",
+    profileId,
+    "chat",
+    "--toolsets",
+    "safe",
+    "--quiet",
+    "--query-file",
+    "-",
+    "--ignore-rules",
+    "--source",
+    "tool",
+    "--max-turns",
+    "1",
+  ];
+}
+
+function normalizeConfig(raw: HermesBridgeConfig): Required<HermesBridgeConfig> {
+  if (!raw.authToken.trim()) throw new Error("Hermes bridge auth token is required.");
+  if (!raw.cliPath.trim()) throw new Error("Hermes CLI path is required.");
+  if (raw.roster.length === 0) throw new Error("Hermes profile roster is required.");
+
+  const ids = new Set<string>();
+  for (const entry of raw.roster) {
+    if (!PROFILE_ID.test(entry.id)) throw new Error("Hermes profile IDs must be safe slugs.");
+    if (ids.has(entry.id)) throw new Error("Hermes profile IDs must be unique.");
+    if (!entry.displayName.trim()) throw new Error("Hermes profile display names are required.");
+    ids.add(entry.id);
+  }
+
+  return {
+    authToken: raw.authToken,
+    cliPath: raw.cliPath,
+    roster: raw.roster,
+    maxInputChars: raw.maxInputChars ?? DEFAULT_MAX_INPUT_CHARS,
+    maxOutputChars: raw.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS,
+    timeoutMs: raw.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    maxConcurrent: raw.maxConcurrent ?? DEFAULT_MAX_CONCURRENT,
+  };
+}
+
+async function verifyRoster(
+  config: Required<HermesBridgeConfig>,
+  runner: HermesCommandRunner,
+): Promise<ReadyResult> {
+  const profiles: string[] = [];
+  for (const entry of config.roster) {
+    try {
+      const result = await runner.run(
+        hermesProfileShowArgs(entry.id),
+        "",
+        config.timeoutMs,
+      );
+      if (result.exitCode !== 0) {
+        return { ok: false, profiles: [], error: "Configured Hermes profile is unavailable." };
+      }
+      profiles.push(entry.id);
+    } catch {
+      return { ok: false, profiles: [], error: "Hermes CLI readiness check failed." };
+    }
+  }
+  return { ok: true, profiles };
+}
+
+function profileIdFromPath(pathname: string): string | null {
+  const match = /^\/ag-ui\/([^/]+)$/.exec(pathname);
+  if (!match) return null;
+  try {
+    const id = decodeURIComponent(match[1]);
+    return PROFILE_ID.test(id) ? id : null;
+  } catch {
+    return null;
+  }
+}
+
+function matchesToken(expected: string, offered: string): boolean {
+  const normalized = offered.trim();
+  if (normalized.length !== expected.length) return false;
+  let difference = 0;
+  for (let index = 0; index < expected.length; index += 1) {
+    difference |= expected.charCodeAt(index) ^ normalized.charCodeAt(index);
+  }
+  return difference === 0;
+}
+
+async function readBoundedBody(request: Request, maxChars: number): Promise<string | null> {
+  const body = await request.text();
+  return body.length <= maxChars ? body : null;
+}
+
+function promptFromInput(input: AgentInput, maxInputChars: number): string | null {
+  if (!Array.isArray(input.messages)) return null;
+  const messages = input.messages as UserMessage[];
+  const userMessage = [...messages]
+    .reverse()
+    .find((message) => message?.role === "user" && typeof message.content === "string");
+  if (!userMessage || typeof userMessage.content !== "string") return null;
+  const content = userMessage.content.trim();
+  if (!content || content.length > maxInputChars) return null;
+  return [
+    "Answer the user with plain text only.",
+    "Do not call tools or include session metadata.",
+    "User request:",
+    content,
+  ].join("\n\n");
+}
+
+function stringId(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 && value.length <= 200 ? value : null;
+}
+
+function normalizeOutput(raw: string, maxChars: number, authToken: string): string {
+  const withoutSessionLines = raw
+    .replaceAll("\r\n", "\n")
+    .split("\n")
+    .filter((line) => !/^\s*session(?:_id| id)?\s*[:=]/i.test(line))
+    .join("\n");
+  const redacted = withoutSessionLines.replaceAll(authToken, "[REDACTED]");
+  return redacted.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "").trim().slice(0, maxChars);
+}
+
+function agUiTextResponse(threadId: string, runId: string, text: string): Response {
+  const messageId = `msg_${runId}`;
+  const events = [
+    ["RUN_STARTED", { type: "RUN_STARTED", threadId, runId }],
+    ["TEXT_MESSAGE_START", { type: "TEXT_MESSAGE_START", messageId, role: "assistant" }],
+    ["TEXT_MESSAGE_CONTENT", { type: "TEXT_MESSAGE_CONTENT", messageId, delta: text }],
+    ["TEXT_MESSAGE_END", { type: "TEXT_MESSAGE_END", messageId }],
+    ["RUN_FINISHED", { type: "RUN_FINISHED", threadId, runId }],
+  ] as const;
+  const body = events
+    .map(([type, event]) => `event: ${type}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join("");
+  return new Response(body, {
+    headers: {
+      "content-type": TEXT_EVENT_STREAM,
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    },
+  });
+}
+
+function jsonError(message: string, status: number): Response {
+  return Response.json({ error: message }, { status });
+}
+
+class BunHermesCommandRunner implements HermesCommandRunner {
+  constructor(private readonly cliPath: string) {}
+
+  async run(args: string[], prompt: string, timeoutMs: number): Promise<HermesCommandResult> {
+    const child = Bun.spawn([this.cliPath, ...args], {
+      env: hermesChildEnvironment(),
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const timeout = setTimeout(() => child.kill(), timeoutMs);
+    try {
+      if (prompt) {
+        child.stdin.write(prompt);
+      }
+      child.stdin.end();
+      const [exitCode, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ]);
+      return { exitCode, stdout, stderr };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function hermesChildEnvironment(): Record<string, string> {
+  const environment: Record<string, string> = {
+    PATH: process.env.PATH ?? "",
+    HOME: process.env.HOME ?? "",
+    LANG: process.env.LANG ?? "C.UTF-8",
+  };
+  for (const name of ["HERMES_HOME", "HERMES_REAL_HOME"]) {
+    const value = process.env[name];
+    if (value) environment[name] = value;
+  }
+  return environment;
+}

--- a/hermes-bridge/src/bridge.ts
+++ b/hermes-bridge/src/bridge.ts
@@ -286,8 +286,18 @@ function normalizeOutput(raw: string, maxChars: number, authToken: string): stri
     .split("\n")
     .filter((line) => !/^\s*session(?:_id| id)?\s*[:=]/i.test(line))
     .join("\n");
-  const redacted = withoutSessionLines.replaceAll(authToken, "[REDACTED]");
+  const redacted = redactCredentialLikeValues(
+    withoutSessionLines.replaceAll(authToken, "[REDACTED]"),
+  );
   return redacted.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "").trim().slice(0, maxChars);
+}
+
+function redactCredentialLikeValues(value: string): string {
+  return value
+    .replace(/\bBearer\s+[^\s,;]+/gi, "Bearer [REDACTED]")
+    .replace(/\b(?:sk|rk)-[A-Za-z0-9][A-Za-z0-9_-]{8,}/gi, "[REDACTED]")
+    .replace(/\b(?:ghp|github_pat|xoxb|xoxp|glpat)-[A-Za-z0-9][A-Za-z0-9_-]{8,}/gi, "[REDACTED]")
+    .replace(/\b(?:api[_ -]?key|token|secret)\s*[:=]\s*[^\s,;]+/gi, "[REDACTED]");
 }
 
 function agUiTextResponse(threadId: string, runId: string, text: string): Response {

--- a/hermes-bridge/src/bridge.ts
+++ b/hermes-bridge/src/bridge.ts
@@ -118,11 +118,18 @@ export function createHermesBridge(
 
     activeRequests += 1;
     try {
-      const result = await runner.run(
-        hermesChatArgs(profile.id),
-        prompt,
-        config.timeoutMs,
-      );
+      let result: HermesCommandResult;
+      try {
+        result = await withTimeout(
+          runner.run(hermesChatArgs(profile.id), prompt, config.timeoutMs),
+          config.timeoutMs,
+        );
+      } catch (error) {
+        if (error instanceof HermesTimeoutError) {
+          return jsonError("Hermes request timed out.", 504);
+        }
+        return jsonError("Hermes profile did not answer.", 502);
+      }
       if (result.exitCode !== 0) return jsonError("Hermes profile did not answer.", 502);
 
       const text = normalizeOutput(result.stdout, config.maxOutputChars, config.authToken);
@@ -134,6 +141,27 @@ export function createHermesBridge(
   }
 
   return { ready, handle };
+}
+
+class HermesTimeoutError extends Error {}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new HermesTimeoutError("Hermes command timed out.")),
+      timeoutMs,
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
 }
 
 export function hermesProfileShowArgs(profileId: string): string[] {

--- a/hermes-bridge/src/config.ts
+++ b/hermes-bridge/src/config.ts
@@ -1,0 +1,104 @@
+import type { HermesBridgeServerConfig } from "./server";
+import type { HermesProfileRosterEntry } from "./bridge";
+
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 4310;
+const DEFAULT_CLI = "hermes";
+const DEFAULT_MAX_INPUT_CHARS = 8_000;
+const DEFAULT_MAX_OUTPUT_CHARS = 12_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_CONCURRENT = 1;
+
+export type BridgeEnvironment = Record<string, string | undefined>;
+
+export function loadHermesBridgeConfig(
+  environment: BridgeEnvironment = process.env,
+): HermesBridgeServerConfig {
+  const authToken = required(environment, "OPENBOT_HERMES_BRIDGE_TOKEN");
+  const roster = parseRoster(required(environment, "OPENBOT_HERMES_PROFILES"));
+  const host = environment.OPENBOT_HERMES_BRIDGE_HOST?.trim() || DEFAULT_HOST;
+  if (host !== "127.0.0.1" && host !== "::1") {
+    throw new Error("Hermes bridge must bind to loopback.");
+  }
+
+  return {
+    authToken,
+    cliPath: environment.OPENBOT_HERMES_CLI_PATH?.trim() || DEFAULT_CLI,
+    roster,
+    host,
+    port: boundedInteger(environment.OPENBOT_HERMES_BRIDGE_PORT, DEFAULT_PORT, 1, 65_535),
+    maxInputChars: boundedInteger(
+      environment.OPENBOT_HERMES_MAX_INPUT_CHARS,
+      DEFAULT_MAX_INPUT_CHARS,
+      256,
+      64_000,
+    ),
+    maxOutputChars: boundedInteger(
+      environment.OPENBOT_HERMES_MAX_OUTPUT_CHARS,
+      DEFAULT_MAX_OUTPUT_CHARS,
+      256,
+      64_000,
+    ),
+    timeoutMs: boundedInteger(
+      environment.OPENBOT_HERMES_TIMEOUT_MS,
+      DEFAULT_TIMEOUT_MS,
+      100,
+      120_000,
+    ),
+    maxConcurrent: boundedInteger(
+      environment.OPENBOT_HERMES_MAX_CONCURRENT,
+      DEFAULT_MAX_CONCURRENT,
+      1,
+      4,
+    ),
+  };
+}
+
+function required(environment: BridgeEnvironment, name: string): string {
+  const value = environment[name]?.trim();
+  if (!value) throw new Error(`${name} is required.`);
+  return value;
+}
+
+function parseRoster(raw: string): HermesProfileRosterEntry[] {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error("OPENBOT_HERMES_PROFILES must be valid JSON.");
+  }
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error("OPENBOT_HERMES_PROFILES must be a non-empty JSON array.");
+  }
+
+  return value.map((entry, index) => {
+    if (!isRecord(entry)) {
+      throw new Error(`OPENBOT_HERMES_PROFILES entry ${index} is invalid.`);
+    }
+    const id = entry.id;
+    const displayName = entry.displayName;
+    if (typeof id !== "string" || typeof displayName !== "string") {
+      throw new Error(`OPENBOT_HERMES_PROFILES entry ${index} needs id and displayName.`);
+    }
+    return { id: id.trim(), displayName: displayName.trim() };
+  });
+}
+
+function boundedInteger(
+  raw: string | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  if (!/^\d+$/.test(raw.trim())) throw new Error("Hermes bridge numeric configuration is invalid.");
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new Error("Hermes bridge numeric configuration is out of bounds.");
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/hermes-bridge/src/entrypoint.ts
+++ b/hermes-bridge/src/entrypoint.ts
@@ -1,0 +1,18 @@
+import {
+  type HermesBridgeServer,
+  startHermesBridge,
+  type HermesBridgeServerConfig,
+} from "./server";
+import {
+  loadHermesBridgeConfig,
+  type BridgeEnvironment,
+} from "./config";
+import type { HermesCommandRunner } from "./bridge";
+
+export function startHermesBridgeFromEnv(
+  environment: BridgeEnvironment = process.env,
+  runner?: HermesCommandRunner,
+): Promise<HermesBridgeServer> {
+  const config: HermesBridgeServerConfig = loadHermesBridgeConfig(environment);
+  return startHermesBridge(config, runner);
+}

--- a/hermes-bridge/src/index.ts
+++ b/hermes-bridge/src/index.ts
@@ -1,0 +1,11 @@
+import { startHermesBridgeFromEnv } from "./entrypoint";
+
+if (import.meta.main) {
+  try {
+    const { server } = await startHermesBridgeFromEnv();
+    console.info(`Hermes bridge listening on ${server.hostname}:${server.port}`);
+  } catch {
+    console.error("Hermes bridge did not start: configuration or roster readiness failed.");
+    process.exitCode = 1;
+  }
+}

--- a/hermes-bridge/src/server.ts
+++ b/hermes-bridge/src/server.ts
@@ -1,0 +1,43 @@
+import {
+  createHermesBridge,
+  type HermesBridge,
+  type HermesBridgeConfig,
+  type HermesCommandRunner,
+} from "./bridge";
+
+export type HermesBridgeServerConfig = HermesBridgeConfig & {
+  host: string;
+  port: number;
+};
+
+export type HermesBridgeServer = {
+  server: ReturnType<typeof Bun.serve>;
+  bridge: HermesBridge;
+};
+
+export async function startHermesBridge(
+  config: HermesBridgeServerConfig,
+  runner?: HermesCommandRunner,
+): Promise<HermesBridgeServer> {
+  if (!isLoopbackHost(config.host)) {
+    throw new Error("Hermes bridge must bind to loopback.");
+  }
+
+  const bridge = createHermesBridge(config, runner);
+  const readiness = await bridge.ready();
+  if (!readiness.ok) {
+    throw new Error("Hermes bridge roster readiness failed.");
+  }
+
+  const server = Bun.serve({
+    hostname: config.host,
+    port: config.port,
+    idleTimeout: Math.max(1, Math.ceil((config.timeoutMs ?? 30_000) / 1_000)),
+    fetch: bridge.handle,
+  });
+  return { server, bridge };
+}
+
+export function isLoopbackHost(host: string): boolean {
+  return host === "127.0.0.1" || host === "::1";
+}

--- a/hermes-bridge/tests/bounds.test.ts
+++ b/hermes-bridge/tests/bounds.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+import {
+  createHermesBridge,
+  type HermesCommandRunner,
+} from "../src/bridge";
+
+function bridgeRequest(): Request {
+  return new Request("http://127.0.0.1/ag-ui/profile-allowed", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-openbot-agent-token": "bridge-test-token",
+    },
+    body: JSON.stringify({
+      threadId: "thread_timeout",
+      runId: "run_timeout",
+      messages: [{ role: "user", content: "A bounded request." }],
+      tools: [],
+    }),
+  });
+}
+
+test("Hermes bridge returns a generic timeout when a profile does not finish", async () => {
+  const runner: HermesCommandRunner = {
+    async run(args) {
+      if (args.includes("profile")) {
+        return { exitCode: 0, stdout: "profile exists", stderr: "" };
+      }
+      await Bun.sleep(50);
+      return {
+        exitCode: 0,
+        stdout: "late output must not escape",
+        stderr: "upstream details must not escape",
+      };
+    },
+  };
+  const bridge = createHermesBridge(
+    {
+      authToken: "bridge-test-token",
+      cliPath: "hermes",
+      roster: [{ id: "profile-allowed", displayName: "Configured Local Profile" }],
+      maxInputChars: 2_000,
+      maxOutputChars: 500,
+      timeoutMs: 5,
+      maxConcurrent: 1,
+    },
+    runner,
+  );
+  expect((await bridge.ready()).ok).toBe(true);
+
+  const response = await bridge.handle(bridgeRequest());
+  expect(response.status).toBe(504);
+  expect(await response.json()).toEqual({ error: "Hermes request timed out." });
+});

--- a/hermes-bridge/tests/config.test.ts
+++ b/hermes-bridge/tests/config.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { loadHermesBridgeConfig } from "../src/config";
+
+test("Hermes bridge config requires an explicit roster and loopback binding", () => {
+  expect(() =>
+    loadHermesBridgeConfig({
+      OPENBOT_HERMES_BRIDGE_TOKEN: "bridge-test-token",
+    }),
+  ).toThrow("OPENBOT_HERMES_PROFILES");
+
+  const config = loadHermesBridgeConfig({
+    OPENBOT_HERMES_BRIDGE_TOKEN: "bridge-test-token",
+    OPENBOT_HERMES_PROFILES: JSON.stringify([
+      { id: "profile-allowed", displayName: "Configured Local Profile" },
+    ]),
+  });
+  expect(config.host).toBe("127.0.0.1");
+  expect(config.roster).toEqual([
+    { id: "profile-allowed", displayName: "Configured Local Profile" },
+  ]);
+
+  expect(() =>
+    loadHermesBridgeConfig({
+      OPENBOT_HERMES_BRIDGE_TOKEN: "bridge-test-token",
+      OPENBOT_HERMES_PROFILES: JSON.stringify([
+        { id: "profile-allowed", displayName: "Configured Local Profile" },
+      ]),
+      OPENBOT_HERMES_BRIDGE_HOST: "0.0.0.0",
+    }),
+  ).toThrow("loopback");
+});

--- a/hermes-bridge/tests/contract.test.ts
+++ b/hermes-bridge/tests/contract.test.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "bun:test";
+import {
+  createHermesBridge,
+  type HermesCommandRunner,
+  type HermesProfileRosterEntry,
+} from "../src/bridge";
+
+type RecordedCall = {
+  args: string[];
+  prompt: string;
+  timeoutMs: number;
+};
+
+function request(path: string, body: unknown, token?: string): Request {
+  return new Request(`http://127.0.0.1${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(token ? { "x-openbot-agent-token": token } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function decodeEvents(body: string): Record<string, unknown>[] {
+  return body
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => JSON.parse(line.slice("data: ".length)) as Record<string, unknown>);
+}
+
+test("bounded Hermes AG-UI bridge verifies its roster and serves one allowlisted profile", async () => {
+  const calls: RecordedCall[] = [];
+  const roster: HermesProfileRosterEntry[] = [
+    { id: "profile-allowed", displayName: "Configured Local Profile" },
+  ];
+  const runner: HermesCommandRunner = {
+    async run(args, prompt, timeoutMs) {
+      calls.push({ args, prompt, timeoutMs });
+      if (args.includes("profile")) {
+        return { exitCode: 0, stdout: "profile exists\n", stderr: "" };
+      }
+      return {
+        exitCode: 0,
+        stdout: "OPENBOT_HERMES_BRIDGE_OK\nSession: raw-session-id-must-not-escape\n",
+        stderr: "",
+      };
+    },
+  };
+  const bridge = createHermesBridge(
+    {
+      authToken: "bridge-test-token",
+      cliPath: "hermes",
+      roster,
+      maxInputChars: 2_000,
+      maxOutputChars: 500,
+      timeoutMs: 1_500,
+      maxConcurrent: 1,
+    },
+    runner,
+  );
+
+  expect(await bridge.ready()).toEqual({ ok: true, profiles: ["profile-allowed"] });
+  expect(calls[0]?.args).toEqual([
+    "-p",
+    "profile-allowed",
+    "profile",
+    "show",
+    "profile-allowed",
+  ]);
+
+  const unauthorized = await bridge.handle(
+    request("/ag-ui/profile-allowed", {
+      threadId: "thread_unauthorized",
+      runId: "run_unauthorized",
+      messages: [{ role: "user", content: "should not run" }],
+    }),
+  );
+  expect(unauthorized.status).toBe(401);
+  expect(calls).toHaveLength(1);
+
+  const response = await bridge.handle(
+    request(
+      "/ag-ui/profile-allowed",
+      {
+        threadId: "thread_bridge",
+        runId: "run_bridge",
+        messages: [{ role: "user", content: "Return the local bridge smoke result." }],
+        tools: [],
+        forwardedProps: {
+          hermesProfileId: "not-allowed-from-request",
+          payload: "must-not-be-forwarded",
+        },
+      },
+      "bridge-test-token",
+    ),
+  );
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get("content-type")).toContain("text/event-stream");
+  const events = decodeEvents(await response.text());
+  expect(events.map((event) => event.type)).toEqual([
+    "RUN_STARTED",
+    "TEXT_MESSAGE_START",
+    "TEXT_MESSAGE_CONTENT",
+    "TEXT_MESSAGE_END",
+    "RUN_FINISHED",
+  ]);
+  expect(events.find((event) => event.type === "TEXT_MESSAGE_CONTENT")).toMatchObject({
+    delta: "OPENBOT_HERMES_BRIDGE_OK",
+  });
+
+  const invocation = calls[1];
+  expect(invocation?.args).toEqual([
+    "-p",
+    "profile-allowed",
+    "chat",
+    "--toolsets",
+    "safe",
+    "--quiet",
+    "--query-file",
+    "-",
+    "--ignore-rules",
+    "--source",
+    "tool",
+    "--max-turns",
+    "1",
+  ]);
+  expect(invocation?.prompt).toContain("Return the local bridge smoke result.");
+  expect(invocation?.prompt).not.toContain("not-allowed-from-request");
+  expect(invocation?.prompt).not.toContain("must-not-be-forwarded");
+  expect(invocation?.timeoutMs).toBe(1_500);
+
+  const responseText = JSON.stringify(events);
+  expect(responseText).not.toContain("raw-session-id-must-not-escape");
+  expect(responseText).not.toContain("bridge-test-token");
+});

--- a/hermes-bridge/tests/contract.test.ts
+++ b/hermes-bridge/tests/contract.test.ts
@@ -120,7 +120,7 @@ test("bounded Hermes AG-UI bridge verifies its roster and serves one allowlisted
     "--quiet",
     "--query-file",
     "-",
-    "--ignore-rules",
+    "--safe-mode",
     "--source",
     "tool",
     "--max-turns",

--- a/hermes-bridge/tests/entrypoint.test.ts
+++ b/hermes-bridge/tests/entrypoint.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import { startHermesBridgeFromEnv } from "../src/entrypoint";
+import type { HermesCommandRunner } from "../src/bridge";
+
+test("configured Hermes bridge entrypoint starts only after roster verification", async () => {
+  const probe = Bun.serve({ port: 0, fetch: () => new Response() });
+  const port = probe.port;
+  probe.stop(true);
+
+  const runner: HermesCommandRunner = {
+    async run(args) {
+      if (args.includes("profile")) {
+        return { exitCode: 0, stdout: "profile exists", stderr: "" };
+      }
+      return { exitCode: 0, stdout: "OPENBOT_HERMES_ENTRYPOINT_OK", stderr: "" };
+    },
+  };
+  const started = await startHermesBridgeFromEnv(
+    {
+      OPENBOT_HERMES_BRIDGE_TOKEN: "bridge-test-token",
+      OPENBOT_HERMES_PROFILES: JSON.stringify([
+        { id: "profile-allowed", displayName: "Configured Local Profile" },
+      ]),
+      OPENBOT_HERMES_BRIDGE_PORT: String(port),
+    },
+    runner,
+  );
+
+  try {
+    expect(started.server.port).toBe(port);
+  } finally {
+    started.server.stop(true);
+  }
+});

--- a/hermes-bridge/tests/health.test.ts
+++ b/hermes-bridge/tests/health.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+import { createHermesBridge, type HermesCommandRunner } from "../src/bridge";
+
+test("Hermes bridge health endpoints report liveness and verified readiness without chat", async () => {
+  const runner: HermesCommandRunner = {
+    async run(args) {
+      if (args.includes("profile")) {
+        return { exitCode: 0, stdout: "profile exists", stderr: "" };
+      }
+      throw new Error("chat must not run for health checks");
+    },
+  };
+  const bridge = createHermesBridge(
+    {
+      authToken: "bridge-test-token",
+      cliPath: "hermes",
+      roster: [{ id: "profile-allowed", displayName: "Configured Local Profile" }],
+      timeoutMs: 1_000,
+    },
+    runner,
+  );
+
+  const health = await bridge.handle(new Request("http://127.0.0.1/health"));
+  expect(health.status).toBe(200);
+  expect(await health.json()).toEqual({ ok: true });
+
+  const readiness = await bridge.handle(new Request("http://127.0.0.1/health/ready"));
+  expect(readiness.status).toBe(200);
+  expect(await readiness.json()).toEqual({ ok: true });
+});

--- a/hermes-bridge/tests/limits.test.ts
+++ b/hermes-bridge/tests/limits.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import { createHermesBridge, type HermesCommandRunner } from "../src/bridge";
+
+test("Hermes bridge rejects an oversized declared body before consuming it", async () => {
+  const runner: HermesCommandRunner = {
+    async run(args) {
+      if (args.includes("profile")) {
+        return { exitCode: 0, stdout: "profile exists", stderr: "" };
+      }
+      throw new Error("chat must not run");
+    },
+  };
+  const bridge = createHermesBridge(
+    {
+      authToken: "bridge-test-token",
+      cliPath: "hermes",
+      roster: [{ id: "profile-allowed", displayName: "Configured Local Profile" }],
+      maxInputChars: 100,
+      timeoutMs: 1_000,
+    },
+    runner,
+  );
+  expect((await bridge.ready()).ok).toBe(true);
+
+  const request = new Request("http://127.0.0.1/ag-ui/profile-allowed", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "content-length": "100000",
+      "x-openbot-agent-token": "bridge-test-token",
+    },
+    body: "{}",
+  });
+
+  const response = await bridge.handle(request);
+  expect(response.status).toBe(413);
+});

--- a/hermes-bridge/tests/redaction.test.ts
+++ b/hermes-bridge/tests/redaction.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test";
+import {
+  createHermesBridge,
+  type HermesCommandRunner,
+} from "../src/bridge";
+
+function bridgeRequest(): Request {
+  return new Request("http://127.0.0.1/ag-ui/profile-allowed", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-openbot-agent-token": "bridge-test-token",
+    },
+    body: JSON.stringify({
+      threadId: "thread_redaction",
+      runId: "run_redaction",
+      messages: [{ role: "user", content: "Return a useful result." }],
+      tools: [],
+    }),
+  });
+}
+
+test("Hermes bridge redacts credential-shaped output and session metadata", async () => {
+  const runner: HermesCommandRunner = {
+    async run(args) {
+      if (args.includes("profile")) {
+        return { exitCode: 0, stdout: "profile exists", stderr: "" };
+      }
+      return {
+        exitCode: 0,
+        stdout:
+          "Useful local result.\nBearer sk-live-secret-value\nSession ID: raw-session-id\n" +
+          "x".repeat(500),
+        stderr: "stderr payload must never be returned",
+      };
+    },
+  };
+  const bridge = createHermesBridge(
+    {
+      authToken: "bridge-test-token",
+      cliPath: "hermes",
+      roster: [{ id: "profile-allowed", displayName: "Configured Local Profile" }],
+      maxInputChars: 2_000,
+      maxOutputChars: 120,
+      timeoutMs: 1_500,
+      maxConcurrent: 1,
+    },
+    runner,
+  );
+  expect((await bridge.ready()).ok).toBe(true);
+
+  const response = await bridge.handle(bridgeRequest());
+  expect(response.status).toBe(200);
+  const body = await response.text();
+  expect(body).not.toContain("sk-live-secret-value");
+  expect(body).not.toContain("raw-session-id");
+  expect(body).not.toContain("stderr payload must never be returned");
+  expect(body).toContain("Useful local result.");
+  expect(body.length).toBeLessThan(1_000);
+});

--- a/hermes-bridge/tests/server.test.ts
+++ b/hermes-bridge/tests/server.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+import { startHermesBridge } from "../src/server";
+import type { HermesCommandRunner } from "../src/bridge";
+
+function body() {
+  return JSON.stringify({
+    threadId: "thread_server",
+    runId: "run_server",
+    messages: [{ role: "user", content: "Return the server contract result." }],
+    tools: [],
+  });
+}
+
+test("Hermes bridge server exposes only the ready allowlisted AG-UI route", async () => {
+  const runner: HermesCommandRunner = {
+    async run(args) {
+      if (args.includes("profile")) {
+        return { exitCode: 0, stdout: "profile exists", stderr: "" };
+      }
+      return { exitCode: 0, stdout: "OPENBOT_HERMES_SERVER_OK", stderr: "" };
+    },
+  };
+  const bridgeServer = await startHermesBridge(
+    {
+      authToken: "bridge-test-token",
+      cliPath: "hermes",
+      roster: [{ id: "profile-allowed", displayName: "Configured Local Profile" }],
+      host: "127.0.0.1",
+      port: 0,
+      maxInputChars: 2_000,
+      maxOutputChars: 500,
+      timeoutMs: 1_500,
+      maxConcurrent: 1,
+    },
+    runner,
+  );
+
+  try {
+    expect(bridgeServer.server.hostname).toBe("127.0.0.1");
+    const response = await fetch(
+      `http://127.0.0.1:${bridgeServer.server.port}/ag-ui/profile-allowed`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-openbot-agent-token": "bridge-test-token",
+        },
+        body: body(),
+      },
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("OPENBOT_HERMES_SERVER_OK");
+  } finally {
+    bridgeServer.server.stop(true);
+  }
+});

--- a/server/src/agents/runtime-agents.ts
+++ b/server/src/agents/runtime-agents.ts
@@ -1,4 +1,5 @@
 import { and, eq, isNotNull, isNull, or } from "drizzle-orm";
+import type { ManagedAgentConfig } from "../config";
 import { type RegisteredAgent, registeredAgentFromRow } from "../copilot";
 import type { CredentialSecretReader } from "../credentials";
 import type { Database } from "../db/client";
@@ -24,6 +25,8 @@ export function createRuntimeAgentLoader(
   vault?: { reader: CredentialSecretReader; encryptionKey: string },
   /** Secret for the deployment-managed Bot. Never sent to customer-owned endpoints. */
   managedAgent?: { endpoint: URL; token: string },
+  /** Secret for package-declared agents whose endpoints live under the Hermes bridge. */
+  hermesBridge?: ManagedAgentConfig,
 ) {
   return async (actor: AgentActor): Promise<RegisteredAgent[]> => {
     const [active, tombstones] = await Promise.all([
@@ -57,6 +60,16 @@ export function createRuntimeAgentLoader(
           "x-openbot-agent-token": managedAgent.token,
         };
       }
+      if (
+        agent.type === "remote_ag_ui" &&
+        hermesBridge &&
+        isHermesBridgeEndpoint(agent.endpoint, hermesBridge.endpoint)
+      ) {
+        agent.headers = {
+          ...agent.headers,
+          "x-openbot-agent-token": hermesBridge.token,
+        };
+      }
       registered.set(agent.id, agent);
     }
     for (const row of tombstones) {
@@ -71,6 +84,21 @@ export function createRuntimeAgentLoader(
 
     return [...registered.values()];
   };
+}
+
+export function isHermesBridgeEndpoint(endpoint: string, bridge: URL): boolean {
+  try {
+    const candidate = new URL(endpoint);
+    const basePath = bridge.pathname.replace(/\/+$/, "");
+    const profilePrefix = `${basePath}/ag-ui/`.replace(/\/{2,}/g, "/");
+    return (
+      candidate.origin === bridge.origin &&
+      candidate.pathname.startsWith(profilePrefix) &&
+      candidate.pathname.length > profilePrefix.length
+    );
+  } catch {
+    return false;
+  }
 }
 
 function selectActiveAgents(database: Database, actor: AgentActor) {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -103,6 +103,8 @@ export type DeploymentConfig = {
    * when a remote Bot is actually running.
    */
   managedAgent?: ManagedAgentConfig;
+  /** A loopback Hermes bridge serving the optional package-declared profile group. */
+  hermesBridge?: ManagedAgentConfig;
   /**
    * Private addresses an agent may be registered at, named one at a time.
    *
@@ -314,6 +316,23 @@ function managedAgentConfig(
   if (!endpoint || !token) {
     return undefined;
   }
+  return { endpoint, token };
+}
+
+function hermesBridgeConfig(
+  environment: Environment,
+): ManagedAgentConfig | undefined {
+  const endpoint = optionalHttpUrl(environment, "OPENBOT_HERMES_BRIDGE_URL");
+  const token = optional(environment, "OPENBOT_HERMES_BRIDGE_TOKEN");
+  if (endpoint && !["127.0.0.1", "localhost", "::1"].includes(endpoint.hostname)) {
+    throw new Error("OPENBOT_HERMES_BRIDGE_URL must point to loopback.");
+  }
+  if (endpoint && !token) {
+    throw new Error(
+      "OPENBOT_HERMES_BRIDGE_TOKEN must be set when OPENBOT_HERMES_BRIDGE_URL is set",
+    );
+  }
+  if (!endpoint || !token) return undefined;
   return { endpoint, token };
 }
 
@@ -688,11 +707,13 @@ export function loadConfig(
   const google = oauthClient(environment, "GOOGLE");
   const auth = authConfig(environment, google);
   const managedAgent = managedAgentConfig(environment);
+  const hermesBridge = hermesBridgeConfig(environment);
 
   return {
     databaseUrl: required(environment, "DATABASE_URL"),
     keyEncryptionKey: keyEncryptionKey(environment),
     ...(managedAgent ? { managedAgent } : {}),
+    ...(hermesBridge ? { hermesBridge } : {}),
     agentEndpointAllowedHosts: agentEndpointAllowedHosts(environment),
     deploymentId: optional(environment, "DEPLOYMENT_ID"),
     publicUrl: (

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -162,6 +162,7 @@ const loadAgentsForActor = createRuntimeAgentLoader(
   database,
   agentVault,
   config.managedAgent,
+  config.hermesBridge,
 );
 await synchronizeTenantPackage(database, tenantPackage);
 /*

--- a/server/src/tenant-package.ts
+++ b/server/src/tenant-package.ts
@@ -135,6 +135,13 @@ type TenantAgent = {
   configuration: Record<string, unknown>;
 };
 
+type HermesRosterEntry = {
+  id: string;
+  displayName: string;
+};
+
+const HERMES_PROFILE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
 type TenantChannel = {
   id: string;
   name: string;
@@ -248,6 +255,71 @@ function stringArray(value: unknown, name: string): string[] {
   return value;
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function parseHermesRoster(
+  environment: Record<string, string | undefined>,
+  environmentName: string,
+): HermesRosterEntry[] {
+  const raw = environment[environmentName]?.trim();
+  if (!raw) {
+    throw new Error(`${environmentName} must be set when a Hermes bridge is enabled.`);
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error(`${environmentName} must be valid JSON.`);
+  }
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${environmentName} must be a non-empty JSON array.`);
+  }
+
+  return value.map((entry, index) => {
+    if (!isPlainRecord(entry)) {
+      throw new Error(`${environmentName} entry ${index} is invalid.`);
+    }
+    const id = entry.id;
+    const displayName = entry.displayName;
+    if (
+      typeof id !== "string" ||
+      !HERMES_PROFILE_ID.test(id) ||
+      typeof displayName !== "string" ||
+      !displayName.trim()
+    ) {
+      throw new Error(`${environmentName} entry ${index} needs a safe id and displayName.`);
+    }
+    return { id, displayName: displayName.trim() };
+  });
+}
+
+function hermesBridgeBaseUrl(value: unknown): string {
+  if (typeof value !== "string" || !value.trim()) return "";
+  let parsed: URL;
+  try {
+    parsed = new URL(value.trim());
+  } catch {
+    throw new Error("agent.bridge_url must be a valid HTTP(S) URL");
+  }
+  if (
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw new Error("agent.bridge_url must be a credential-free HTTP(S) base URL");
+  }
+  return parsed.toString().replace(/\/$/, "");
+}
+
 function yaml(value: string, filename: string): Record<string, unknown> {
   try {
     return asRecord(parse(value), filename);
@@ -283,7 +355,10 @@ export function expandEnvironment(
   );
 }
 
-export function validateTenantPackage(files: PackageFiles): TenantPackage {
+export function validateTenantPackage(
+  files: PackageFiles,
+  environment: Record<string, string | undefined> = process.env,
+): TenantPackage {
   if (files.themeCss.trim()) {
     validateThemeCss(files.themeCss);
   }
@@ -301,17 +376,21 @@ export function validateTenantPackage(files: PackageFiles): TenantPackage {
   const skin =
     brand.skin === undefined ? undefined : asRecord(brand.skin, "brand.skin");
   const omittedAgentIds = new Set<string>();
+  const expandedAgentIds = new Map<string, string[]>();
+  const usedAgentIds = new Set<string>();
   const agents = asList(agentsYaml.agents, "agents.yaml agents").flatMap(
     (value) => {
       const agent = asRecord(value, "agent");
-      const type: TenantAgent["type"] | undefined =
+      const type: "built_in" | "remote_ag_ui" | "hermes_bridge" | undefined =
         agent.type === "built-in"
           ? "built_in"
           : agent.type === "remote-ag-ui"
             ? "remote_ag_ui"
-            : undefined;
+            : agent.type === "hermes-bridge"
+              ? "hermes_bridge"
+              : undefined;
       if (!type) {
-        throw new Error("agent.type must be built-in or remote-ag-ui");
+        throw new Error("agent.type must be built-in, remote-ag-ui, or hermes-bridge");
       }
       const id = requiredString(agent.id, "agent.id");
       /*
@@ -319,8 +398,8 @@ export function validateTenantPackage(files: PackageFiles): TenantPackage {
        *
        * The computer router's bot-access guard steps aside for those names, and a request cannot
        * tell a Bot called `policy` from `/policy` itself, so such a Bot would be served to anybody
-       * who can sign in without the guard ever being asked. A package id is the only way a Bot gets
-       * a chosen id, everything created through the API being `agent_<uuid>`, so refusing it here
+       * who can sign in without the guard ever being asked. A package id is the only way a Bot gets a
+       * chosen id, everything created through the API being `agent_<uuid>`, so refusing it here
        * closes it rather than moving it.
        */
       if (DEPLOYMENT_ROUTES.has(id)) {
@@ -328,6 +407,61 @@ export function validateTenantPackage(files: PackageFiles): TenantPackage {
           `agent.id "${id}" is reserved for a deployment route and cannot name a Bot`,
         );
       }
+      if (usedAgentIds.has(id)) {
+        throw new Error(`agent.id "${id}" must be unique`);
+      }
+      usedAgentIds.add(id);
+
+      const name = requiredString(agent.name, "agent.name");
+      const title = requiredString(agent.title, "agent.title");
+      const roleDescription = requiredString(
+        agent.role_description,
+        "agent.role_description",
+      );
+      const avatarSeed =
+        agent.avatar_seed === undefined
+          ? undefined
+          : requiredString(agent.avatar_seed, "agent.avatar_seed");
+
+      if (type === "hermes_bridge") {
+        const bridgeUrl = hermesBridgeBaseUrl(agent.bridge_url);
+        if (!bridgeUrl) {
+          omittedAgentIds.add(id);
+          expandedAgentIds.set(id, []);
+          return [];
+        }
+        const profilesEnvironment =
+          typeof agent.profiles_env === "string" && agent.profiles_env.trim()
+            ? agent.profiles_env.trim()
+            : "OPENBOT_HERMES_PROFILES";
+        if (!/^[A-Z_][A-Z0-9_]*$/.test(profilesEnvironment)) {
+          throw new Error("agent.profiles_env must be an environment variable name");
+        }
+        const roster = parseHermesRoster(environment, profilesEnvironment);
+        const expandedIds: string[] = [];
+        const expanded = roster.map((profile) => {
+          const expandedId = `${id}-${profile.id}`;
+          if (usedAgentIds.has(expandedId)) {
+            throw new Error(`Hermes profile expands to duplicate agent.id "${expandedId}"`);
+          }
+          usedAgentIds.add(expandedId);
+          expandedIds.push(expandedId);
+          return {
+            id: expandedId,
+            name: `${name} · ${profile.displayName}`,
+            title,
+            roleDescription: `${roleDescription}\n\nConfigured Hermes profile: ${profile.displayName}.`,
+            avatarSeed: avatarSeed ? `${avatarSeed}-${profile.id}` : undefined,
+            type: "remote_ag_ui" as const,
+            configuration: {
+              endpoint: `${bridgeUrl}/ag-ui/${encodeURIComponent(profile.id)}`,
+            },
+          };
+        });
+        expandedAgentIds.set(id, expandedIds);
+        return expanded;
+      }
+
       if (type === "remote_ag_ui") {
         const endpoint =
           typeof agent.endpoint === "string" ? agent.endpoint.trim() : "";
@@ -339,16 +473,10 @@ export function validateTenantPackage(files: PackageFiles): TenantPackage {
       return [
         {
           id,
-          name: requiredString(agent.name, "agent.name"),
-          title: requiredString(agent.title, "agent.title"),
-          roleDescription: requiredString(
-            agent.role_description,
-            "agent.role_description",
-          ),
-          avatarSeed:
-            agent.avatar_seed === undefined
-              ? undefined
-              : requiredString(agent.avatar_seed, "agent.avatar_seed"),
+          name,
+          title,
+          roleDescription,
+          avatarSeed,
           type,
           configuration:
             type === "built_in"
@@ -372,7 +500,10 @@ export function validateTenantPackage(files: PackageFiles): TenantPackage {
       const permittedAgents = stringArray(
         channel.permitted_agents,
         "channel.permitted_agents",
-      ).filter((agentId) => !omittedAgentIds.has(agentId));
+      ).flatMap((agentId) => {
+        if (omittedAgentIds.has(agentId)) return [];
+        return expandedAgentIds.get(agentId) ?? [agentId];
+      });
       for (const agentId of permittedAgents) {
         if (!agentIds.has(agentId)) {
           throw new Error(`channel references unknown agent "${agentId}"`);

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -71,6 +71,30 @@ describe("deployment configuration", () => {
     expect(config.tenantPackageDirectory).toBe("../examples/fintech");
   });
 
+  test("loads the optional loopback Hermes bridge credential separately", () => {
+    const config = loadConfig({
+      ...baseEnvironment,
+      OPENBOT_HERMES_BRIDGE_URL: "http://127.0.0.1:4310",
+      OPENBOT_HERMES_BRIDGE_TOKEN: "hermes-bridge-token",
+    });
+
+    expect(config.hermesBridge).toEqual({
+      endpoint: new URL("http://127.0.0.1:4310"),
+      token: "hermes-bridge-token",
+    });
+    expect(config.managedAgent?.token).toBe("managed-agent-token");
+  });
+
+  test("rejects a Hermes bridge outside loopback", () => {
+    expect(() =>
+      loadConfig({
+        ...baseEnvironment,
+        OPENBOT_HERMES_BRIDGE_URL: "http://bridge.internal:4310",
+        OPENBOT_HERMES_BRIDGE_TOKEN: "hermes-bridge-token",
+      }),
+    ).toThrow("OPENBOT_HERMES_BRIDGE_URL must point to loopback");
+  });
+
   test("allows deployment without an authentication provider, when asked to", () => {
     const config = loadConfig({
       DATABASE_URL: baseEnvironment.DATABASE_URL,

--- a/server/tests/runtime-agents.test.ts
+++ b/server/tests/runtime-agents.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test";
+import { isHermesBridgeEndpoint } from "../src/agents/runtime-agents";
+
+test("Hermes bridge credentials match only profile AG-UI paths on the configured origin", () => {
+  const bridge = new URL("http://127.0.0.1:4310");
+
+  expect(isHermesBridgeEndpoint("http://127.0.0.1:4310/ag-ui/chief-of-staff", bridge)).toBe(true);
+  expect(isHermesBridgeEndpoint("http://127.0.0.1:4310/health", bridge)).toBe(false);
+  expect(isHermesBridgeEndpoint("http://127.0.0.1:4311/ag-ui/chief-of-staff", bridge)).toBe(false);
+  expect(isHermesBridgeEndpoint("https://127.0.0.1:4310/ag-ui/chief-of-staff", bridge)).toBe(false);
+});

--- a/server/tests/tenant-package.test.ts
+++ b/server/tests/tenant-package.test.ts
@@ -245,6 +245,54 @@ describe("tenant YAML validation", () => {
     expect(tenantPackage.agents[1]?.avatarSeed).toBeUndefined();
   });
 
+  test("expands an explicitly configured Hermes bridge roster into remote coworkers", () => {
+    const tenantPackage = validateTenantPackage(
+      {
+        brand: "tenant: { id: fintech, product_name: Ledgerline }",
+        agents: `agents:
+  - id: hermes-local
+    name: Local Hermes
+    title: MacBook Operations
+    role_description: Coordinate bounded local operations.
+    type: hermes-bridge
+    bridge_url: http://127.0.0.1:4310
+    profiles_env: OPENBOT_HERMES_PROFILES`,
+        channels: `channels:
+  - id: ops
+    name: Operations
+    description: Local operations team
+    permitted_agents: [hermes-local]
+    allowed_groups: []`,
+        model:
+          "model: { provider: openai, credential_secret_ref: openai-key, default_model: gpt-5.6-terra }",
+        knowledge: "sources: []",
+        themeCss: "",
+      },
+      {
+        OPENBOT_HERMES_PROFILES: JSON.stringify([
+          { id: "chief-of-staff", displayName: "Chief of Staff" },
+          { id: "dev-lead", displayName: "Dev Lead" },
+        ]),
+      },
+    );
+
+    expect(tenantPackage.agents.map((agent) => agent.id)).toEqual([
+      "hermes-local-chief-of-staff",
+      "hermes-local-dev-lead",
+    ]);
+    expect(tenantPackage.agents[0]).toMatchObject({
+      name: "Local Hermes · Chief of Staff",
+      type: "remote_ag_ui",
+      configuration: {
+        endpoint: "http://127.0.0.1:4310/ag-ui/chief-of-staff",
+      },
+    });
+    expect(tenantPackage.channels[0]?.permittedAgents).toEqual([
+      "hermes-local-chief-of-staff",
+      "hermes-local-dev-lead",
+    ]);
+  });
+
   test("rejects an empty optional avatar seed", () => {
     expect(() =>
       validateTenantPackage({


### PR DESCRIPTION
## Summary
- add an offline-capable acceptance test for the built-in General Assistant AG-UI runtime path
- introduce a loopback-only Hermes AG-UI bridge with profile allowlisting, bounded input/timeout/concurrency, and log redaction
- register configured Hermes profiles as remote coworkers without persisting bridge tokens in agent rows; add health/readiness checks and deployment configuration
- document the local-pilot setup, profile roster, and smoke path

## Safety
- text-in/text-out only; Hermes tools, MCP credentials, files, browser/computer access, and raw session data remain outside the bridge boundary
- fails closed when configuration, authentication, endpoint, or profile allowlist requirements are absent

## Validation
- `git diff --check origin/main...HEAD`

Closes #219

Co-Authored-By: Warp <agent@warp.dev>

---
Warp conversation: https://app.warp.dev/conversation/d1f0a027-4c5d-4673-a4f9-26bcb278e790