### PR TITLE
Drop the capabilities a Bot's computer does not use, under Compose and on Kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A Bot's computer keeps no capability it does not use
+
+The supervisor starts every per-Bot computer with `CapDrop: ["ALL"]` and `no-new-privileges`, on the
+grounds that Chromium needs none of them and each is a documented container escape route. Compose and
+the Helm chart start the same image with the same command and dropped nothing, so the process that
+renders the open internet held `cap_dac_override`, `cap_net_raw`, `cap_mknod` and `cap_setuid` among
+others, with Chromium's own sandbox off.
+
+Both now match the supervisor. Nothing about a Bot's computer changes otherwise: with no capabilities
+at all it still launches Chromium, navigates, snapshots and screenshots, which was driven before this
+was written rather than assumed.
+
 ### A channel a Bot has spoken in unseen shows a dot
 
 The sidebar marks a channel when a Bot has said something since you last had it open: a dot beside

--- a/charts/openbot/templates/_helpers.tpl
+++ b/charts/openbot/templates/_helpers.tpl
@@ -325,6 +325,9 @@ be able to address the API server at all, and the default is the wrong way round
         "image" (include "openbot.image" .)
         "imagePullPolicy" .Values.image.pullPolicy
         "command" (list "/usr/local/bin/bun" "/app/agent-computer/src/index.ts")
+        "securityContext" (dict
+          "capabilities" (dict "drop" (list "ALL"))
+          "allowPrivilegeEscalation" false)
         "ports" (list (dict "name" "http" "containerPort" 4100))
         "env" (concat
           (list

--- a/charts/openbot/templates/computer/statefulset.yaml
+++ b/charts/openbot/templates/computer/statefulset.yaml
@@ -111,6 +111,11 @@ spec:
             browser process directly, so a computer pod carries no API and no database.
           */}}
           command: ["/usr/local/bin/bun", "/app/agent-computer/src/index.ts"]
+          {{- /* The drop `supervisor/src/docker.ts` already makes for every computer it starts. */}}
+          securityContext:
+            capabilities:
+              drop: ["ALL"]
+            allowPrivilegeEscalation: false
           ports:
             - name: http
               containerPort: 4100

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,11 @@ services:
       - agent-workspace:/workspace
       # Chromium's user-data directory is volume-backed so logins survive container restarts.
       - agent-profiles:/profiles
+    # The posture `supervisor/src/docker.ts` already gives every computer it starts, for the one it does not.
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     # Gives Chromium time to flush its profile after SIGTERM before Docker sends SIGKILL.
     stop_grace_period: 30s
     healthcheck:


### PR DESCRIPTION
Closes #261.

## What this changes

`supervisor/src/docker.ts:358-361` starts every per-Bot computer with `CapDrop: ["ALL"]` and `no-new-privileges:true`, because "Chromium needs none of these, and each is a documented container escape route". Compose and the Helm chart start the same image with the same command and dropped nothing, so on those two the process rendering the open internet held the runtime's full default capability set with Chromium's own sandbox off.

Both now match the supervisor. Nothing else moves: no `USER`, no change to `podSecurityContext` defaults, no new values.

## Where it runs

- [x] **New state that outlives a request?** None. Two container-security stanzas and a changelog line.
- [x] **What happens on the second replica?** Identical. A `securityContext` is per-container, so every replica of the computer StatefulSet and every per-Bot Sandbox gets the same one; there is no shared state here.
- [x] **Anything serialised?** Nothing.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** None. This removes privilege from an existing container; it opens nothing.

## Boundary and audit

- [x] Every acting call still goes through the gateway: no server code changed.
- [x] New refusals and new failures each write a row: no new refusals or failures.
- [x] Nothing new is trusted from the client: no new input reaches this.

This narrows rather than widens, so the risk is the reverse of the usual one — a capability something quietly needed. `agent-computer` was driven with all of them removed before this was written; see Proof.

## Changelog

- [x] A line in `CHANGELOG.md` under `Unreleased`.

## Proof

Measured on the image this repository builds, same command, before and after:

```
supervisor-started computer (unchanged, the reference)
  uid=0(root)   CapEff: 0000000000000000

compose agent-computer, before
  uid=0(root)   CapEff: 00000000a80425fb
  = cap_chown, cap_dac_override, cap_fowner, cap_fsetid, cap_kill, cap_setgid, cap_setuid,
    cap_setpcap, cap_net_bind_service, cap_net_raw, cap_sys_chroot, cap_mknod,
    cap_audit_write, cap_setfcap

compose agent-computer, after
  uid=0(root)   CapEff: 0000000000000000
  HostConfig.SecurityOpt ["no-new-privileges:true"]   HostConfig.CapDrop ["ALL"]
```

Then driven against that hardened container, because a capability drop that breaks the browser is worse than the gap it closes:

```
POST /navigate  https://example.com/
  {"url":"https://example.com/","title":"Example Domain","text":"Example Domain...","elapsedMs":6893}

GET /screenshot
  {"base64":"iVBORw0KGgoAAAANSUhEUgAABQAAAAMg...      (a real PNG)

ps -eo user,args
  root  /ms-playwright/chromium_headless_shell-1234/chrome-linux/headless_shell ...

GET /health  ->  200
```

Chromium launches, navigates, reads the page and screenshots it with no capabilities at all, which is what the supervisor's comment predicts and what its own computers have been doing all along.

Chart side, rendered on all five shipped `ci/` targets:

- `helm lint`: 0 failed.
- `helm template` + `bun scripts/check-rendered-chart.ts`: coherent on all five.
- Shared mode, the computer container: `capabilities.drop: ["ALL"]`, `allowPrivilegeEscalation: false`.
- Sandbox mode, the per-Bot pod template: the same two, inside the mounted `sandbox-template.json`.
- `docker compose config` still parses.

Not covered here, and worth its own change rather than being folded in: `agent-computer/Dockerfile` still declares no `USER`, so these containers run as uid 0 with no capabilities rather than as a non-root user. Doing it properly means moving bun off `/root/.bun` and settling ownership of two named volumes that arrive root-owned, which is a larger change than this one and should be reviewable on its own.
