### PR TITLE
Correct embedded PostgreSQL volume path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ One image carries the app, the API, the browser the Bots drive, and optionally P
 ```sh
 docker build -t openbot .
 docker run -p 3001:3001 --env-file .env \
-  -e EMBEDDED_POSTGRES=on -v openbot-data:/var/lib/postgresql/data openbot
+  -e EMBEDDED_POSTGRES=on -v openbot-data:/var/lib/postgresql openbot
 ```
 
 Leave `EMBEDDED_POSTGRES` off and set `DATABASE_URL` to point at a database you already run.


### PR DESCRIPTION
## What this changes

Corrects the embedded PostgreSQL volume path in the root README's `docker run` example. The example now mounts the volume at `/var/lib/postgresql`, matching `docs/deployment.md`, the Dockerfile guidance, and the first-boot fix recorded in the changelog.

Mounting a platform volume directly at `/var/lib/postgresql/data` can expose `lost+found` to `initdb`, which refuses to initialize a non-empty data directory. Mounting the parent leaves `data` as an ordinary subdirectory.

## Where it runs

- [x] **New state that outlives a request?** None; this changes one documentation command only.
- [x] **What happens on the second replica?** Nothing changes at runtime or across replicas.
- [x] **Anything serialised?** No.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** No.

## Boundary and audit

- [x] No acting call, refusal, failure, trust boundary, or audit behavior changes; this is documentation-only.

## Changelog

- [x] No new changelog entry: the existing `Unreleased` entry already documents the parent-volume requirement and first-boot fix. This patch brings the root README into agreement with it.

## Proof

- compared the root command against `docs/deployment.md` and the existing `CHANGELOG.md` entry; all now use `/var/lib/postgresql`
- checked all 52 relative links across the repository's 17 tracked Markdown files; zero broken links
- `git diff --check`

No image or service was built or started because the change only corrects an already-documented command path.
