### PR TITLE
Answer an ADK agent's sign-in request with a consent card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### An ADK agent can now ask the person to sign in
+
+A remote agent built on Google ADK that holds a per-user tool — an MCP server with OAuth, say —
+asks for the person's own sign-in by suspending its run on an `adk_request_credential` tool call.
+OpenBot previously drew that as an inert tool line and the conversation hung there. It is now a
+consent card: the card names the provider and the scopes, the person signs in with the provider in
+a popup or declines, and either answer resumes the run.
+
+The sign-in happens with the provider directly. OpenBot's part is a static callback page at
+`/api/agents/oauth/callback` that hands the provider's answer back to the waiting tab; the agent
+redeems the code on its own side, and no token, password, or connection state is stored in OpenBot.
+The callback address must be registered as a redirect URI on the OAuth client the agent uses — see
+`docs/coworkers.md`.
+
 ### A Bot in trouble no longer needs somebody watching
 
 A boundary refusal or a stalled run was recorded and then waited for a person to happen to look — at

--- a/app/src/components/agents/consent-card.tsx
+++ b/app/src/components/agents/consent-card.tsx
@@ -1,0 +1,270 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Badge, GalleryFrame } from "@/components/gallery/frame";
+import { Button } from "@/components/ui/button";
+import {
+  AGENT_OAUTH_CALLBACK_MESSAGE,
+  AGENT_OAUTH_CALLBACK_PATH,
+  callbackMatches,
+  completedAuthConfig,
+  consentUrl,
+  type CredentialRequest,
+  readConnectionOutcome,
+  readCredentialRequest,
+} from "@/lib/copilot/adk-credential";
+
+/**
+ * A remote agent asking to act as this person somewhere else.
+ *
+ * The card names the provider and what is asked for, and the person either signs in or declines.
+ * Sign-in happens in a popup rather than by leaving the page: the run that asked is suspended in
+ * this tab, and navigating away would abandon it. The popup ends on our own callback page, which
+ * posts the provider's answer back here (see the callback route in server/src/agents/routes.ts);
+ * the answer resumes the run, and the agent exchanges it for a token on its own side. No token
+ * ever reaches this card.
+ */
+
+type Waiting =
+  | {
+      status: "inProgress";
+      args: Record<string, unknown>;
+      respond: undefined;
+      result: undefined;
+    }
+  | {
+      status: "executing";
+      args: Record<string, unknown>;
+      respond: (result: unknown) => Promise<void>;
+      result: undefined;
+    }
+  | {
+      status: "complete";
+      args: Record<string, unknown>;
+      respond: undefined;
+      result: string;
+    };
+
+const TITLE = "Sign in for this agent";
+
+export function AgentConsentCard(props: Waiting) {
+  const request = readCredentialRequest(props.args);
+
+  if (props.status === "inProgress") {
+    return (
+      <GalleryFrame title={TITLE}>
+        <p className="text-sm text-muted-foreground">Preparing the request…</p>
+      </GalleryFrame>
+    );
+  }
+
+  if (props.status === "complete") {
+    const outcome = readConnectionOutcome(props.result);
+    return (
+      <GalleryFrame
+        action={
+          outcome === "connected" ? (
+            <Badge tone="positive">Signed in</Badge>
+          ) : outcome === "declined" ? (
+            <Badge tone="negative">Declined</Badge>
+          ) : undefined
+        }
+        title={TITLE}
+      >
+        <p className="text-sm text-muted-foreground">
+          {request
+            ? outcome === "connected"
+              ? `You signed in with ${request.provider} for this agent.`
+              : `The agent asked you to sign in with ${request.provider}.`
+            : "The agent asked for a sign-in."}
+        </p>
+      </GalleryFrame>
+    );
+  }
+
+  if (!request) {
+    return <UnanswerableRequest args={props.args} respond={props.respond} />;
+  }
+
+  return <ConsentPrompt request={request} respond={props.respond} />;
+}
+
+function ConsentPrompt({
+  request,
+  respond,
+}: {
+  request: CredentialRequest;
+  respond: (result: unknown) => Promise<void>;
+}) {
+  const [phase, setPhase] = useState<
+    "idle" | "waiting" | "abandoned" | "blocked" | "sending"
+  >("idle");
+  const popup = useRef<Window | null>(null);
+  // One redirect for the whole exchange: the provider must be told the same address during sign-in
+  // and during the agent's later token exchange, so it is minted once and travels into both.
+  const redirectUri = useRef<string>(
+    `${window.location.origin}${AGENT_OAUTH_CALLBACK_PATH}`,
+  );
+
+  const finish = useCallback(
+    async (callbackUrl: string) => {
+      setPhase("sending");
+      popup.current?.close();
+      await respond(
+        completedAuthConfig(
+          request.authConfig,
+          callbackUrl,
+          redirectUri.current,
+        ),
+      );
+    },
+    [request, respond],
+  );
+
+  // The callback page posts to whoever opened it. Same origin only, matched to this request by the
+  // OAuth state, so two waiting cards cannot take each other's answer.
+  useEffect(() => {
+    if (phase !== "waiting") return;
+    const heard = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      const data = event.data as { type?: unknown; url?: unknown } | null;
+      if (data?.type !== AGENT_OAUTH_CALLBACK_MESSAGE) return;
+      if (typeof data.url !== "string") return;
+      if (!callbackMatches(data.url, request.state)) return;
+      void finish(data.url);
+    };
+    window.addEventListener("message", heard);
+    // A closed popup means the person walked away from the provider's page. The card says so and
+    // offers the button again rather than waiting forever on a window that no longer exists.
+    const watch = window.setInterval(() => {
+      if (popup.current?.closed) {
+        setPhase((current) => (current === "waiting" ? "abandoned" : current));
+      }
+    }, 1000);
+    return () => {
+      window.removeEventListener("message", heard);
+      window.clearInterval(watch);
+    };
+  }, [phase, request.state, finish]);
+
+  const connect = () => {
+    const opened = window.open(
+      consentUrl(request, redirectUri.current),
+      "openbot-agent-consent",
+      "popup,width=480,height=720",
+    );
+    if (!opened) {
+      setPhase("blocked");
+      return;
+    }
+    popup.current = opened;
+    setPhase("waiting");
+  };
+
+  const decline = async () => {
+    setPhase("sending");
+    // The config goes back exactly as it came. With no answer URL inside, the agent's exchange
+    // finds nothing to redeem and the tool fails with an auth error it can tell the person about.
+    await respond(request.authConfig);
+  };
+
+  return (
+    <GalleryFrame
+      action={<Badge tone="caution">Waiting on you</Badge>}
+      title={TITLE}
+    >
+      <p className="text-sm">
+        This agent asks you to sign in with{" "}
+        <span className="font-medium">{request.provider}</span> so it can act on
+        your behalf there.
+      </p>
+
+      {request.scopes.length > 0 ? (
+        <ul className="mt-2 space-y-1">
+          {request.scopes.map((scope) => (
+            <li className="text-xs text-muted-foreground" key={scope}>
+              {scope}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {phase === "abandoned" ? (
+        <p className="mt-2 text-xs text-muted-foreground">
+          The sign-in window was closed before finishing. You can try again.
+        </p>
+      ) : null}
+      {phase === "blocked" ? (
+        <p className="mt-2 text-xs text-muted-foreground">
+          The browser blocked the sign-in window. Allow popups for this site and
+          try again.
+        </p>
+      ) : null}
+
+      <div className="mt-4 flex gap-2">
+        <Button
+          disabled={phase === "waiting" || phase === "sending"}
+          onClick={connect}
+          size="sm"
+        >
+          {phase === "waiting"
+            ? "Waiting for sign-in…"
+            : phase === "sending"
+              ? "Sending…"
+              : `Sign in with ${request.provider}`}
+        </Button>
+        <Button
+          disabled={phase === "sending"}
+          onClick={() => void decline()}
+          size="sm"
+          variant="outline"
+        >
+          Decline
+        </Button>
+      </div>
+    </GalleryFrame>
+  );
+}
+
+/**
+ * A request the card cannot act on: no authorization URL to send anybody to.
+ *
+ * The run is still suspended on this call, so it must be answered to let the conversation
+ * continue. What came in goes back unchanged — the agent's own parser recognizes its own config,
+ * and a made-up shape would fail inside the agent instead of in front of the person.
+ */
+function UnanswerableRequest({
+  args,
+  respond,
+}: {
+  args: Record<string, unknown>;
+  respond: (result: unknown) => Promise<void>;
+}) {
+  const [sending, setSending] = useState(false);
+  const echo =
+    (args.authConfig as Record<string, unknown> | undefined) ??
+    (args.auth_config as Record<string, unknown> | undefined) ??
+    args;
+  return (
+    <GalleryFrame
+      action={<Badge tone="negative">Cannot sign in</Badge>}
+      title={TITLE}
+    >
+      <p className="text-sm text-muted-foreground">
+        The agent asked for a sign-in but did not say where. Dismissing tells it
+        no sign-in happened.
+      </p>
+      <div className="mt-4">
+        <Button
+          disabled={sending}
+          onClick={() => {
+            setSending(true);
+            void respond(echo);
+          }}
+          size="sm"
+          variant="outline"
+        >
+          {sending ? "Sending…" : "Dismiss"}
+        </Button>
+      </div>
+    </GalleryFrame>
+  );
+}

--- a/app/src/lib/copilot/adk-credential.ts
+++ b/app/src/lib/copilot/adk-credential.ts
@@ -1,0 +1,218 @@
+/**
+ * The credential request an ADK agent makes, read defensively.
+ *
+ * A remote agent built on Google ADK asks for a person's own sign-in by emitting a tool call named
+ * `adk_request_credential` and pausing its run. The arguments carry an `authConfig`: the OAuth
+ * authorization URL the person must visit, and room for the answer. The client's half of the
+ * contract is to send that same `authConfig` back as the tool result with `authResponseUri` (the
+ * full callback URL the provider redirected to) and `redirectUri` (where we asked it to redirect)
+ * filled in; the agent then exchanges the code for a token on its own side. The token itself never
+ * passes through here.
+ *
+ * ADK serializes with camelCase aliases, but other stacks dump the same models in snake_case, so
+ * everything is read in both spellings and answers are written back in the spelling that arrived.
+ */
+
+/** The path the consent popup returns to. The server serves a static page at this address. */
+export const AGENT_OAUTH_CALLBACK_PATH = "/api/agents/oauth/callback";
+
+/** The `type` of the message that page posts to its opener. */
+export const AGENT_OAUTH_CALLBACK_MESSAGE = "openbot:agent-oauth-callback";
+
+type Json = Record<string, unknown>;
+
+export type CredentialRequest = {
+  /** The whole config as it arrived, echoed back verbatim on decline and completed on consent. */
+  authConfig: Json;
+  /** Where the person signs in. The provider's consent page, built by the agent. */
+  authorizationUrl: string;
+  /** The state the agent minted into that URL, used to match the callback to this request. */
+  state: string | undefined;
+  /** The host asking for the sign-in, e.g. accounts.google.com. For display. */
+  provider: string;
+  /** What is being asked for, when the request says. For display. */
+  scopes: string[];
+};
+
+function asObject(value: unknown): Json | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Json)
+    : undefined;
+}
+
+/** Read a field in whichever spelling the sender used. An explicit camelCase value wins. */
+function pick(object: Json | undefined, camel: string, snake: string): unknown {
+  if (!object) return undefined;
+  return object[camel] !== undefined ? object[camel] : object[snake];
+}
+
+function oauth2Of(authConfig: Json): Json | undefined {
+  const exchanged = asObject(
+    pick(authConfig, "exchangedAuthCredential", "exchanged_auth_credential"),
+  );
+  return asObject(exchanged?.oauth2);
+}
+
+/**
+ * Read the tool call's arguments into a request, or nothing when they do not carry one.
+ *
+ * Arguments stream in, so an incomplete object is the normal in-progress state rather than an
+ * error; the card shows a placeholder until this returns something.
+ */
+export function readCredentialRequest(
+  args: unknown,
+): CredentialRequest | undefined {
+  const authConfig = asObject(
+    pick(asObject(args), "authConfig", "auth_config"),
+  );
+  if (!authConfig) return undefined;
+
+  const authUri = pick(oauth2Of(authConfig), "authUri", "auth_uri");
+  if (typeof authUri !== "string" || !authUri) return undefined;
+
+  let url: URL;
+  try {
+    url = new URL(authUri);
+  } catch {
+    return undefined;
+  }
+  // Only somewhere a person can actually sign in. A javascript: or data: "URL" is not that.
+  if (url.protocol !== "https:" && url.protocol !== "http:") return undefined;
+
+  return {
+    authConfig,
+    authorizationUrl: url.toString(),
+    state: url.searchParams.get("state") ?? undefined,
+    provider: url.hostname,
+    scopes: readScopes(authConfig),
+  };
+}
+
+/**
+ * What the request asks to reach, pulled from wherever the auth scheme keeps it.
+ *
+ * OAuth2 schemes name scopes per flow as `{scope: description}`; OpenID Connect configs carry a
+ * plain list. Both appear in the wild, so both are read, and an empty answer just means the card
+ * shows none rather than guessing.
+ */
+function readScopes(authConfig: Json): string[] {
+  const scheme = asObject(pick(authConfig, "authScheme", "auth_scheme"));
+  const found: string[] = [];
+
+  const flows = asObject(scheme?.flows);
+  for (const flowName of [
+    "authorizationCode",
+    "authorization_code",
+    "implicit",
+    "password",
+    "clientCredentials",
+    "client_credentials",
+  ]) {
+    const scopes = asObject(asObject(flows?.[flowName])?.scopes);
+    if (scopes) found.push(...Object.keys(scopes));
+  }
+
+  const listed = scheme?.scopes;
+  if (Array.isArray(listed)) {
+    found.push(
+      ...listed.filter((scope): scope is string => typeof scope === "string"),
+    );
+  }
+
+  return [...new Set(found)];
+}
+
+/**
+ * The URL the person is sent to, with our callback as the redirect.
+ *
+ * The agent's URL usually has no `redirect_uri` because the agent cannot know where its client
+ * lives; when it names one anyway it is replaced, because the provider will only ever redirect a
+ * browser of ours to an address of ours.
+ */
+export function consentUrl(
+  request: CredentialRequest,
+  redirectUri: string,
+): string {
+  const url = new URL(request.authorizationUrl);
+  url.searchParams.set("redirect_uri", redirectUri);
+  return url.toString();
+}
+
+/**
+ * Whether a callback URL answers this request, decided by the `state` the agent minted.
+ *
+ * Two consent cards can wait at once, and both hear every message the callback page posts. The
+ * state is the correlation the OAuth flow already carries, so it is the one used here too. A
+ * request without state accepts any callback: there is nothing to compare, and refusing would
+ * strand the person who just signed in.
+ */
+export function callbackMatches(
+  callbackUrl: string,
+  state: string | undefined,
+): boolean {
+  if (state === undefined) return true;
+  try {
+    return new URL(callbackUrl).searchParams.get("state") === state;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The tool result that says yes: the config as it arrived, plus where the provider sent the
+ * browser back. Written in the sender's own spelling so its parser recognizes its own model, and
+ * into a copy, because the original is render state.
+ */
+export function completedAuthConfig(
+  authConfig: Json,
+  callbackUrl: string,
+  redirectUri: string,
+): Json {
+  const completed = structuredClone(authConfig);
+
+  const exchangedKey =
+    "exchanged_auth_credential" in completed &&
+    !("exchangedAuthCredential" in completed)
+      ? "exchanged_auth_credential"
+      : "exchangedAuthCredential";
+  let exchanged = asObject(completed[exchangedKey]);
+  if (!exchanged) {
+    exchanged = {};
+    completed[exchangedKey] = exchanged;
+  }
+  let oauth2 = asObject(exchanged.oauth2);
+  if (!oauth2) {
+    oauth2 = {};
+    exchanged.oauth2 = oauth2;
+  }
+
+  const snake = "auth_uri" in oauth2 && !("authUri" in oauth2);
+  oauth2[snake ? "auth_response_uri" : "authResponseUri"] = callbackUrl;
+  oauth2[snake ? "redirect_uri" : "redirectUri"] = redirectUri;
+
+  return completed;
+}
+
+/**
+ * What a completed card should say, recovered from the serialized tool result.
+ *
+ * A result carrying an answer URL was a sign-in; the same config echoed without one was a decline.
+ * Anything unreadable gets no badge rather than a wrong one.
+ */
+export function readConnectionOutcome(
+  result: string | undefined,
+): "connected" | "declined" | undefined {
+  if (!result) return undefined;
+  try {
+    const parsed = asObject(JSON.parse(result));
+    if (!parsed) return undefined;
+    const answer = pick(
+      oauth2Of(parsed),
+      "authResponseUri",
+      "auth_response_uri",
+    );
+    return typeof answer === "string" && answer ? "connected" : "declined";
+  } catch {
+    return undefined;
+  }
+}

--- a/app/src/lib/copilot/agent-credential-tools.tsx
+++ b/app/src/lib/copilot/agent-credential-tools.tsx
@@ -1,0 +1,31 @@
+import { useHumanInTheLoop } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+import { AgentConsentCard } from "@/components/agents/consent-card";
+
+/**
+ * The sign-in a remote ADK agent asks for, answered by the person.
+ *
+ * Google ADK agents behind an AG-UI endpoint pause their run and emit a tool call named
+ * `adk_request_credential` when a tool of theirs needs the person's own account (a per-user OAuth
+ * MCP server, for instance). The name is ADK's, not ours; registering it here is what routes that
+ * call to a consent card instead of the generic tool line, and what routes the person's answer
+ * back as the tool result that resumes the run.
+ *
+ * `available: false` is the other half: the agent originates this call itself, so the model must
+ * never be offered it as something to invoke. The registration exists to answer, not to advertise.
+ */
+export function AgentCredentialTools() {
+  useHumanInTheLoop({
+    name: "adk_request_credential",
+    description:
+      "Answered by the person when an ADK agent asks for their sign-in. Never offered to the model.",
+    // The arguments are ADK's own AuthConfig, streamed in as the agent built it. The card reads it
+    // defensively; a schema strict enough to be worth having would just be a second copy of ADK.
+    parameters: z.record(z.string(), z.unknown()),
+    available: false,
+    render: AgentConsentCard as Parameters<
+      typeof useHumanInTheLoop
+    >[0]["render"],
+  });
+  return null;
+}

--- a/app/src/lib/copilot/provider.tsx
+++ b/app/src/lib/copilot/provider.tsx
@@ -1,6 +1,7 @@
 import { CopilotKitProvider } from "@copilotkit/react-core/v2";
 import type { ReactNode } from "react";
 import { ActiveBotProvider } from "./active-bot";
+import { AgentCredentialTools } from "./agent-credential-tools";
 import { ComputerTools } from "./computer-tools";
 import { GalleryTools } from "./gallery-tools";
 import { SandboxedTools } from "./sandboxed-tools";
@@ -29,6 +30,8 @@ export function CopilotProvider({ children }: { children: ReactNode }) {
         <GalleryTools />
         {/* Browser-authored components use the same component grants as the compiled gallery. */}
         <SandboxedTools />
+        {/* Consent cards for remote ADK agents asking for the person's own sign-in. */}
+        <AgentCredentialTools />
         {children}
       </ActiveBotProvider>
     </CopilotKitProvider>

--- a/app/tests/adk-credential.test.ts
+++ b/app/tests/adk-credential.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import {
+  callbackMatches,
+  completedAuthConfig,
+  consentUrl,
+  readConnectionOutcome,
+  readCredentialRequest,
+} from "../src/lib/copilot/adk-credential";
+
+/**
+ * The contract with ADK, exercised in both of its spellings.
+ *
+ * ADK serializes its models with camelCase aliases, but the same models dumped without aliases
+ * arrive in snake_case, and the card must answer in whichever spelling the agent will recognize as
+ * its own. The fixtures mirror what `ag-ui-adk` actually streams: `{functionCallId, authConfig}`
+ * with the consent URL inside the exchanged credential.
+ */
+
+const AUTH_URI =
+  "https://accounts.google.com/o/oauth2/v2/auth?client_id=abc&response_type=code&state=xyz-123";
+
+function camelArgs() {
+  return {
+    functionCallId: "call-1",
+    authConfig: {
+      authScheme: {
+        type: "oauth2",
+        flows: {
+          authorizationCode: {
+            scopes: {
+              "https://www.googleapis.com/auth/spreadsheets": "Sheets",
+              openid: "OpenID",
+            },
+          },
+        },
+      },
+      exchangedAuthCredential: {
+        authType: "oauth2",
+        oauth2: { authUri: AUTH_URI, clientId: "abc", clientSecret: "shh" },
+      },
+      credentialKey: "adk_key",
+    },
+  };
+}
+
+function snakeArgs() {
+  return {
+    function_call_id: "call-1",
+    auth_config: {
+      auth_scheme: { type: "openIdConnect", scopes: ["openid", "email"] },
+      exchanged_auth_credential: {
+        auth_type: "oauth2",
+        oauth2: { auth_uri: AUTH_URI, client_id: "abc" },
+      },
+    },
+  };
+}
+
+describe("reading the request", () => {
+  test("camelCase, as ADK serializes it", () => {
+    const request = readCredentialRequest(camelArgs());
+    expect(request).toBeDefined();
+    expect(request?.authorizationUrl).toBe(AUTH_URI);
+    expect(request?.provider).toBe("accounts.google.com");
+    expect(request?.state).toBe("xyz-123");
+    expect(request?.scopes).toEqual([
+      "https://www.googleapis.com/auth/spreadsheets",
+      "openid",
+    ]);
+  });
+
+  test("snake_case, as the same models dump without aliases", () => {
+    const request = readCredentialRequest(snakeArgs());
+    expect(request?.authorizationUrl).toBe(AUTH_URI);
+    expect(request?.scopes).toEqual(["openid", "email"]);
+  });
+
+  test("arguments still streaming in are not yet a request", () => {
+    expect(readCredentialRequest(undefined)).toBeUndefined();
+    expect(readCredentialRequest({})).toBeUndefined();
+    expect(readCredentialRequest({ authConfig: {} })).toBeUndefined();
+    expect(
+      readCredentialRequest({ authConfig: { exchangedAuthCredential: {} } }),
+    ).toBeUndefined();
+  });
+
+  test("a consent 'URL' that is not somewhere to sign in is refused", () => {
+    const args = camelArgs();
+    args.authConfig.exchangedAuthCredential.oauth2.authUri =
+      "javascript:alert(1)";
+    expect(readCredentialRequest(args)).toBeUndefined();
+  });
+});
+
+describe("building the consent URL", () => {
+  test("our callback becomes the redirect and the rest survives", () => {
+    const request = readCredentialRequest(camelArgs());
+    if (!request) throw new Error("fixture did not parse");
+    const url = new URL(
+      consentUrl(request, "https://openbot.example/api/agents/oauth/callback"),
+    );
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://openbot.example/api/agents/oauth/callback",
+    );
+    expect(url.searchParams.get("state")).toBe("xyz-123");
+    expect(url.searchParams.get("client_id")).toBe("abc");
+  });
+
+  test("a redirect the agent guessed at is replaced, not joined", () => {
+    const args = camelArgs();
+    args.authConfig.exchangedAuthCredential.oauth2.authUri = `${AUTH_URI}&redirect_uri=https%3A%2F%2Felsewhere.example%2Fcb`;
+    const request = readCredentialRequest(args);
+    if (!request) throw new Error("fixture did not parse");
+    const url = new URL(consentUrl(request, "https://openbot.example/cb"));
+    expect(url.searchParams.getAll("redirect_uri")).toEqual([
+      "https://openbot.example/cb",
+    ]);
+  });
+});
+
+describe("matching the callback to its request", () => {
+  test("the state the agent minted is the correlation", () => {
+    expect(
+      callbackMatches(
+        "https://openbot.example/cb?code=c&state=xyz-123",
+        "xyz-123",
+      ),
+    ).toBe(true);
+    expect(
+      callbackMatches(
+        "https://openbot.example/cb?code=c&state=other",
+        "xyz-123",
+      ),
+    ).toBe(false);
+  });
+
+  test("a request without state accepts the answer it gets", () => {
+    expect(
+      callbackMatches("https://openbot.example/cb?code=c", undefined),
+    ).toBe(true);
+  });
+
+  test("an unparseable callback matches nothing", () => {
+    expect(callbackMatches("not a url", "xyz-123")).toBe(false);
+  });
+});
+
+describe("completing the config", () => {
+  test("answer fields land beside the credential, in its own spelling", () => {
+    const { authConfig } = camelArgs();
+    const completed = completedAuthConfig(
+      authConfig,
+      "https://openbot.example/cb?code=c&state=xyz-123",
+      "https://openbot.example/cb",
+    ) as typeof authConfig & {
+      exchangedAuthCredential: {
+        oauth2: Record<string, unknown>;
+      };
+    };
+    expect(completed.exchangedAuthCredential.oauth2.authResponseUri).toBe(
+      "https://openbot.example/cb?code=c&state=xyz-123",
+    );
+    expect(completed.exchangedAuthCredential.oauth2.redirectUri).toBe(
+      "https://openbot.example/cb",
+    );
+    // Everything the agent needs to redeem the code rides along untouched.
+    expect(completed.exchangedAuthCredential.oauth2.clientId).toBe("abc");
+    expect(completed.credentialKey).toBe("adk_key");
+  });
+
+  test("a snake_case config is answered in snake_case", () => {
+    const authConfig = snakeArgs().auth_config;
+    const completed = completedAuthConfig(
+      authConfig,
+      "https://openbot.example/cb?code=c",
+      "https://openbot.example/cb",
+    ) as Record<string, { oauth2: Record<string, unknown> }>;
+    expect(completed.exchanged_auth_credential.oauth2.auth_response_uri).toBe(
+      "https://openbot.example/cb?code=c",
+    );
+    expect(completed.exchanged_auth_credential.oauth2.redirect_uri).toBe(
+      "https://openbot.example/cb",
+    );
+  });
+
+  test("the original is render state and is left alone", () => {
+    const { authConfig } = camelArgs();
+    completedAuthConfig(
+      authConfig,
+      "https://cb.example/?code=c",
+      "https://cb.example/",
+    );
+    expect(
+      (authConfig.exchangedAuthCredential.oauth2 as Record<string, unknown>)
+        .authResponseUri,
+    ).toBeUndefined();
+  });
+});
+
+describe("reading a completed card's outcome", () => {
+  test("an answer URL inside means signed in", () => {
+    const completed = completedAuthConfig(
+      camelArgs().authConfig,
+      "https://cb.example/?code=c",
+      "https://cb.example/",
+    );
+    expect(readConnectionOutcome(JSON.stringify(completed))).toBe("connected");
+  });
+
+  test("the config echoed back untouched means declined", () => {
+    expect(readConnectionOutcome(JSON.stringify(camelArgs().authConfig))).toBe(
+      "declined",
+    );
+  });
+
+  test("anything unreadable gets no badge rather than a wrong one", () => {
+    expect(readConnectionOutcome(undefined)).toBeUndefined();
+    expect(readConnectionOutcome("not json")).toBeUndefined();
+    expect(readConnectionOutcome('"a string"')).toBeUndefined();
+  });
+});

--- a/docs/coworkers.md
+++ b/docs/coworkers.md
@@ -93,6 +93,26 @@ Endpoint registration uses target checks. Cloud metadata addresses are refused u
 
 `POST /api/agents/test-connection` checks whether an endpoint answers before saving it.
 
+## Per-user sign-in for ADK agents
+
+An agent built on Google ADK can hold tools that act as the person talking to it — an MCP server
+with per-user OAuth, for instance. When such a tool runs for the first time, the agent suspends its
+run and emits a tool call named `adk_request_credential` carrying the provider's consent URL.
+OpenBot renders that as a consent card in the transcript: the person signs in with the provider in
+a popup, or declines, and either answer resumes the run. The agent exchanges the authorization code
+for a token on its own side; neither the token nor the person's password ever passes through
+OpenBot, and nothing about the connection is stored here — the credential lives with the agent.
+
+One thing is the deployment operator's to do: the popup returns to
+`https://<your-openbot>/api/agents/oauth/callback`, and OAuth providers only redirect to addresses
+they have been told about. Register that URL as a redirect URI on the OAuth client the agent uses
+(for a Google client, under *Authorized redirect URIs*; for a server supporting dynamic client
+registration, at registration time). A consent popup that ends on the provider's
+`redirect_uri_mismatch` page means this step is missing.
+
+Declining sends the request back unanswered: the agent's tool fails to authenticate and the agent
+says so, rather than the conversation hanging on a question nobody answered.
+
 ## Capabilities
 
 A coworker's role does not grant capabilities. Capabilities are governed separately:

--- a/server/src/agents/routes.ts
+++ b/server/src/agents/routes.ts
@@ -193,6 +193,29 @@ export function createAgentRoutes(
     return context.json({ recorded: true });
   });
 
+  /**
+   * Where a remote agent's OAuth consent popup lands.
+   *
+   * A remote ADK agent asking for the person's own sign-in suspends its run on an
+   * `adk_request_credential` tool call; the app opens the provider's consent page in a popup with
+   * this address as the redirect. The provider sends the browser back here with the authorization
+   * code in the URL, and this page's only job is to carry that URL to the tab that is waiting —
+   * it posts `location.href` to its opener and closes. The agent redeems the code on its own side;
+   * this server never touches it.
+   *
+   * Deliberately not behind `requireUser`: the browser arrives on a cross-site redirect, and the
+   * page acts for nobody — it holds no session, calls no store, and reflects nothing from the
+   * request into the markup, so there is nothing here to protect or to inject into. The message
+   * goes only to this page's own origin, so a foreign site that opens this URL itself hears
+   * nothing back.
+   *
+   * The address must be registered as a redirect URI with the OAuth client the agent uses; see
+   * docs/coworkers.md.
+   */
+  routes.get("/oauth/callback", (context) =>
+    context.html(AGENT_OAUTH_CALLBACK_PAGE),
+  );
+
   routes.get("/", requireUser, async (context) => {
     try {
       const hidden = context.req.query("hidden") === "true";
@@ -442,6 +465,36 @@ export function createAgentRoutes(
 
   return routes;
 }
+
+/**
+ * Static on purpose. The interesting values — code and state — stay in the URL, which the script
+ * reads from its own `location` rather than having the server print into the page, so nothing a
+ * provider (or anybody else) appends to the query string can become markup. The message `type`
+ * is matched by the consent card; see app/src/lib/copilot/adk-credential.ts.
+ */
+const AGENT_OAUTH_CALLBACK_PAGE = `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Sign-in complete</title></head>
+<body>
+<p>Returning you to OpenBot…</p>
+<script>
+  (function () {
+    var note = document.querySelector("p");
+    if (window.opener) {
+      window.opener.postMessage(
+        { type: "openbot:agent-oauth-callback", url: window.location.href },
+        window.location.origin
+      );
+      note.textContent = "Signed in. You can close this window.";
+      window.setTimeout(function () { window.close(); }, 50);
+    } else {
+      note.textContent =
+        "This page only makes sense as a sign-in popup. You can close it.";
+    }
+  })();
+</script>
+</body>
+</html>`;
 
 function boundedText(
   value: unknown,

--- a/server/tests/agent-oauth-callback.test.ts
+++ b/server/tests/agent-oauth-callback.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import type { MiddlewareHandler } from "hono";
+import { Hono } from "hono";
+import type { AgentProfileStore } from "../src/agents/profile-store";
+import { createAgentRoutes } from "../src/agents/routes";
+import type { AppVariables } from "../src/auth/guards";
+
+/**
+ * The page a remote agent's OAuth consent popup lands on.
+ *
+ * Its whole contract is to be inert: no session, no store, and above all no reflection — the
+ * authorization code and state arrive in the query string, and the page must carry them to its
+ * opener via its own `location` without the server ever printing them into markup.
+ */
+
+/** The route touches nothing, and a store that proves it by exploding is the cheapest fake. */
+const untouchedStore = new Proxy({} as AgentProfileStore, {
+  get(_target, property) {
+    throw new Error(
+      `The callback page must not touch the store (${String(property)}).`,
+    );
+  },
+});
+
+const noSession: MiddlewareHandler<{ Variables: AppVariables }> = async () => {
+  throw new Error("The callback page must not require a session.");
+};
+
+function app() {
+  const routes = new Hono<{ Variables: AppVariables }>();
+  routes.route("/", createAgentRoutes(untouchedStore, noSession));
+  return routes;
+}
+
+describe("the agent OAuth callback page", () => {
+  test("answers without a session and without the store", async () => {
+    const response = await app().request(
+      "/oauth/callback?code=secret-code&state=xyz-123",
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/html");
+  });
+
+  test("reflects nothing from the query string", async () => {
+    const marker = "<script>alert(1)</script>";
+    const response = await app().request(
+      `/oauth/callback?code=secret-code-value&state=${encodeURIComponent(marker)}`,
+    );
+    const page = await response.text();
+    expect(page).not.toContain(marker);
+    expect(page).not.toContain("secret-code-value");
+  });
+
+  test("posts to its opener, and only to its own origin", async () => {
+    const page = await (await app().request("/oauth/callback?code=c")).text();
+    expect(page).toContain("window.opener.postMessage");
+    expect(page).toContain("openbot:agent-oauth-callback");
+    // The origin argument is the page's own, never *: a foreign opener hears nothing.
+    expect(page).toContain("window.location.origin");
+    expect(page).not.toMatch(/postMessage\([^)]*"\*"/);
+  });
+
+  test("does not shadow fetching an agent by id", async () => {
+    // "/:agentId" and "/oauth/callback" share a prefix; the static path must win only for itself.
+    const routes = new Hono<{ Variables: AppVariables }>();
+    const anyStore = {
+      async get() {
+        return null;
+      },
+    } as unknown as AgentProfileStore;
+    const allowAnyone: MiddlewareHandler<{ Variables: AppVariables }> = async (
+      context,
+      next,
+    ) => {
+      context.set("actor", {
+        id: "user-1",
+        email: "member@openbot.test",
+        role: "user",
+      });
+      await next();
+    };
+    routes.route("/", createAgentRoutes(anyStore, allowAnyone));
+    const response = await routes.request("/some-agent");
+    expect(response.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## What this changes

A remote agent built on Google ADK that holds a per-user tool — an MCP server with OAuth, say — asks for the person's own sign-in by suspending its run on a tool call named `adk_request_credential`. OpenBot drew that as an inert tool line, and the conversation hung there: nobody could answer, and the run never resumed.

It is now a consent card. The card names the provider and the scopes being asked for; the person signs in with the provider in a popup or declines; either answer resumes the run. The agent redeems the authorization code for a token on its own side — no token, password, or connection state ever reaches or is stored in OpenBot.

How it works, in the shape the codebase already has:

- **`app/src/lib/copilot/agent-credential-tools.tsx`** registers `adk_request_credential` with `useHumanInTheLoop`, exactly like the gallery's decision cards: the person's answer IS the tool result. `available: false` is load-bearing — the agent originates this call itself, so the model must never be offered it as something to invoke; the registration exists to answer, not to advertise.
- **`app/src/components/agents/consent-card.tsx`** renders the request. Sign-in opens the provider's consent URL in a popup rather than a redirect, because the suspended run lives in this tab and navigating away would abandon it. Concurrent cards are disambiguated by the OAuth `state` the agent minted.
- **`app/src/lib/copilot/adk-credential.ts`** is the pure half: parse the streamed `authConfig` defensively (ADK serializes camelCase; the same models dumped without aliases arrive snake_case — both are read, and the answer is written back in the sender's own spelling), set our `redirect_uri` on the consent URL, refuse non-http(s) authorization "URLs", and complete the config with `authResponseUri`/`redirectUri`.
- **`GET /api/agents/oauth/callback`** (server/src/agents/routes.ts) is where the popup lands. A static page: it posts its own `location.href` to `window.opener`, same-origin only, and closes. The interesting values — code and state — stay in the URL and are read by the page's own script, never printed into markup by the server, so nothing a provider appends to the query string can become markup.

The wire contract was taken from source rather than guessed: `ag-ui-adk` (0.7.0) emits ADK long-running tool calls as ordinary AG-UI tool-call events and turns the next run's `role:"tool"` message back into a `FunctionResponse` (`adk_agent.py`, `_build_function_response_parts`), and `google-adk`'s `_AuthLlmRequestProcessor` / `AuthHandler` validate the returned `AuthConfig` and redeem the code via `fetch_token(authorization_response=auth_response_uri, ...)`. Declining echoes the config back unanswered; ADK's exchanger catches the failed redemption and the tool fails with an auth error the agent can relay, rather than the run crashing.

One thing is the deployment operator's to do, documented in `docs/coworkers.md`: register `https://<openbot>/api/agents/oauth/callback` as a redirect URI on the OAuth client the agent uses.

## Where it runs

- [x] **New state that outlives a request?** None. The suspended tool call is CopilotKit run state in the tab that owns the conversation; the provider's answer travels popup → opener via `postMessage` inside that same browser. The server's callback page is constant bytes.
- [x] **What happens on the second replica?** Any replica serves the identical static page; nothing is looked up, so it cannot matter which one answers.
- [x] **Anything serialised?** Nothing. Two people (or two cards) consenting at once never meet: correlation is per-browser, keyed by the OAuth `state`.
- [x] **Anything fanned out to a browser?** Nothing crosses processes; the message goes window-to-window in one browser.
- [x] **New listener, port, or schedule?** No. One GET route on the existing `/api/agents` router, same ingress as everything else.

## Boundary and audit

- [x] Every acting call still goes through the gateway: this change performs no acting call. The callback route acts for nobody — no session, no store; the test pins that with a store that throws on any touch.
- [x] New refusals and new failures each write a row — none are created server-side. Stated plainly: the consent decision itself is **not** in the audit trail, because the server never learns it; it is a tool result between the person's browser and their agent, like every other HITL decision card today. If consent should become auditable, that is a follow-up with its own design, not a silent property of this change.
- [x] Nothing new is trusted from the client: the server reads nothing off the callback URL — not the code, not the state.

## Changelog

- [x] A section under `Unreleased`.

## Proof

- `bun test app/tests/adk-credential.test.ts server/tests/agent-oauth-callback.test.ts` — 19 pass: both ADK spellings, streaming (partial) arguments, `javascript:` authorization URLs refused, `redirect_uri` replaced not joined, state matching, config completion without mutation, and the callback page answering with no session, no store, and no reflection of query values.
- `bun run lint`, `bun run format`, `bun run typecheck` clean.
- The protocol halves were verified against the shipped sources of `ag-ui-adk` 0.7.0 and `google-adk` (functions named above) rather than against documentation. Said honestly: an end-to-end run against a live ADK agent with a per-user OAuth MCP has not been recorded yet — it needs an OAuth client that lists a reachable OpenBot callback among its redirect URIs. The unit surface pins both directions of the contract in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqRRjoTegSESA76xZzgojd
