### PR TITLE
Read the conversation that asked before taking a lock on the one being answered in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A hop that cannot read the conversation no longer locks one on its way out
+
+Delivering a hop took the run lock on the conversation the answer lands in, and only then read the
+conversation that asked. A platform that answers that read with anything other than a missing thread
+— an outage, a bad key, a dropped connection — threw from between the lock and the `finally` that
+gives it back, so the lock was left held and unrenewed. For the next couple of minutes the person
+could not start a run in that conversation, and the hop's own retry collided with the lock it was
+still holding itself and spent one of its attempts reporting the conversation as busy. The read now
+happens before the lock is taken, which it never needed: it is a different conversation.
+
 ### A Bot's shell can no longer reach the embedded database without a password
 
 In the all-in-one image the cluster was `trust`-auth on loopback, and the Bot's shell runs in the

--- a/server/src/agents/handoff-delivery.ts
+++ b/server/src/agents/handoff-delivery.ts
@@ -203,6 +203,23 @@ export function createHandoffDelivery(options: {
         : await answerIn({ actorId: work.actorId, botId: work.toBotId });
 
       /*
+       * The conversation that ASKED, read BEFORE the lock is taken.
+       *
+       * The addressed Bot is joining something already in progress and has to have read it; its own
+       * conversation is new and empty, and reading that would tell it nothing. This is a different
+       * thread from the one about to be locked, so the lock never protected this read — and holding
+       * one across it means a read that throws leaks it. `historyOrEmpty` answers a missing thread
+       * with nothing and rethrows everything else on purpose ("a 500 from the platform means an
+       * outage or a bad key"), so one 500 left the addressed Bot's conversation locked, unrenewed and
+       * unreleasable until the platform's own TTL expired. For those two minutes the person could not
+       * start a run there, and the hop's own retry a minute later collided with the lock it was still
+       * holding itself, reported the conversation as busy, and spent one of its five attempts on it.
+       */
+      const prior = conversationOnly(
+        await history({ threadId: work.threadId, actorId: work.actorId }),
+      );
+
+      /*
        * The conversation's lock, before a single event is streamed.
        *
        * The platform's run id is the one it hands back, not the one asked for: it is the identity the
@@ -239,14 +256,7 @@ export function createHandoffDelivery(options: {
        * displayed the question directly above the answer.
        */
       const asked = [
-        /*
-         * The conversation that ASKED, not the one it is answering in. The addressed Bot is joining
-         * something already in progress and has to have read it; its own conversation is new and
-         * empty, and reading that would tell it nothing.
-         */
-        ...conversationOnly(
-          await history({ threadId: work.threadId, actorId: work.actorId }),
-        ),
+        ...prior,
         { id: `handoff-${runId}`, role: "user", content: message },
       ];
       agent.threadId = where.threadId;

--- a/server/tests/agent-handoff-delivery.test.ts
+++ b/server/tests/agent-handoff-delivery.test.ts
@@ -44,7 +44,17 @@ function delivery(
   events: BaseEvent[],
   agent: AbstractAgent | null = stubAgent(),
   lockHeld = true,
-  options: { history?: readonly unknown[]; deadlineMs?: number } = {},
+  options: {
+    history?: readonly unknown[];
+    deadlineMs?: number;
+    /**
+     * The platform refusing to hand back the asking conversation.
+     *
+     * `historyOrEmpty` answers a missing thread with nothing and rethrows everything else, on
+     * purpose: a 500 is an outage or a bad key, not an empty conversation.
+     */
+    historyError?: Error;
+  } = {},
 ) {
   const requests: Array<{
     threadId: string;
@@ -62,7 +72,10 @@ function delivery(
         ? {}
         : { deadlineMs: options.deadlineMs }),
       agentFor: async () => agent,
-      history: async () => options.history ?? PRIOR,
+      history: async () => {
+        if (options.historyError) throw options.historyError;
+        return options.history ?? PRIOR;
+      },
       newRunId: () => "run-2",
       answerIn: async () => ({ threadId: "answer-thread" }),
       lock: {
@@ -99,6 +112,37 @@ function delivery(
 }
 
 describe("turning a hop into a turn", () => {
+  /*
+   * A hop that cannot read the conversation it was asked in has to fail without taking anything with
+   * it. The lock is on the conversation being ANSWERED in, the read is of the one that ASKED, so the
+   * lock never protected this read — and holding one across it means the failure costs a person the
+   * use of a conversation they are not even part of, for as long as the platform's own TTL.
+   */
+  test("a history the platform will not hand back leaves no lock behind", async () => {
+    const { delivery: deliver, lockCalls } = delivery(
+      FINISHED,
+      stubAgent(),
+      true,
+      { historyError: new Error("the platform answered 500") },
+    );
+
+    await expect(
+      deliver.deliver({
+        work: WORK,
+        message: "m",
+        shown: "s",
+        assertion: "signed",
+      }),
+    ).rejects.toThrow("the platform answered 500");
+
+    /*
+     * Nothing was taken, so nothing was left held. Asserting the whole sequence rather than the
+     * absence of a release: a delivery that acquired and then released would also be correct, and
+     * this says which of the two happened.
+     */
+    expect(lockCalls).toEqual([]);
+  });
+
   test("the addressed Bot reads the conversation before the ask", async () => {
     const { delivery: deliver, requests } = delivery(FINISHED);
 


### PR DESCRIPTION
## What this changes

`server/src/agents/handoff-delivery.ts` takes the run lock on the conversation the answer lands in,
and then reads the history of the conversation that **asked** — a different thread, which the lock
never protected:

- `:212` `const held = await lock.acquire({ threadId: where.threadId, … })`
- `:248` `await history({ threadId: work.threadId, actorId: work.actorId })`
- `:265` `try { … } finally { clearInterval(heartbeat); await lock.release(…) }`

The read at `:248` is the one `await` in the delivery that sits between the acquire and the `finally`
that gives the lock back.

`historyOrEmpty` (`server/src/copilot.ts:953-963`) answers a missing thread with nothing and rethrows
everything else, deliberately — *"A 500 from the platform means an outage or a bad key"*. So one 500,
one expired key, one dropped connection, and the delivery throws with the lock still held:

1. The hop rejects and goes back on the queue with a 60 s delay
   (`handoff-runner.ts:393-399`), which is correct.
2. The lock on `where.threadId` — the addressed Bot's own conversation with that person — is never
   released and never renewed (the heartbeat is only armed at `:261`, after the read). It sits until
   the platform's TTL, `THREAD_LOCK_TTL_SECONDS = 120` (`copilot.ts:993`). For those two minutes the
   person cannot start a run in that conversation.
3. The retry a minute later collides with the lock the hop is still holding *itself*, gets `null`
   from `acquire`, throws *"is busy with another run"* and spends one of its five attempts on it.

The module already argues this case for the other direction. The `finally` at `:348-359` says:

> *Given back whatever happened. Left held, the conversation is unusable by anybody until the lock
> expires: the person cannot ask a follow-up and the next hop is refused, which turns one failed
> delivery into a conversation that has stopped working.*

That is exactly what a failed history read produces — it just happens one line above where the
`finally` starts.

### The fix

Hoist the read above the acquire. It is a read of another conversation, so the lock was doing nothing
for it, and moving it earlier also shortens the window the lock is held on the happy path. Nothing
else moves: the ask is still appended with the platform's own run id, which is only known after the
lock.

## Where it runs

- [x] **New state that outlives a request?** None. One local moved earlier in the same function.
- [x] **What happens on the second replica?** Better, and this is the point. The lock is the
      platform's, shared by every replica; a replica that leaked one made the conversation unusable
      from all of them for the TTL, and the hop's own retry — which any replica may claim — walked
      into it. After this, a failed read leaves nothing behind for another replica to trip over.
- [x] **Anything serialised?** Unchanged. The lock is still taken `NX` through the platform, and is
      still the thing that serialises runs in a conversation. What changed is that it is no longer
      held across an operation that can throw outside its `finally`.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: unchanged.
- [x] New refusals and new failures each write a row. No new outcome — the hop already rejects and is
      retried, and `agent.handoff_retried` / `agent.handoff_failed` are written by the runner exactly
      as before. This changes only what is left behind on the way out.
- [x] Nothing new is trusted from the client.

## Changelog

- [x] `CHANGELOG.md`, under `Unreleased`.

## Proof

`server/tests/agent-handoff-delivery.test.ts` gains a `historyError` option to the existing stub
harness and one case: a history read that throws, asserting the whole lock sequence is empty. It is
red on `main` and green here.

Against `main`'s `handoff-delivery.ts` with the new test in place:

```
143 |     expect(lockCalls).toEqual([]);
error: expect(received).toEqual(expected)
- []
+ [ "acquire" ]
(fail) turning a hop into a turn > a history the platform will not hand back leaves no lock behind
 17 pass, 1 fail
```

With the change:

```
bun test server/tests/agent-handoff-delivery.test.ts server/tests/agent-handoff-runner.test.ts \
         server/tests/agent-handoff.test.ts server/tests/agent-handoff-tool.test.ts
                       -> 60 pass, 0 fail (113 expect() calls)
bun run format:check   -> Checked 487 files. No fixes applied.
bun run lint           -> Checked 490 files. No fixes applied.
bun run typecheck      -> app / server / worker all exit 0
```

The sequence is asserted rather than the absence of a release, because a delivery that acquired and
then released would also be correct and the assertion should say which of the two happened.
