### PR TITLE
Pin the formatter, and stop format-gating generated migrations

### DIFF
--- a/app/src/routes/_authed/admin/boundaries.tsx
+++ b/app/src/routes/_authed/admin/boundaries.tsx
@@ -301,7 +301,6 @@ function BoundariesPage() {
   );
 }
 
-
 /**
  * What the tested rule would have done to actions already on the trail.
  *

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.10/schema.json",
   "files": {
     "includes": [
       "**",
@@ -7,7 +7,8 @@
       "!.",
       "!app/src/components/ui",
       "!app/src/lib/generated/application-config.ts",
-      "!app/src/routeTree.gen.ts"
+      "!app/src/routeTree.gen.ts",
+      "!server/drizzle"
     ]
   },
   "formatter": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "mock:knowledge": "bun scripts/mock-knowledge-mcp.ts"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.8",
+    "@biomejs/biome": "2.5.10",
     "@copilotkit/aimock": "1.39.0",
     "@types/bun": "^1.3.3",
     "roughjs": "^4.6.6",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -664,7 +664,12 @@ export function createApp(
   if (auditReader && attentionStore) {
     app.route(
       "/api/attention",
-      createAttentionRoutes(auditReader, attentionStore, requireUser, canUseBot),
+      createAttentionRoutes(
+        auditReader,
+        attentionStore,
+        requireUser,
+        canUseBot,
+      ),
     );
   }
 

--- a/server/src/attention/view.ts
+++ b/server/src/attention/view.ts
@@ -47,7 +47,9 @@ const text = (value: unknown): string =>
  * "google-drive/search_files", which is not a Bot, which `canUseBot` correctly denies, which hid
  * every tool rejection from exactly the person it was for.
  */
-export function botOf(event: Pick<AuditEvent, "targetType" | "targetId" | "payload">): string {
+export function botOf(
+  event: Pick<AuditEvent, "targetType" | "targetId" | "payload">,
+): string {
   if (event.targetType === "computer" || event.targetType === "agent") {
     return event.targetId ?? text(event.payload.bot);
   }

--- a/server/src/computer/routes.ts
+++ b/server/src/computer/routes.ts
@@ -19,10 +19,7 @@ import {
 import type { PageFrameStore } from "./page-frames";
 import type { AuditReader } from "../audit";
 import { type PolicyStore, parseActionPolicy } from "./policy-store";
-import {
-  dryRunAgainstHistory,
-  REPLAYABLE_EVENT_TYPES,
-} from "./policy-dry-run";
+import { dryRunAgainstHistory, REPLAYABLE_EVENT_TYPES } from "./policy-dry-run";
 
 /**
  * The Bot computer's surface, behind the same session guard as every other API route.
@@ -672,7 +669,9 @@ export function createComputerRoutes(
       targetType: "computer",
     });
 
-    return context.json({ report: dryRunAgainstHistory(parsed.policy, events) });
+    return context.json({
+      report: dryRunAgainstHistory(parsed.policy, events),
+    });
   });
 
   return routes;

--- a/server/src/db/schema/attention.ts
+++ b/server/src/db/schema/attention.ts
@@ -1,4 +1,10 @@
-import { pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import {
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
 
 /**
  * A trail row somebody has marked handled.

--- a/server/tests/attention-view.test.ts
+++ b/server/tests/attention-view.test.ts
@@ -13,7 +13,10 @@ function event(overrides: Partial<AuditEvent>): AuditEvent {
     actorUserId: null,
     eventType: overrides.eventType ?? "computer.action_refused",
     targetType: overrides.targetType ?? "computer",
-    targetId: overrides.targetId === undefined ? "general-assistant" : overrides.targetId,
+    targetId:
+      overrides.targetId === undefined
+        ? "general-assistant"
+        : overrides.targetId,
     payload: overrides.payload ?? {},
     createdAt: overrides.createdAt ?? "2026-08-25T00:00:00.000Z",
   };
@@ -33,7 +36,9 @@ describe("attentionItemsFrom", () => {
     );
     expect(items).toHaveLength(1);
     expect(items[0]?.kind).toBe("refused");
-    expect(items[0]?.sentence).toBe("“Submit order” on shop.example is blocked.");
+    expect(items[0]?.sentence).toBe(
+      "“Submit order” on shop.example is blocked.",
+    );
     expect(items[0]?.botId).toBe("general-assistant");
   });
 

--- a/server/tests/computer-policy.test.ts
+++ b/server/tests/computer-policy.test.ts
@@ -620,7 +620,6 @@ describe("a rule about one surface does not refuse another", () => {
   });
 });
 
-
 describe("refusal wording under the context the gateway actually builds", () => {
   /*
    * The gateway attaches a neutral all-empty `mcp` to every browser context so a rule naming
@@ -630,7 +629,11 @@ describe("refusal wording under the context the gateway actually builds", () => 
    */
   test("a browser refusal names the element, neutral mcp notwithstanding", () => {
     const decision = evaluateActionPolicy(
-      { mode: "enforce", deny: ['contains(element.name, "Submit")'], allow: ["true"] },
+      {
+        mode: "enforce",
+        deny: ['contains(element.name, "Submit")'],
+        allow: ["true"],
+      },
       {
         tool: { name: "computer_click" },
         bot: { id: "general-assistant" },


### PR DESCRIPTION
Main has been red since Biome 2.5.10 landed: `@biomejs/biome` was a caret range, so a release changed what CI considers correctly formatted without anybody committing anything. Every branch opened against main fails the same check.

Pinned to the version already in the lockfile, with the schema reference and the nine files it wants brought into line.

`server/drizzle` is generated by drizzle-kit and now excluded from formatting. Reformatting a migration snapshot is a few hundred lines of diff that says nothing, on files whose whole point is that they match what the tool wrote.