### PR TITLE
Initialise embedded PostgreSQL where a platform volume lets it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### Embedded PostgreSQL initialises on a platform volume, and says so when it cannot
+
+`EMBEDDED_POSTGRES=on` could not create its cluster on a platform whose persistent volume is an ext4
+mount — Railway, and by the same mechanism most others — and it failed differently depending on where
+the volume was mounted. Neither of the two paths this repo suggested worked, and the two suggestions
+disagreed with each other: `docs/deployment.md` said `/var/lib/postgresql/data`, the `Dockerfile`
+comment said `/var/lib/postgresql`.
+
+Mounted at the parent, the mount arrives owned by root, `data` is not in it, and the image's
+build-time `chown` is hidden underneath — so `initdb`, which has already dropped to the `postgres`
+user, cannot create the directory. `postgres-init` now creates and chowns it first, as root, which is
+the only step in a position to. This also fixes the plain
+`docker run -v openbot-data:/var/lib/postgresql` case, which relied entirely on that hidden chown.
+
+Mounted directly on the data directory, the mount arrives holding a `lost+found`, and `initdb` will
+not initialise into a directory with anything in it. **The documented mount is now the parent,
+`/var/lib/postgresql`**, which leaves `data` an ordinary subdirectory — what PostgreSQL's own hint
+asks for, and what the `Dockerfile` already said. A volume already mounted at
+`/var/lib/postgresql/data` and working — a Docker named volume, which arrives empty rather than with a
+`lost+found` — keeps working and needs no change.
+
+**The failure said nothing useful.** `api` waits on `postgres` and `migrate`, so neither started, the
+container came up anyway, the platform reported the deploy a success, and the public URL served a
+persistent 502 with the real reason visible only in the container log. A data directory that holds no
+cluster and is not empty is now refused with a sentence naming the mount to use instead.
+
+Reported by [@jerelvelarde](https://github.com/CopilotKit/OpenBot/issues/269) with the container logs
+for both mount paths, which is what made the two failure modes separable.
+
 ### The framework Bot answers on 5.6-tier models, and can be told how hard to think
 
 Pointing `BOT_MODEL` at a `gpt-5.6-*` model gave a Bot that started, reported healthy, and then said

--- a/docker/s6/scripts/postgres-init.sh
+++ b/docker/s6/scripts/postgres-init.sh
@@ -9,6 +9,30 @@ set -eu
 
 DATA=/var/lib/postgresql/data
 if [ ! -s "$DATA/PG_VERSION" ]; then
+  # Created and owned here, as root, because this is the only step in a position to do it.
+  #
+  # The image creates and chowns this at build time, and a volume mounted over /var/lib/postgresql at
+  # run time hides that completely: the mount arrives owned by root, `data` is not in it, and nothing
+  # else in the image puts either back. There is no `fix-attrs.d` under docker/s6, so the built-in
+  # s6-overlay service of that name has nothing to act on. `postgres-init` is a oneshot whose `up`
+  # runs as root, so it can, and `initdb` a line below cannot — it has already dropped to `postgres`.
+  mkdir -p "$DATA"
+  chown postgres:postgres "$DATA"
+
+  # A volume mounted directly AT the data directory, rather than at its parent, arrives holding
+  # `lost+found` on any platform whose volume is an ext4 mount — which is most of them. `initdb`
+  # refuses a directory with anything in it, and its own hint says to use a subdirectory instead.
+  #
+  # Said here, naming this image's answer, rather than left to that hint. The failure is otherwise a
+  # generic message about mount points in a container log, while `api` never starts because it depends
+  # on `postgres` and `migrate`, the platform reports the deploy a success, and the public URL serves
+  # a 502 with nothing on it to explain why.
+  if [ -n "$(ls -A "$DATA" 2>/dev/null)" ]; then
+    echo "postgres-init: $DATA holds no cluster and is not empty, so initdb cannot use it." >&2
+    echo "postgres-init: mount the volume at /var/lib/postgresql rather than at $DATA. A volume mounted directly on the data directory arrives with a lost+found in it, and PostgreSQL will not initialise into that." >&2
+    exit 1
+  fi
+
   s6-setuidgid postgres /usr/lib/postgresql/16/bin/initdb -D "$DATA" -A trust -U openbot >/dev/null
   s6-setuidgid postgres /usr/lib/postgresql/16/bin/pg_ctl -D "$DATA" -o "-c listen_addresses=127.0.0.1" -w start >/dev/null
   s6-setuidgid postgres /usr/lib/postgresql/16/bin/createdb -U openbot openbot

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,7 +11,7 @@ docker run -p 3001:3001 --env-file .env openbot
 
 # Or one inside the container. Nothing else to provision.
 docker run -p 3001:3001 --env-file .env \
-  -e EMBEDDED_POSTGRES=on -v openbot-data:/var/lib/postgresql/data openbot
+  -e EMBEDDED_POSTGRES=on -v openbot-data:/var/lib/postgresql openbot
 ```
 
 ## What is in the image, and what is not
@@ -24,8 +24,16 @@ process beside it.
 the database and the `vector` extension the first time, and runs the migrations on every start. It
 listens on loopback only and is never published, so there is no password to manage.
 
-Give it a volume at `/var/lib/postgresql/data`. Without one, a redeploy takes the audit trail with
-it, and the audit trail is the product. Platforms that offer no persistent volume are the ones to
+Give it a volume at `/var/lib/postgresql` — the parent, not the data directory itself. Without one,
+a redeploy takes the audit trail with it, and the audit trail is the product.
+
+**Mount the parent, not `/var/lib/postgresql/data`.** On any platform whose volume is an ext4 mount,
+and that is most of them, the mount arrives holding a `lost+found` directory. `initdb` will not
+initialise into a directory that has anything in it, so mounting it directly on the data directory
+leaves the cluster uncreated — and because `api` waits on `postgres` and `migrate`, the container
+starts, the platform reports the deploy a success, and the URL serves a 502. Mounting the parent
+leaves `data` as an ordinary subdirectory, which is what PostgreSQL asks for. A Docker named volume
+works either way; a platform volume does not. Platforms that offer no persistent volume are the ones to
 point at a managed database instead: set `DATABASE_URL` and leave `EMBEDDED_POSTGRES` off. The
 `vector` extension must be enabled there; RDS, Cloud SQL and Azure Database all support it, none
 enable it for you.


### PR DESCRIPTION
## What this changes

Closes #269. @jerelvelarde reported it with the container logs for both mount paths, which is what made
the two failure modes separable — the diagnosis below is theirs.

`EMBEDDED_POSTGRES=on` could not create its cluster on a platform whose persistent volume is an ext4
mount, and it failed differently depending on where the volume was mounted. Neither of the two paths
this repo suggested worked, and the two suggestions disagreed with each other: `docs/deployment.md`
said `/var/lib/postgresql/data`, the `Dockerfile` comment at line 126 said `/var/lib/postgresql`.

**Mounted at the parent**, the mount arrives owned by root, `data` is not in it, and the image's
build-time `chown` is underneath the mount. `initdb` has already dropped to `postgres` by the time it
runs, so it cannot create the directory. `postgres-init` is a oneshot whose `up` runs as root, so it
now creates and chowns it first — which is also the fix for plain
`docker run -v openbot-data:/var/lib/postgresql`, a case that relied entirely on a chown a mount hides.

**Mounted on the data directory itself**, the mount holds a `lost+found` and `initdb` refuses a
directory with anything in it. The documented mount is now the parent, leaving `data` an ordinary
subdirectory — which is what `initdb`'s own hint asks for and what the `Dockerfile` already said.

**The failure said nothing useful, which is the half worth fixing on its own.** `api` waits on
`postgres` and `migrate`, so neither started, the container came up regardless, the platform reported
the deploy a **success**, and the public URL served a persistent 502 with the real reason only in the
container log. A data directory that holds no cluster and is not empty is now refused with a sentence
naming the mount to use instead.

### Why the data directory is not moved into a subdirectory of itself

That would fix both mount paths in code with no documentation change, and it is the wrong trade. A
Docker named volume at `/var/lib/postgresql/data` arrives **empty** rather than with a `lost+found`,
so that configuration works today — `docker-compose.yml` and the old `docker run` line both use it.
Looking for the cluster one level deeper would find nothing there, initialise a fresh one, and leave
the existing cluster sitting in the same volume unreferenced. That is losing somebody's audit trail to
fix a first-boot error, and the audit trail is the product.

So: existing working deployments are untouched and need no migration, and the change for new ones is a
mount path in the docs.

`docker-compose.yml` is deliberately not touched. Its `postgres:` service is the official PostgreSQL
image, where `/var/lib/postgresql/data` is that image's own documented mount and none of this applies.

## Where it runs

- **New state that outlives a request?** None. This is container first-boot, before anything serves.
- **What happens on the second replica?** Unchanged, and this is the single-container shape by
  definition — `EMBEDDED_POSTGRES` exists for the deployment that runs one thing. A deployment with
  replicas points `DATABASE_URL` at a managed database and never runs this script.
- **Anything serialised?** `postgres-init` is a oneshot that `postgres` and `migrate` depend on, so it
  completes before either starts. That ordering is unchanged; what changed is that it now fails
  loudly instead of leaving the two never starting for an unexplained reason.
- **Anything fanned out to a browser?** No.
- **New listener, port, or schedule?** No.

## Boundary and audit

- No boundary change. This runs before the API exists, creates the cluster the API then migrates, and
  touches nothing about who may do what.
- Trust-auth and loopback-only are unchanged, including the comment explaining them. Worth noting that
  #226 is about that premise and this PR deliberately does not touch it — the two would collide in
  this file, and this one is a first-boot failure rather than a boundary.
- No audit rows: there is no database to write one to at this point in the boot.

## Changelog

Added under `Unreleased`, naming both failure modes, the mount change, and that an existing volume at
the old path keeps working.

## Proof

**Stated plainly: I did not build or boot the image.** There is no working Docker on this machine, so
the container itself is unverified by me. What I did run:

`sh -n docker/s6/scripts/postgres-init.sh` — clean.

The decision logic exercised against real directory fixtures, for all four states the script can meet:

| Fixture | Result |
| --- | --- |
| no volume — image-built empty `data` | proceeds to `initdb` |
| platform volume at the **parent**, `lost+found` beside `data` | proceeds to `initdb` — this is the mode 2 fix |
| platform volume **on** `data`, `lost+found` inside it | refused, with the message |
| existing cluster (`PG_VERSION` present) | skipped entirely |

The last row is the one I most wanted to see: an initialised cluster is still never re-initialised, so
nothing here can take a working deployment's data.

Also checked, because a CRLF shebang would break the image and this machine is Windows: the committed
blob has zero carriage returns, matching upstream's.

CI's `image` job covers the no-volume path. Neither it nor I cover a real platform volume, which is
the case the issue is about — a Railway deploy at the new mount path is the check that actually
closes this, and @jerelvelarde is the one who can do it.

## What is not covered

- **The 502-on-success problem itself.** A first-start failure that leaves the platform reporting a
  healthy deploy is a real gap, and the issue raises it as worth considering separately. This makes
  the reason legible in the log; it does not make the container report itself unhealthy. That wants a
  healthcheck decision rather than a line in this script.
- **An existing broken deployment** with a platform volume on `/var/lib/postgresql/data` still has to
  change its mount. Nothing is lost by doing so — the cluster never initialised, so the volume holds
  no data — and the new message says which path to use.
