### PR TITLE
Point the test at the database the project actually has

### DIFF
--- a/server/tests/server-side-tools.integration.test.ts
+++ b/server/tests/server-side-tools.integration.test.ts
@@ -31,7 +31,7 @@ import { TEST_POOL } from "./support/database";
 
 const database = createDatabase(
   process.env.DATABASE_URL ??
-    "postgres://openkai:openkai@localhost:5432/openkai",
+    "postgres://openbot:openbot@localhost:5432/openbot",
   TEST_POOL,
 );
 


### PR DESCRIPTION
Closes #233

## What this changes

`server/tests/server-side-tools.integration.test.ts` fell back to `postgres://openkai:openkai@localhost:5432/openkai` when `DATABASE_URL` was not set. No user, password or database by that name exists in `docker-compose.yml` or `.env.example`, and the string appears nowhere else in the tree. It now says `openbot`, like the twenty-five other test files that carry the same fallback.

The failure only showed up when the file was run from inside `server/`. Bun reads `.env` from the working directory, `DATABASE_URL` is set in the repository's root `.env`, and there is no `server/.env` — so the fallback fires there and nowhere else. Every other file's fallback was already correct, so the whole suite was green from the root and green in CI while this one file failed for anyone who ran it from the workspace it lives in.

What they saw was `password authentication failed for user "openkai"`, plus a Drizzle error from the `afterAll` cleanup pointing at `plugin_grants`. Neither names the real cause, and nothing else in the project mentions `openkai` to search for.

Deliberately left alone: the DSN is still written out twenty-six times. Giving it one home in `server/tests/support/` — next to `TEST_POOL` in `database.ts` and `testEnvironment()` in `environment.ts` — is the change that stops this recurring, but it touches twenty-six files and is a separate call. Happy to send it if wanted.

## Where it runs

- [x] **New state that outlives a request?** None. Test-only change, one string literal.
- [x] **What happens on the second replica?** Nothing differs. No runtime code is touched.
- [x] **Anything serialised?** Nothing new.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** No.

## Boundary and audit

- [x] Every acting call still goes through the gateway: no acting call is touched.
- [x] New refusals and new failures each write a row: no refusal or failure path is touched.
- [x] Nothing new is trusted from the client: no request handling is touched.

## Changelog

No `CHANGELOG.md` entry. A deployment behaves no differently afterwards — the change is a fallback value inside a test file, reached only when `DATABASE_URL` is unset, which never happens in a running deployment.

## Proof

Before, from `server/` with `DATABASE_URL` unset:

```
$ cd server && bun test tests/server-side-tools.integration.test.ts
PostgresError: password authentication failed for user "openkai"
 0 pass
 2 fail
```

After, same command, same shell:

```
$ cd server && bun test tests/server-side-tools.integration.test.ts
 5 pass
 0 fail
 12 expect() calls
Ran 5 tests across 1 file. [560.00ms]
```

Note the count: the file has five tests, and before the fix only two of them were reported at all.

Full server suite from `server/`, `DATABASE_URL` still unset — the run that used to carry the two failures:

```
 1078 pass
 0 fail
Ran 1078 tests across 75 files. [6.84s]
```

`bun run typecheck` passes across `app`, `server` and `worker`. `bun run lint` reports no findings on 421 files.
