### PR TITLE
Fix grammar: add missing 'or' in enumeration in SKILL.md

### DIFF
--- a/.claude/skills/openbot-data-access/SKILL.md
+++ b/.claude/skills/openbot-data-access/SKILL.md
@@ -54,7 +54,7 @@ Not everything crossing the wire is cached state, and the shape follows from whi
    success.
 3. **Everything else is a plain exported function**, living beside the factories for its entity.
    A verdict about this moment (`decideComponent`, `testAgentConnection`), a tool call during a
-   Bot's turn (`callPluginTool`, the computer control surface), a frame of a screen, a step inside
+   Bot's turn (`callPluginTool`, the computer control surface), a frame of a screen, or a step inside
    another write (`storeMcpToken`). These fail closed and return a value rather than throwing,
    because a refusal is usually the answer. Giving one a cache key would create a key nothing reads
    and an invalidation nothing triggers.


### PR DESCRIPTION
## Documentation Fix

**File:** `.claude/skills/openbot-data-access/SKILL.md`
**Line:** 57
**Category:** grammar
**Severity:** minor

### Problem

The list of examples is missing an 'or' before the final item, making the enumeration read as a run-on rather than a proper list.

### Fix

Added 'or' before the final item: 'a frame of a screen, or a step inside another write'.

### Verification
- [x] Fix applied to the exact line
- [x] No other occurrences in the file
- [x] No functional code changes — documentation only