### PR TITLE
Let a deployment sign in through Grok Build OIDC.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,16 @@ OPENBOT_SINGLE_USER=true
 # OKTA_OAUTH_CLIENT_ID=
 # OKTA_OAUTH_CLIENT_SECRET=
 # OKTA_OAUTH_ISSUER=https://example.okta.com/oauth2/default
+#
+# Any other OpenID Connect issuer. Default redirect URI is
+# http://localhost:3001/api/auth/callback/oidc. Grok Build's public client
+# (issuer https://auth.x.ai) is registered for loopback /callback instead:
+# http://127.0.0.1:3001/callback. Override with OIDC_REDIRECT_URI if needed.
+# The client secret is optional: leave it unset for a public PKCE client.
+# OIDC_CLIENT_ID=
+# OIDC_CLIENT_SECRET=
+# OIDC_ISSUER=https://auth.example.com
+# OIDC_REDIRECT_URI=
 
 # Where this deployment is reached from outside. Only needed for connectors that a person connects
 # their own account to, such as Google Drive: it builds the redirect URI the vendor sends them back

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ docs/plans/
 .env
 .env.*
 !.env.example
+.local/
 node_modules/
 **/dist/
 app/src/lib/generated/application-config.ts

--- a/app/src/components/auth/provider-logo.tsx
+++ b/app/src/components/auth/provider-logo.tsx
@@ -19,6 +19,7 @@ import type { AuthProviderId } from "@/lib/auth/queries";
 export function ProviderLogo({ provider }: { provider: AuthProviderId }) {
   if (provider === "google") return <GoogleMark />;
   if (provider === "microsoft") return <MicrosoftMark />;
+  if (provider === "oidc") return <OidcMark />;
   return <OktaMark />;
 }
 
@@ -90,6 +91,34 @@ function OktaMark() {
       <path
         d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm0 15a5 5 0 1 1 0-10 5 5 0 0 1 0 10z"
         fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+/**
+ * A generic OpenID Connect mark.
+ *
+ * `currentColor`, like Okta: this is not one company's button. The issuer is whoever the
+ * deployment registered, so a branded colour would be a lie on most of them and unreadable in
+ * one of the two themes on the rest.
+ */
+function OidcMark() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-[18px]"
+      fill="none"
+      focusable="false"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="2" />
+      <path
+        d="M12 7v10"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="2"
       />
     </svg>
   );

--- a/app/src/lib/auth/client.ts
+++ b/app/src/lib/auth/client.ts
@@ -9,6 +9,7 @@ const PROVIDER_NAMES: Record<AuthProviderId, string> = {
   google: "Google",
   microsoft: "Microsoft",
   okta: "Okta",
+  oidc: "Grok",
 };
 
 export function providerName(provider: AuthProviderId): string {
@@ -29,6 +30,22 @@ type SocialResult = { error?: { message?: string } | null };
  * `start` is injectable because Better Auth's client is a proxy, so a test cannot replace the method
  * on it. Named so it cannot shadow anything it defaults to.
  */
+/**
+ * Pick up a Grok Build session that finished on loopback CORS, where the
+ * browser would not store Better Auth's Set-Cookie on the consent fetch.
+ */
+export async function claimOidcSession(): Promise<boolean> {
+  const response = await fetch("/api/auth/oidc-claim", {
+    method: "POST",
+    credentials: "include",
+  });
+  if (!response.ok) {
+    return false;
+  }
+  const body = (await response.json()) as { claimed?: boolean };
+  return body.claimed === true;
+}
+
 export async function signInWith(
   provider: AuthProviderId,
   start: (input: {

--- a/app/src/lib/auth/queries.ts
+++ b/app/src/lib/auth/queries.ts
@@ -16,7 +16,7 @@ export const authKeys = {
 };
 
 /** An identity provider this deployment can sign somebody in with. */
-export type AuthProviderId = "google" | "microsoft" | "okta";
+export type AuthProviderId = "google" | "microsoft" | "okta" | "oidc";
 
 /** What the sign-in screen may offer, answered by the process that knows. */
 export type SignInOptions = {

--- a/app/src/routes/_authed.tsx
+++ b/app/src/routes/_authed.tsx
@@ -1,9 +1,15 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+import { claimOidcSession } from "../lib/auth/client";
 import { currentUserQueryOptions } from "../lib/auth/queries";
 import { CopilotProvider } from "../lib/copilot/provider";
 
 export const Route = createFileRoute("/_authed")({
   beforeLoad: async ({ context }) => {
+    if (await claimOidcSession()) {
+      context.queryClient.removeQueries({
+        queryKey: currentUserQueryOptions().queryKey,
+      });
+    }
     const user = await context.queryClient.ensureQueryData(
       currentUserQueryOptions(),
     );

--- a/app/src/routes/_authed/admin/identity-providers.tsx
+++ b/app/src/routes/_authed/admin/identity-providers.tsx
@@ -108,7 +108,7 @@ function IdentityProvidersPage() {
       title="Identity providers"
     >
       <PageSection
-        description="Google, Microsoft and Okta are configured in the environment instead and do not appear here."
+        description="Google, Microsoft, Okta and a generic OpenID Connect issuer are configured in the environment instead and do not appear here."
         title="Registered"
       >
         {failure ? (

--- a/app/src/routes/_authed/admin/people.tsx
+++ b/app/src/routes/_authed/admin/people.tsx
@@ -38,6 +38,7 @@ const PROVIDER_NAMES: Record<string, string> = {
   google: "Google",
   microsoft: "Microsoft",
   okta: "Okta",
+  oidc: "Grok",
 };
 
 /**

--- a/app/src/routes/sign.tsx
+++ b/app/src/routes/sign.tsx
@@ -1,13 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { motion, useReducedMotion } from "motion/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import AgentOrb from "@/components/agents/orb/agent-orb";
 import { ProviderLogo } from "@/components/auth/provider-logo";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import {
+  claimOidcSession,
   providerName,
   signInWith,
   signInWithEmailDomain,
@@ -27,6 +28,11 @@ const ENTRANCE_OFFSET = "translateY(12px)";
 
 export const Route = createFileRoute("/sign")({
   beforeLoad: async ({ context }) => {
+    if (await claimOidcSession()) {
+      context.queryClient.removeQueries({
+        queryKey: currentUserQueryOptions().queryKey,
+      });
+    }
     const user = await context.queryClient.ensureQueryData(
       currentUserQueryOptions(),
     );
@@ -48,6 +54,19 @@ function SignScreen() {
   const { data: options } = useQuery(authProvidersQueryOptions());
   const providers = options?.providers ?? [];
   const [email, setEmail] = useState("");
+  const [pasted, setPasted] = useState("");
+
+  // Grok Build's OAuth client is registered for 127.0.0.1, not localhost. The
+  // session cookie is host-bound, so sign-in that starts on localhost cannot
+  // complete on 127.0.0.1. Bounce before offering the button.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (window.location.hostname !== "localhost") return;
+    if (!providers.includes("oidc")) return;
+    const next = new URL(window.location.href);
+    next.hostname = "127.0.0.1";
+    window.location.replace(next.toString());
+  }, [providers]);
 
   /**
    * Sign in through whichever identity provider covers this address.
@@ -197,6 +216,47 @@ function SignScreen() {
                 {opening === "sso"
                   ? "Opening…"
                   : "Continue with your company account"}
+              </Button>
+            </form>
+          ) : null}
+          {providers.includes("oidc") ? (
+            <form
+              className="mt-4 space-y-2"
+              onSubmit={(submission) => {
+                submission.preventDefault();
+                const raw = pasted.trim();
+                if (!raw) return;
+                try {
+                  const asUrl = new URL(raw);
+                  const code = asUrl.searchParams.get("code");
+                  const oauthState = asUrl.searchParams.get("state");
+                  if (code && oauthState) {
+                    window.location.assign(
+                      `http://127.0.0.1:3001/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(oauthState)}`,
+                    );
+                    return;
+                  }
+                } catch {
+                  // Bare codes from the consent screen still need the state query.
+                }
+                setError(
+                  "Paste the full http://127.0.0.1:3001/callback?... URL. A bare code is not enough.",
+                );
+              }}
+            >
+              <Input
+                onChange={(event) => setPasted(event.target.value)}
+                placeholder="Or paste the Grok callback URL"
+                value={pasted}
+              />
+              <Button
+                className="h-10 w-full tracking-tight"
+                disabled={opening !== null || pasted.trim().length === 0}
+                size="lg"
+                type="submit"
+                variant="outline"
+              >
+                Finish with pasted URL
               </Button>
             </form>
           ) : null}

--- a/app/tests/auth-client.test.ts
+++ b/app/tests/auth-client.test.ts
@@ -20,7 +20,7 @@ import { providerName, signInWith } from "@/lib/auth/client";
  * deployment can gain one without the app being rebuilt.
  */
 describe("signInWith", () => {
-  test.each(["google", "microsoft", "okta"] as const)(
+  test.each(["google", "microsoft", "okta", "oidc"] as const)(
     "starts %s through the same call",
     async (provider) => {
       const asked: string[] = [];
@@ -79,5 +79,6 @@ describe("providerName", () => {
     expect(providerName("google")).toBe("Google");
     expect(providerName("microsoft")).toBe("Microsoft");
     expect(providerName("okta")).toBe("Okta");
+    expect(providerName("oidc")).toBe("Grok");
   });
 });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,6 +122,10 @@ Two things are worth knowing before pointing a deployment at any gateway. Not ev
 | `OKTA_OAUTH_CLIENT_ID`       | Okta client id.                                                                        |
 | `OKTA_OAUTH_CLIENT_SECRET`   | Okta client secret.                                                                    |
 | `OKTA_OAUTH_ISSUER`          | Which Okta, for example `https://example.okta.com/oauth2/default`.                     |
+| `OIDC_CLIENT_ID`             | Client id for any other OpenID Connect issuer.                                         |
+| `OIDC_CLIENT_SECRET`         | Client secret. Optional for a public client that authenticates with PKCE.              |
+| `OIDC_ISSUER`                | Issuer origin, for example `https://auth.example.com`.                                 |
+| `OIDC_REDIRECT_URI`          | Exact redirect URI sent to the issuer. Grok Build (`https://auth.x.ai`) defaults to `http://127.0.0.1:<api-port>/callback`. |
 | `BETTER_AUTH_SECRET`         | At least 32 characters. Required with any provider.                                    |
 | `BETTER_AUTH_URL`            | Public API server base URL, where OAuth callbacks return. Required with any provider.  |
 | `TRUSTED_ORIGINS`            | Comma-separated app origins accepted by the API, plus every host in a registered OIDC provider's discovery document. |
@@ -135,10 +139,11 @@ configure, because a public URL where every visitor is an administrator fails si
 does not enter into it. `.env.example` ships the line switched on, so a clone runs with no
 configuration at all.
 
-**Any one provider turns sign-in on**, and several may be configured at once. Each provider's id and
-secret must be set together, Okta additionally needs its issuer, and any of them requires
-`BETTER_AUTH_SECRET`, `BETTER_AUTH_URL` and `INITIAL_ADMIN_EMAILS`. Every incomplete combination is
-refused at start-up rather than at somebody's first attempt to sign in.
+**Any one provider turns sign-in on**, and several may be configured at once. Each named provider's
+id and secret must be set together, Okta additionally needs its issuer, a generic OpenID Connect
+issuer needs `OIDC_CLIENT_ID` and `OIDC_ISSUER` (the secret is optional for a public client), and
+any of them requires `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL` and `INITIAL_ADMIN_EMAILS`. Every
+incomplete combination is refused at start-up rather than at somebody's first attempt to sign in.
 
 `INITIAL_ADMIN_EMAILS` is required because nothing else grants the administrator role at first: an
 address it names becomes an administrator at every sign-in and cannot be demoted from the People
@@ -160,7 +165,7 @@ added it. The client secret and any SAML signing material are encrypted at rest 
 `KEY_ENCRYPTION_KEY`.
 
 The redirect URI to register with each provider is `<BETTER_AUTH_URL>/api/auth/callback/<provider>`,
-where `<provider>` is `google`, `microsoft` or `okta`.
+where `<provider>` is `google`, `microsoft`, `okta` or `oidc`.
 
 `OPENBOT_PUBLIC_URL` and `OPENBOT_APP_URL` matter only for a connector each person connects their own account to, such as Google Drive.
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -20,6 +20,10 @@ import {
   requireAdmin,
 } from "./auth/guards";
 import type { IdentityProviderStore } from "./auth/identity-provider-store";
+import {
+  claimOidcLoopbackCookies,
+  stashOidcLoopbackCookies,
+} from "./auth/oidc-loopback-claim";
 import type { ChannelEventHub } from "./channels/events";
 import { type ChannelStore, createChannelRoutes } from "./channels/routes";
 import type { ThreadIdentity } from "./channels/thread-identity";
@@ -30,9 +34,9 @@ import type { SandboxedStore } from "./components/sandboxed";
 import { createSandboxedRoutes } from "./components/sandboxed-routes";
 import type { ComponentStore } from "./components/store";
 import type { ComputerGateway } from "./computer/gateway";
+import type { PageFrameStore } from "./computer/page-frames";
 import type { PolicyStore } from "./computer/policy-store";
 import { createComputerRoutes } from "./computer/routes";
-import type { PageFrameStore } from "./computer/page-frames";
 import { configuredAuthProviders, type DeploymentConfig } from "./config";
 import type { CredentialAdminService, CredentialInput } from "./credentials";
 import { createIntelligenceClient } from "./intelligence-client";
@@ -43,6 +47,21 @@ import { REFUSAL_MARKER } from "./plugins/tools";
 import type { IntentRouter } from "./routing/classify";
 import { createRoutingRoutes } from "./routing/routes";
 import type { PackageStatusReader } from "./tenant-package";
+
+function oidcLoopbackCallbackPath(
+  redirectURI: string | undefined,
+): string | null {
+  if (!redirectURI) return null;
+  try {
+    const parsed = new URL(redirectURI);
+    if (parsed.hostname !== "127.0.0.1" && parsed.hostname !== "localhost") {
+      return null;
+    }
+    return parsed.pathname || "/callback";
+  } catch {
+    return null;
+  }
+}
 
 /**
  * One row for something an administrator did to somebody's access.
@@ -213,6 +232,30 @@ export function createApp(
     "/api/auth/sso/delete-provider",
   ]);
 
+  /*
+   * First-party handoff after the Grok consent tab's CORS fetch. That fetch
+   * cannot store OpenBot's session cookie (third-party). The sign-in page
+   * claims the stashed cookies over Vite, which is first-party.
+   */
+  app.post("/api/auth/oidc-claim", (context) => {
+    const host = (context.req.header("host") ?? "").split(":")[0] ?? "";
+    if (host !== "127.0.0.1" && host !== "localhost") {
+      return context.json({ error: "Loopback only." }, 403);
+    }
+    const cookies = claimOidcLoopbackCookies();
+    if (!cookies) {
+      return context.json({ claimed: false });
+    }
+    const headers = new Headers({ "content-type": "application/json" });
+    for (const cookie of cookies) {
+      headers.append("set-cookie", cookie.replace(/;\s*secure/gi, ""));
+    }
+    return new Response(JSON.stringify({ claimed: true }), {
+      status: 200,
+      headers,
+    });
+  });
+
   app.on(["GET", "POST"], "/api/auth/*", async (context) => {
     if (!auth) {
       return context.json(
@@ -240,6 +283,62 @@ export function createApp(
 
     return auth.handler(context.req.raw);
   });
+
+  /*
+   * Grok Build's OAuth client will not accept Better Auth's default callback path. It is registered
+   * for loopback `/callback` (see `OidcClient.redirectURI`). The consent page at accounts.x.ai
+   * delivers the code with `fetch()` onto that URL, so this route must speak CORS and Private
+   * Network Access the way the Grok Build CLI's loopback server does.
+   */
+  const oidcLoopbackPath = oidcLoopbackCallbackPath(
+    config.auth?.oidc?.redirectURI,
+  );
+  if (oidcLoopbackPath) {
+    const grokAccountsOrigin = "https://accounts.x.ai";
+    const grokLoopbackCors: Record<string, string> = {
+      "Access-Control-Allow-Origin": grokAccountsOrigin,
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+      "Access-Control-Allow-Private-Network": "true",
+    };
+    const grokAppUrl = config.appUrl ?? "http://127.0.0.1:3010";
+    const grokSignedInHtml = `<!doctype html><html><head><meta charset="utf-8"><title>Signed in</title></head><body style="font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0"><p>Grok sign-in finished. Return to OpenBot and it will pick up the session.</p><p><a href="${grokAppUrl}">Open OpenBot</a></p><script>setTimeout(function(){window.location.replace(${JSON.stringify(grokAppUrl)})},800)</script></body></html>`;
+
+    app.options(oidcLoopbackPath, (context) =>
+      context.body(null, 204, grokLoopbackCors),
+    );
+    app.on(["GET", "POST"], oidcLoopbackPath, async (context) => {
+      if (!auth) {
+        return context.json(
+          { error: "No identity provider is configured." },
+          503,
+        );
+      }
+      const inbound = new URL(context.req.url);
+      inbound.pathname = "/api/auth/callback/oidc";
+      const authResponse = await auth.handler(
+        new Request(inbound, context.req.raw),
+      );
+      const setCookies = authResponse.headers.getSetCookie();
+      if (authResponse.status < 400) {
+        stashOidcLoopbackCookies(setCookies);
+      }
+      const fromAccounts = context.req.header("origin") === grokAccountsOrigin;
+      if (!fromAccounts) {
+        return authResponse;
+      }
+      const headers = new Headers(grokLoopbackCors);
+      headers.set("content-type", "text/html; charset=utf-8");
+      for (const cookie of setCookies) {
+        headers.append("set-cookie", cookie);
+      }
+      const ok = authResponse.status < 400;
+      return new Response(ok ? grokSignedInHtml : await authResponse.text(), {
+        status: ok ? 200 : authResponse.status,
+        headers,
+      });
+    });
+  }
 
   const authenticationUnavailable: MiddlewareHandler<{
     Variables: AppVariables;

--- a/server/src/auth/dev-actor.ts
+++ b/server/src/auth/dev-actor.ts
@@ -80,7 +80,7 @@ export function singleUserEnabled(
   if (asked) return true;
 
   throw new Error(
-    "No identity provider is configured. Set GOOGLE_OAUTH_*, MICROSOFT_OAUTH_* or OKTA_OAUTH_* with BETTER_AUTH_SECRET and BETTER_AUTH_URL, or set OPENBOT_SINGLE_USER=true to run with one administrator and no sign-in. Refusing to start rather than serving a deployment where every visitor is an administrator.",
+    "No identity provider is configured. Set GOOGLE_OAUTH_*, MICROSOFT_OAUTH_*, OKTA_OAUTH_* or OIDC_* with BETTER_AUTH_SECRET and BETTER_AUTH_URL, or set OPENBOT_SINGLE_USER=true to run with one administrator and no sign-in. Refusing to start rather than serving a deployment where every visitor is an administrator.",
   );
 }
 

--- a/server/src/auth/index.ts
+++ b/server/src/auth/index.ts
@@ -115,29 +115,58 @@ export function createAuth(
   }
 
   /*
-   * Okta goes through the generic OAuth plugin, the other two do not.
+   * Okta and generic OpenID Connect go through the generic OAuth plugin, the other two do not.
    *
    * Google and Entra are named providers that Better Auth knows the endpoints of. Okta is not one
    * place: every customer has their own issuer, so it is OIDC discovery against a URL rather than a
-   * provider with a fixed address. The plugin is only registered when Okta is configured, so a
-   * deployment that does not use it carries no extra routes.
+   * provider with a fixed address. A generic issuer is the same shape without Okta's helper: the
+   * discovery document at that URL is the whole configuration. The plugin is only registered when
+   * one of them is configured, so a deployment that does not use either carries no extra routes.
    *
-   * They converge again at the browser: `signIn.social({ provider })` starts all three, so the
+   * They converge again at the browser: `signIn.social({ provider })` starts all of them, so the
    * sign-in screen has one code path and does not need to know which kind each provider is.
    */
-  const plugins = [
+  const genericProviders = [
     ...(authConfig.okta
       ? [
-          genericOAuth({
-            config: [
-              okta({
-                clientId: authConfig.okta.clientId,
-                clientSecret: authConfig.okta.clientSecret,
-                issuer: authConfig.okta.issuer,
-              }),
-            ],
+          okta({
+            clientId: authConfig.okta.clientId,
+            clientSecret: authConfig.okta.clientSecret,
+            issuer: authConfig.okta.issuer,
           }),
         ]
+      : []),
+    ...(authConfig.oidc
+      ? [
+          {
+            providerId: "oidc" as const,
+            name: authConfig.oidc.name,
+            clientId: authConfig.oidc.clientId,
+            ...(authConfig.oidc.clientSecret
+              ? { clientSecret: authConfig.oidc.clientSecret }
+              : {}),
+            ...(authConfig.oidc.redirectURI
+              ? { redirectURI: authConfig.oidc.redirectURI }
+              : {}),
+            discoveryUrl: `${authConfig.oidc.issuer.replace(/\/$/, "")}/.well-known/openid-configuration`,
+            pkce: true,
+            scopes: authConfig.oidc.scopes,
+            ...(authConfig.oidc.issuer.replace(/\/$/, "") ===
+            "https://auth.x.ai"
+              ? {
+                  authorizationUrlParams: {
+                    plan: "generic",
+                    referrer: "grok-build",
+                  },
+                }
+              : {}),
+          },
+        ]
+      : []),
+  ];
+  const plugins = [
+    ...(genericProviders.length > 0
+      ? [genericOAuth({ config: genericProviders })]
       : []),
     /*
      * Identity providers a company registers while this is running, by SAML or OIDC.
@@ -194,6 +223,12 @@ export function createAuth(
        * accounts of everybody who has already signed in.
        */
       encryptOAuthTokens: true,
+      /*
+       * Grok Build's consent page delivers the auth code with `fetch()` from
+       * accounts.x.ai onto loopback. That request has no Better Auth state
+       * cookie. PKCE and the server-stored verifier still bind the code.
+       */
+      ...(authConfig.oidc?.redirectURI ? { skipStateCookieCheck: true } : {}),
     },
     plugins,
     socialProviders: {

--- a/server/src/auth/oidc-loopback-claim.ts
+++ b/server/src/auth/oidc-loopback-claim.ts
@@ -1,0 +1,42 @@
+/**
+ * One-shot session handoff after Grok Build's CORS loopback callback.
+ *
+ * accounts.x.ai delivers the auth code with `fetch()` onto 127.0.0.1. The
+ * browser treats that as a third-party request, so Better Auth's Set-Cookie
+ * does not become the OpenBot page's session. The API keeps the cookies here
+ * for a short window; the sign-in page claims them first-party through Vite.
+ */
+
+const CLAIM_TTL_MS = 2 * 60 * 1000;
+
+type PendingClaim = {
+  cookies: string[];
+  expiresAt: number;
+};
+
+let pending: PendingClaim | null = null;
+
+export function stashOidcLoopbackCookies(setCookies: string[]): boolean {
+  const session = setCookies.filter((cookie) => /session_token=/i.test(cookie));
+  if (session.length === 0) {
+    return false;
+  }
+  pending = {
+    cookies: setCookies,
+    expiresAt: Date.now() + CLAIM_TTL_MS,
+  };
+  return true;
+}
+
+export function claimOidcLoopbackCookies(): string[] | null {
+  const held = pending;
+  pending = null;
+  if (!held || held.expiresAt < Date.now()) {
+    return null;
+  }
+  return held.cookies;
+}
+
+export function hasOidcLoopbackClaim(): boolean {
+  return pending !== null && pending.expiresAt >= Date.now();
+}

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -68,10 +68,32 @@ export type ComputerConfig =
  * has Google or Entra or Okta and is not going to acquire another, so the shape here is a set of
  * optional providers rather than one required one, and the deployment turns on whichever it has.
  */
-export type AuthProviderId = "google" | "microsoft" | "okta";
+export type AuthProviderId = "google" | "microsoft" | "okta" | "oidc";
 
 /** An OAuth client, as every provider here needs one. */
 export type OAuthClient = { clientId: string; clientSecret: string };
+
+/**
+ * A generic OpenID Connect provider, identified by its issuer.
+ *
+ * The client secret is optional because some issuers register public clients and authenticate the
+ * token request with PKCE (`token_endpoint_auth_methods_supported` includes `none`) rather than a
+ * shared secret. Okta, Google and Entra still require one; this is the path for everyone else.
+ */
+export type OidcClient = {
+  clientId: string;
+  clientSecret?: string;
+  issuer: string;
+  /** Shown on the sign-in button. Defaults to "OpenID Connect". */
+  name: string;
+  scopes: string[];
+  /**
+   * Exact redirect URI sent to the issuer. Grok Build's public client is
+   * registered for loopback `/callback` (RFC 8252), not Better Auth's default
+   * `/api/auth/callback/oidc`.
+   */
+  redirectURI?: string;
+};
 
 export type AuthConfig = {
   baseUrl: string;
@@ -87,6 +109,8 @@ export type AuthConfig = {
   microsoft?: OAuthClient & { tenantId: string };
   /** Okta is an OIDC provider rather than a named one, so it is identified by its issuer. */
   okta?: OAuthClient & { issuer: string };
+  /** Any other OpenID Connect issuer, reached the same way Okta is. */
+  oidc?: OidcClient;
 };
 
 /**
@@ -104,6 +128,7 @@ export function configuredAuthProviders(
   if (auth.google) providers.push("google");
   if (auth.microsoft) providers.push("microsoft");
   if (auth.okta) providers.push("okta");
+  if (auth.oidc) providers.push("oidc");
   return providers;
 }
 
@@ -366,7 +391,7 @@ function commaSeparated(environment: Environment, name: string): string[] {
 /**
  * Sign-in, if this deployment has an identity provider to sign people in with.
  *
- * Any one of the three turns authentication on. More than one is allowed and is the normal shape
+ * Any one of them turns authentication on. More than one is allowed and is the normal shape
  * for a company mid-migration, where some people are on Entra and some are still on Okta.
  *
  * Every combination that cannot work refuses at start-up rather than at somebody's first attempt to
@@ -380,14 +405,15 @@ function authConfig(
 ): AuthConfig | undefined {
   const microsoft = microsoftAuth(environment);
   const okta = oktaAuth(environment);
+  const oidc = oidcAuth(environment);
 
   const secret = optional(environment, "BETTER_AUTH_SECRET");
   const baseUrl = url(environment, "BETTER_AUTH_URL");
 
-  if (!google && !microsoft && !okta) {
+  if (!google && !microsoft && !okta && !oidc) {
     if (secret || baseUrl) {
       throw new Error(
-        "BETTER_AUTH_SECRET or BETTER_AUTH_URL is set but no identity provider is. Configure GOOGLE_OAUTH_*, MICROSOFT_OAUTH_* or OKTA_OAUTH_*, or unset both",
+        "BETTER_AUTH_SECRET or BETTER_AUTH_URL is set but no identity provider is. Configure GOOGLE_OAUTH_*, MICROSOFT_OAUTH_*, OKTA_OAUTH_* or OIDC_*, or unset both",
       );
     }
     return undefined;
@@ -430,6 +456,7 @@ function authConfig(
     ...(google ? { google } : {}),
     ...(microsoft ? { microsoft } : {}),
     ...(okta ? { okta } : {}),
+    ...(oidc ? { oidc } : {}),
   };
 }
 
@@ -476,6 +503,81 @@ function oktaAuth(
     );
   }
   return { ...client, issuer };
+}
+
+/**
+ * Any OpenID Connect issuer, reached the same way Okta is.
+ *
+ * The issuer is required because there is no default: this is not one company's product, it is
+ * whoever published a discovery document at that URL. The client secret is not, because a public
+ * client authenticates the token request with PKCE rather than a shared secret, and refusing to
+ * start without one would lock out the issuers this path exists for.
+ */
+function oidcAuth(environment: Environment): OidcClient | undefined {
+  const clientId = optional(environment, "OIDC_CLIENT_ID");
+  const clientSecret = optional(environment, "OIDC_CLIENT_SECRET");
+  const issuer = url(environment, "OIDC_ISSUER");
+
+  if (!clientId && !clientSecret && !issuer) {
+    return undefined;
+  }
+  if (!clientId) {
+    throw new Error(
+      "OIDC_ISSUER is set but OIDC_CLIENT_ID is not. A generic OpenID Connect provider needs the client this deployment registered with that issuer",
+    );
+  }
+  if (!issuer) {
+    throw new Error(
+      "OpenID Connect sign-in requires OIDC_ISSUER, such as https://auth.example.com",
+    );
+  }
+
+  const grokBuild = issuer.replace(/\/$/, "") === "https://auth.x.ai";
+  const name =
+    optional(environment, "OIDC_NAME") ??
+    (grokBuild ? "Grok" : "OpenID Connect");
+  const scopes = commaSeparated(environment, "OIDC_SCOPES");
+  const redirectURI =
+    optional(environment, "OIDC_REDIRECT_URI") ??
+    (grokBuild ? grokBuildRedirectURI(environment) : undefined);
+  return {
+    clientId,
+    issuer,
+    name,
+    scopes: scopes.length
+      ? scopes
+      : grokBuild
+        ? [
+            "openid",
+            "profile",
+            "email",
+            "offline_access",
+            "grok-cli:access",
+            "api:access",
+          ]
+        : ["openid", "profile", "email", "offline_access"],
+    ...(redirectURI ? { redirectURI } : {}),
+    ...(clientSecret ? { clientSecret } : {}),
+  };
+}
+
+/**
+ * Grok Build registers `http://127.0.0.1:<port>/callback`. `localhost` and
+ * `/api/auth/callback/oidc` are both refused at authorize time.
+ */
+function grokBuildRedirectURI(environment: Environment): string {
+  const configured = url(environment, "BETTER_AUTH_URL");
+  let port = "3001";
+  if (configured) {
+    try {
+      port =
+        new URL(configured).port ||
+        (configured.startsWith("https:") ? "443" : "80");
+    } catch {
+      port = "3001";
+    }
+  }
+  return `http://127.0.0.1:${port}/callback`;
 }
 
 /**

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -710,7 +710,7 @@ if (config.singleUser) {
   console.warn(
     "No identity provider is configured, so every request is treated as " +
       `${DEV_ACTOR.email} (administrator). Configure GOOGLE_OAUTH_*, ` +
-      "MICROSOFT_OAUTH_* or OKTA_OAUTH_* before anybody else can reach this.",
+      "MICROSOFT_OAUTH_*, OKTA_OAUTH_* or OIDC_* before anybody else can reach this.",
   );
 }
 

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "node:fs";
 import { describe, expect, spyOn, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import { configuredAuthProviders, loadConfig } from "../src/config";
 
 // Intelligence is part of the MINIMUM contract, so it belongs in the base environment every other
@@ -306,6 +306,83 @@ describe("deployment configuration", () => {
       "microsoft",
       "okta",
     ]);
+  });
+
+  test("enables a generic OpenID Connect issuer", () => {
+    const config = loadConfig({
+      ...withoutSignIn,
+      ...SESSION,
+      OIDC_CLIENT_ID: "oidc-client-id",
+      OIDC_CLIENT_SECRET: "oidc-client-secret",
+      OIDC_ISSUER: "https://auth.example.com",
+    });
+
+    expect(config.auth?.oidc).toEqual({
+      clientId: "oidc-client-id",
+      clientSecret: "oidc-client-secret",
+      issuer: "https://auth.example.com",
+      name: "OpenID Connect",
+      scopes: ["openid", "profile", "email", "offline_access"],
+    });
+    expect(configuredAuthProviders(config.auth)).toEqual(["oidc"]);
+  });
+
+  test("admits a public OpenID Connect client with no secret", () => {
+    const config = loadConfig({
+      ...withoutSignIn,
+      ...SESSION,
+      OIDC_CLIENT_ID: "oidc-public-client",
+      OIDC_ISSUER: "https://auth.example.com",
+    });
+
+    expect(config.auth?.oidc).toEqual({
+      clientId: "oidc-public-client",
+      issuer: "https://auth.example.com",
+      name: "OpenID Connect",
+      scopes: ["openid", "profile", "email", "offline_access"],
+    });
+  });
+
+  test("names the grok-build issuer Grok and asks for its CLI scopes", () => {
+    const config = loadConfig({
+      ...withoutSignIn,
+      ...SESSION,
+      OIDC_CLIENT_ID: "b1a00492-073a-47ea-816f-4c329264a828",
+      OIDC_ISSUER: "https://auth.x.ai",
+    });
+
+    expect(config.auth?.oidc?.name).toBe("Grok");
+    expect(config.auth?.oidc?.scopes).toEqual([
+      "openid",
+      "profile",
+      "email",
+      "offline_access",
+      "grok-cli:access",
+      "api:access",
+    ]);
+    expect(config.auth?.oidc?.redirectURI).toBe(
+      "http://127.0.0.1:3001/callback",
+    );
+  });
+
+  test("refuses an OpenID Connect issuer with no client", () => {
+    expect(() =>
+      loadConfig({
+        ...withoutSignIn,
+        ...SESSION,
+        OIDC_ISSUER: "https://auth.example.com",
+      }),
+    ).toThrow("OIDC_CLIENT_ID");
+  });
+
+  test("refuses an OpenID Connect client with no issuer", () => {
+    expect(() =>
+      loadConfig({
+        ...withoutSignIn,
+        ...SESSION,
+        OIDC_CLIENT_ID: "oidc-client-id",
+      }),
+    ).toThrow("OIDC_ISSUER");
   });
 
   /**

--- a/server/tests/oidc-loopback-claim.test.ts
+++ b/server/tests/oidc-loopback-claim.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import {
+  claimOidcLoopbackCookies,
+  stashOidcLoopbackCookies,
+} from "../src/auth/oidc-loopback-claim";
+
+describe("oidc loopback claim", () => {
+  test("hands session cookies over once", () => {
+    expect(
+      stashOidcLoopbackCookies([
+        "better-auth.session_token=abc; Path=/; HttpOnly",
+        "better-auth.session_data=xyz; Path=/",
+      ]),
+    ).toBe(true);
+
+    const first = claimOidcLoopbackCookies();
+    expect(first?.some((cookie) => cookie.includes("session_token=abc"))).toBe(
+      true,
+    );
+    expect(claimOidcLoopbackCookies()).toBeNull();
+  });
+
+  test("ignores responses with no session cookie", () => {
+    expect(stashOidcLoopbackCookies(["unrelated=1"])).toBe(false);
+    expect(claimOidcLoopbackCookies()).toBeNull();
+  });
+});


### PR DESCRIPTION
Google, Microsoft and Okta stay as named providers. A generic OpenID Connect issuer is configured the same way, and auth.x.ai uses Grok Build's loopback PKCE callback so the consent page can finish on 127.0.0.1.

## What this changes

<!-- What it does, and why it is worth doing. -->

## Where it runs

OpenBot is deployed as several server processes behind a load balancer, serving a whole company.
Consecutive requests from the same person reach different processes, and the process that answered a
WebSocket upgrade is rarely the one that answers the next call on that conversation.

State that outlives a single request therefore has to be shared, or the change works on one machine
and stops working the moment there are two, without saying so. That failure is worse than not
shipping the feature: it passes review, passes CI, passes a local demo, and only surfaces as a Bot
that forgets, a question nobody can answer, or a boundary that never fires.

Answer these even when the answer is "none":

- [ ] **New state that outlives a request?** Where does it live? A `Map` or `Set` held in a module or
      a factory closure does not count as somewhere.
- [ ] **What happens on the second replica?** Name the concrete outcome, not "should be fine".
- [ ] **Anything serialised?** Say what stops two processes doing it at once. A unique index, a
      conditional update, or an advisory lock are answers. A check-then-write is not.
- [ ] **Anything fanned out to a browser?** Say how it reaches a socket held by another process.
- [ ] **New listener, port, or schedule?** Say how it is reached through the same ingress as the API,
      and what a hundred copies of it do.

Postgres is already there and is the default answer to all of the above: a table, a unique index, a
conditional update, `LISTEN`/`NOTIFY` for fan-out.

## Boundary and audit

- [ ] Every acting call still goes through the gateway: resolve, decide, audit, then act.
- [ ] New refusals and new failures each write a row.
- [ ] Nothing new is trusted from the client that the server can resolve itself.

## Changelog

- [ ] A line in `CHANGELOG.md` under `Unreleased`, or a sentence on why a deployment behaves no
      differently afterwards.

## Proof

<!-- What you ran, and what you saw. Screenshots or a recording for anything with a surface. -->
