### PR TITLE
Fix grammar: fused sentence in pydantic-ai-bot README

### DIFF
--- a/examples/pydantic-ai-bot/README.md
+++ b/examples/pydantic-ai-bot/README.md
@@ -40,7 +40,7 @@ It listens on `http://localhost:4600/ag-ui` (`PORT` to change) and answers `GET 
 `OPENAI_BASE_URL` points the OpenAI provider at a compatible gateway, the same way the rest of the
 deployment is configured (see [docs/configuration.md](../../docs/configuration.md)). Note which API
 that gateway has to serve: Pydantic AI calls `/responses`, not `/v1/chat/completions`. A gateway
-offering only chat completions will not answer this example, and the reverse of the constraint the
+offering only chat completions will not answer this example. This is the reverse of the constraint the
 two TypeScript Bots carry, which is that they speak chat completions and so cannot use the models
 that require Responses.
 


### PR DESCRIPTION
## Documentation Fix

**File:** `examples/pydantic-ai-bot/README.md`
**Line:** 43
**Category:** grammar
**Severity:** moderate

### Problem

The clause after 'and' is a sentence fragment with no main verb, producing a fused run-on sentence that is hard to parse.

### Fix

Split the run-on into two sentences.

### Verification
- [x] Fix applied to the exact line
- [x] No other occurrences in the file
- [x] No functional code changes — documentation only