### PR TITLE
Let a person collapse the sidebar, and reach the roster on a phone

### DIFF
--- a/app/src/components/layout/page-shell.tsx
+++ b/app/src/components/layout/page-shell.tsx
@@ -3,6 +3,7 @@ import { Link, type LinkProps } from "@tanstack/react-router";
 import type * as React from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
+import { SidebarToggle } from "./sidebar-toggle";
 
 /**
  * The frame every configuration screen sits in.
@@ -58,8 +59,15 @@ export function PageShell({
 }) {
   return (
     <>
-      {!!backButton && (
-        <div className="max-w-7xl w-full h-14 flex items-center px-3">
+      {/*
+       * The bar is unconditional. The sidebar toggle has to sit at the pane's left edge in both
+       * states, and the prose column is centred — a toggle inside it would be 400px from the edge it
+       * belongs to on a wide screen. Six screens already drew exactly this bar for their Back link,
+       * so this is that bar always rendered rather than a second one above it.
+       */}
+      <div className="max-w-7xl w-full h-14 flex items-center gap-1 px-3">
+        <SidebarToggle />
+        {!!backButton && (
           <Button
             variant="ghost"
             render={(props) => <Link {...backButton.linkProps} {...props} />}
@@ -67,12 +75,11 @@ export function PageShell({
             <IconChevronLeft />
             {backButton.label}
           </Button>
-        </div>
-      )}
+        )}
+      </div>
       <div
         className={cn(
-          "mx-auto flex w-full flex-col px-4 py-12",
-          { "pt-8": !!backButton },
+          "mx-auto flex w-full flex-col px-4 pt-8 pb-12",
           WIDTHS[width],
           className,
         )}

--- a/app/src/components/layout/page-shell.tsx
+++ b/app/src/components/layout/page-shell.tsx
@@ -3,6 +3,7 @@ import { Link, type LinkProps } from "@tanstack/react-router";
 import type * as React from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
+import { useOptionalSidebar } from "../ui/sidebar";
 import { SidebarToggle } from "./sidebar-toggle";
 
 /**
@@ -57,29 +58,42 @@ export function PageShell({
     label: string;
   };
 }) {
+  /*
+   * Whether this screen has a sidebar at all. `/assist` and `/link/slack` draw PageShell directly
+   * under `_authed`, which mounts no provider, so there is nothing for a toggle to act on there.
+   */
+  const hasSidebar = useOptionalSidebar() !== null;
+  /*
+   * The bar carries the toggle and the Back link, and is drawn when it has at least one of them.
+   * The screens with a Back link already drew exactly this bar, so for them nothing changes; what
+   * changed is that a sidebar is now reason enough on its own, because the toggle has to sit at the
+   * pane's left edge in both states and the prose column is centred — a control inside it would be
+   * 400px from the edge it belongs to on a wide screen. Drawing it with neither would be a 56px
+   * band holding nothing, which reads as a layout bug rather than as chrome.
+   */
+  const bar = hasSidebar || !!backButton;
+
   return (
     <>
-      {/*
-       * The bar is unconditional. The sidebar toggle has to sit at the pane's left edge in both
-       * states, and the prose column is centred — a toggle inside it would be 400px from the edge it
-       * belongs to on a wide screen. Six screens already drew exactly this bar for their Back link,
-       * so this is that bar always rendered rather than a second one above it.
-       */}
-      <div className="max-w-7xl w-full h-14 flex items-center gap-1 px-3">
-        <SidebarToggle />
-        {!!backButton && (
-          <Button
-            variant="ghost"
-            render={(props) => <Link {...backButton.linkProps} {...props} />}
-          >
-            <IconChevronLeft />
-            {backButton.label}
-          </Button>
-        )}
-      </div>
+      {bar ? (
+        <div className="max-w-7xl w-full h-14 flex items-center gap-1 px-3">
+          {hasSidebar ? <SidebarToggle /> : null}
+          {!!backButton && (
+            <Button
+              variant="ghost"
+              render={(props) => <Link {...backButton.linkProps} {...props} />}
+            >
+              <IconChevronLeft />
+              {backButton.label}
+            </Button>
+          )}
+        </div>
+      ) : null}
       <div
         className={cn(
-          "mx-auto flex w-full flex-col px-4 pt-8 pb-12",
+          "mx-auto flex w-full flex-col px-4 pb-12",
+          // Without a bar above it the heading keeps the full original space.
+          bar ? "pt-8" : "pt-12",
           WIDTHS[width],
           className,
         )}

--- a/app/src/components/layout/sidebar-shell.tsx
+++ b/app/src/components/layout/sidebar-shell.tsx
@@ -1,0 +1,62 @@
+import { type CSSProperties, type ReactNode, useEffect, useState } from "react";
+
+import { SidebarProvider } from "@/components/ui/sidebar";
+import {
+  applySidebarOpen,
+  parseStoredSidebarOpen,
+  SIDEBAR_STORAGE_KEY,
+} from "@/lib/sidebar";
+
+/**
+ * The frame the three shells — app, admin, settings — hang their sidebar in.
+ *
+ * It exists for one reason: the open/closed state has to outlive a reload, and the primitive's
+ * `SidebarProvider` cannot do that on its own (it writes a cookie nothing reads and hardcodes
+ * `defaultOpen` to true). Driving it as controlled state is a dozen lines, and three copies of a
+ * dozen lines is three chances for one shell to forget the preference the other two remember.
+ *
+ * `width` is what actually differs between the shells. The app's roster earns 340px because its
+ * rows are two-line message previews; admin and settings hold short nav labels and earn 300px.
+ */
+export function SidebarShell({
+  children,
+  className,
+  width,
+}: {
+  children: ReactNode;
+  className?: string;
+  width: string;
+}) {
+  // Read before the first paint, so a shell somebody left collapsed never flashes open.
+  const [open, setOpen] = useState(() =>
+    parseStoredSidebarOpen(window.localStorage.getItem(SIDEBAR_STORAGE_KEY)),
+  );
+
+  useEffect(() => {
+    applySidebarOpen(open, {
+      setStoredValue: (key, value) => window.localStorage.setItem(key, value),
+    });
+  }, [open]);
+
+  return (
+    <SidebarProvider
+      className={className}
+      onOpenChange={setOpen}
+      open={open}
+      /*
+       * `--sidebar-width-mobile` is set for the shape's sake and currently goes unread: the
+       * primitive's mobile branch styles its Sheet from a hardcoded 18rem. Below 768px the sidebar
+       * is that Sheet, which is also why the stored preference never reaches it — a panel that
+       * covers the screen it overlays has no business being open before anybody asked for it.
+       */
+      style={
+        {
+          "--sidebar-width": width,
+          "--sidebar-width-mobile": "20rem",
+        } as CSSProperties
+      }
+    >
+      {children}
+    </SidebarProvider>
+  );
+}

--- a/app/src/components/layout/sidebar-toggle.tsx
+++ b/app/src/components/layout/sidebar-toggle.tsx
@@ -1,7 +1,7 @@
 import { IconLayoutSidebar } from "@tabler/icons-react";
 
 import { Button } from "@/components/ui/button";
-import { useSidebar } from "@/components/ui/sidebar";
+import { useOptionalSidebar } from "@/components/ui/sidebar";
 import {
   Tooltip,
   TooltipContent,
@@ -35,7 +35,10 @@ const SHORTCUT_LABEL = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent)
  * contradict the label below. The state still belongs to the primitive: `toggleSidebar` is its hook.
  */
 export function SidebarToggle({ className }: { className?: string }) {
-  const { isMobile, open, toggleSidebar } = useSidebar();
+  const sidebar = useOptionalSidebar();
+  // No sidebar in scope, so nothing to toggle and nothing to draw.
+  if (!sidebar) return null;
+  const { isMobile, open, toggleSidebar } = sidebar;
   /*
    * The label says what the click will do, not what is on screen. Below 768px the sidebar is an
    * overlay Sheet with its own open state, and `open` describes the desktop pane — reading it there

--- a/app/src/components/layout/sidebar-toggle.tsx
+++ b/app/src/components/layout/sidebar-toggle.tsx
@@ -38,13 +38,15 @@ export function SidebarToggle({ className }: { className?: string }) {
   const sidebar = useOptionalSidebar();
   // No sidebar in scope, so nothing to toggle and nothing to draw.
   if (!sidebar) return null;
-  const { isMobile, open, toggleSidebar } = sidebar;
+  const { isMobile, open, openMobile, toggleSidebar } = sidebar;
   /*
    * The label says what the click will do, not what is on screen. Below 768px the sidebar is an
    * overlay Sheet with its own open state, and `open` describes the desktop pane — reading it there
    * would name the wrong action.
    */
-  const label = isMobile || !open ? "Show sidebar" : "Hide sidebar";
+  const label = (isMobile ? openMobile : open)
+    ? "Hide sidebar"
+    : "Show sidebar";
 
   return (
     <Tooltip>

--- a/app/src/components/layout/sidebar-toggle.tsx
+++ b/app/src/components/layout/sidebar-toggle.tsx
@@ -1,0 +1,84 @@
+import { IconLayoutSidebar } from "@tabler/icons-react";
+
+import { Button } from "@/components/ui/button";
+import { useSidebar } from "@/components/ui/sidebar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+/**
+ * ⌘ on Apple platforms, Ctrl everywhere else. The primitive's listener accepts either modifier, so
+ * this only decides which of the two to name.
+ */
+const SHORTCUT_LABEL = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent)
+  ? "⌘B"
+  : "Ctrl+B";
+
+/**
+ * The control that opens and closes the shell's sidebar.
+ *
+ * WHAT THIS IS FIXING. The sidebar could always collapse — the primitive has had the state, the
+ * width transition and a ⌘B shortcut since it was vendored in. Nothing ever rendered a trigger for
+ * it. The only affordance was `SidebarRail`, a 16px transparent strip carrying `tabIndex={-1}`, so
+ * the eye could not find it and the keyboard could not reach it; and under 768px, where the sidebar
+ * becomes a Sheet that starts closed, there was no way to open the roster at all.
+ *
+ * It is therefore drawn in the chrome each screen already has, and in BOTH states, rather than
+ * inside the sidebar it hides — a trigger that disappears along with the sidebar cannot bring it
+ * back.
+ *
+ * Built from `Button` rather than the primitive's `SidebarTrigger` because that component hardcodes
+ * its own children after the prop spread, including an `sr-only` "Toggle Sidebar" that would
+ * contradict the label below. The state still belongs to the primitive: `toggleSidebar` is its hook.
+ */
+export function SidebarToggle({ className }: { className?: string }) {
+  const { isMobile, open, toggleSidebar } = useSidebar();
+  /*
+   * The label says what the click will do, not what is on screen. Below 768px the sidebar is an
+   * overlay Sheet with its own open state, and `open` describes the desktop pane — reading it there
+   * would name the wrong action.
+   */
+  const label = isMobile || !open ? "Show sidebar" : "Hide sidebar";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            aria-label={label}
+            className={cn("text-muted-foreground", className)}
+            onClick={toggleSidebar}
+            size="icon"
+            variant="ghost"
+          >
+            <IconLayoutSidebar className="size-4.5" />
+          </Button>
+        }
+      />
+      {/* An accelerator nobody is told about is not a feature. */}
+      <TooltipContent side="bottom">
+        {label}
+        <span className="text-background/60">{SHORTCUT_LABEL}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+/**
+ * The toggle on a screen that draws no header of its own.
+ *
+ * Three `_app` screens open straight into their content, and the toggle still has to land in the
+ * same 48px band it occupies everywhere else — a control that moves between screens is a control
+ * somebody has to look for each time. No bottom border: a divider under an otherwise empty bar is a
+ * line with nothing to divide.
+ */
+export function SidebarToggleBar() {
+  return (
+    <div className="h-12 shrink-0 flex items-center px-3">
+      <SidebarToggle />
+    </div>
+  );
+}

--- a/app/src/components/ui/sidebar.tsx
+++ b/app/src/components/ui/sidebar.tsx
@@ -52,6 +52,18 @@ function useSidebar() {
 }
 
 /**
+ * The sidebar's state, or null where there is no sidebar.
+ *
+ * `useSidebar` throwing is right for a part OF a sidebar, where its absence is a wiring bug. A
+ * control that merely offers to toggle one is the other case: `PageShell` sits inside the three
+ * shells today, and a screen that renders it outside one is a layout choice rather than a defect.
+ * Throwing there would take a whole screen down over a button that should simply not be drawn.
+ */
+function useOptionalSidebar() {
+  return React.useContext(SidebarContext);
+}
+
+/**
  * Sidebar state, uncontrolled by default.
  *
  * This vendored file used to write a `sidebar_state` cookie on every toggle, so a server-rendered
@@ -723,5 +735,6 @@ export {
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
+  useOptionalSidebar,
   useSidebar,
 };

--- a/app/src/components/ui/sidebar.tsx
+++ b/app/src/components/ui/sidebar.tsx
@@ -25,8 +25,6 @@ import {
 } from "@/components/ui/tooltip";
 import { IconLayoutSidebar } from "@tabler/icons-react";
 
-const SIDEBAR_COOKIE_NAME = "sidebar_state";
-const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
@@ -53,6 +51,15 @@ function useSidebar() {
   return context;
 }
 
+/**
+ * Sidebar state, uncontrolled by default.
+ *
+ * This vendored file used to write a `sidebar_state` cookie on every toggle, so a server-rendered
+ * shell could paint the right width on its first byte. Nothing renders this app on a server and
+ * nothing ever read the cookie back, so the preference lives in `lib/sidebar.ts` and the shells
+ * drive `open`/`onOpenChange` through `layout/sidebar-shell.tsx` instead. Re-adding the cookie would
+ * stand a second, staler answer beside that one.
+ */
 function SidebarProvider({
   defaultOpen = true,
   open: openProp,
@@ -81,9 +88,6 @@ function SidebarProvider({
       } else {
         _setOpen(openState);
       }
-
-      // This sets the cookie to keep the sidebar state.
-      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
     },
     [setOpenProp, open],
   );

--- a/app/src/lib/sidebar.ts
+++ b/app/src/lib/sidebar.ts
@@ -1,0 +1,33 @@
+/**
+ * Whether the shell's sidebar is open, remembered across reloads.
+ *
+ * The primitive under `components/ui/sidebar.tsx` writes a `sidebar_state` cookie of its own, which
+ * exists so a server-rendered shell can paint the right width on the first byte. Nothing renders
+ * this app on a server, and nothing ever read that cookie back — so the preference lives here
+ * instead, in the same shape and the same storage as the theme preference next door.
+ */
+export const SIDEBAR_STORAGE_KEY = "openbot-sidebar";
+
+/**
+ * Only the exact stored `collapsed` starts the sidebar closed.
+ *
+ * Everything else opens it: a key never written, a value from an older build, a value somebody
+ * else's script left behind. The roster is this app's navigation, and the cost of the two mistakes
+ * is not symmetric — opening a sidebar somebody wanted shut costs them one click, while shutting one
+ * on a guess hides every channel they have behind an affordance they have not found yet.
+ */
+export function parseStoredSidebarOpen(value: string | null) {
+  return value !== "collapsed";
+}
+
+type SidebarEffects = {
+  setStoredValue: (key: string, value: string) => void;
+};
+
+/**
+ * Records the state in the vocabulary the primitive already uses for it — `expanded` and
+ * `collapsed`, the two values of its `data-state` attribute — rather than inventing a second pair.
+ */
+export function applySidebarOpen(open: boolean, effects: SidebarEffects) {
+  effects.setStoredValue(SIDEBAR_STORAGE_KEY, open ? "expanded" : "collapsed");
+}

--- a/app/src/routes/_authed/_app.tsx
+++ b/app/src/routes/_authed/_app.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 import { AppSidebar } from "@/components/app-sidebar/app-sidebar";
-import { SidebarProvider } from "@/components/ui/sidebar";
+import { SidebarShell } from "@/components/layout/sidebar-shell";
 
 export const Route = createFileRoute("/_authed/_app")({
   component: RouteComponent,
@@ -10,19 +10,11 @@ function RouteComponent() {
   return (
     // One viewport, never scrolls: panes scroll inside it. A growable shell lets the transcript's
     // scroller size against the page, grow it, and grow again.
-    <SidebarProvider
-      className="h-svh overflow-hidden"
-      style={
-        {
-          "--sidebar-width": "340px",
-          "--sidebar-width-mobile": "20rem",
-        } as React.CSSProperties
-      }
-    >
+    <SidebarShell className="h-svh overflow-hidden" width="340px">
       <AppSidebar />
       <main className="flex-1 flex flex-col min-h-0 overflow-hidden">
         <Outlet />
       </main>
-    </SidebarProvider>
+    </SidebarShell>
   );
 }

--- a/app/src/routes/_authed/_app/agents/index.tsx
+++ b/app/src/routes/_authed/_app/agents/index.tsx
@@ -6,6 +6,7 @@ import { AgentCard } from "@/components/agents/agent-card";
 import { AgentProfile as AgentProfileDetail } from "@/components/agents/agent-profile";
 import { NewAgent } from "@/components/agents/new-agent";
 import { DetailPanel } from "@/components/layout/detail-panel";
+import { SidebarToggleBar } from "@/components/layout/sidebar-toggle";
 import { StaggerItem } from "@/components/layout/stagger";
 import { Button } from "@/components/ui/button";
 import { Empty, EmptyHeader, EmptyTitle } from "@/components/ui/empty";
@@ -58,6 +59,7 @@ function AgentsScreen() {
         ) : null
       }
     >
+      <SidebarToggleBar />
       <div className="max-w-2xl px-4 w-full mx-auto">
         <div className="mt-12 w-full max-w-2xl">
           <div className="flex flex-row w-full items-center justify-between">

--- a/app/src/routes/_authed/_app/bot.tsx
+++ b/app/src/routes/_authed/_app/bot.tsx
@@ -2,6 +2,7 @@ import { CopilotChat } from "@copilotkit/react-core/v2";
 import { IconPlus } from "@tabler/icons-react";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
+import { SidebarToggleBar } from "@/components/layout/sidebar-toggle";
 import { Button } from "@/components/ui/button";
 import { agentListQueryOptions } from "@/lib/agents/queries";
 import { useActiveBot } from "@/lib/copilot/active-bot";
@@ -76,6 +77,7 @@ function BotChat({ agentId, name }: { agentId: string; name: string }) {
 
   return (
     <div className="flex h-screen flex-col">
+      <SidebarToggleBar />
       <header className="border-b px-6 py-3">
         <div className="flex items-baseline justify-between">
           {/*

--- a/app/src/routes/_authed/_app/channel/$channelId.tsx
+++ b/app/src/routes/_authed/_app/channel/$channelId.tsx
@@ -17,6 +17,7 @@ import { ActivityLog } from "@/components/computer/activity-log";
 import { ComputerView } from "@/components/computer/computer-view";
 import { useNeedsYou } from "@/components/computer/needs-you";
 import { DetailPanel } from "@/components/layout/detail-panel";
+import { SidebarToggle } from "@/components/layout/sidebar-toggle";
 import { Button } from "@/components/ui/button";
 import { markChannelReadMutationOptions } from "@/lib/channels/mutations";
 import {
@@ -177,6 +178,7 @@ function RouteComponent() {
         <div className="h-12 border-b border-border sticky top-0 flex flex-row items-center justify-between px-3 gap-2">
           {/* Keyed on the displayed name so cold channel loads animate the resolved name, not the id. */}
           <div className="flex min-w-0 items-center gap-1.5">
+            <SidebarToggle />
             <motion.div
               animate={{ opacity: 1 }}
               className="shrink-0"

--- a/app/src/routes/_authed/_app/channel/new.tsx
+++ b/app/src/routes/_authed/_app/channel/new.tsx
@@ -6,6 +6,7 @@ import { ChannelAvatar } from "@/components/channels/avatar";
 import { canSend, type Recipient } from "@/components/channels/compose-state";
 import { ConversationView } from "@/components/channels/conversation-view";
 import { seedMessage } from "@/components/channels/transcript-messages";
+import { SidebarToggle } from "@/components/layout/sidebar-toggle";
 import {
   Combobox,
   ComboboxContent,
@@ -64,6 +65,7 @@ function RouteComponent() {
   return (
     <div className="flex h-full flex-col">
       <div className="h-12 border-b border-border sticky top-0 flex flex-row px-2 items-center">
+        <SidebarToggle className="mr-1" />
         <span className="text-sm text-muted-foreground">To:</span>
         <Combobox
           // Do not auto-open when the recipient came from the URL; the field is already answered.

--- a/app/src/routes/_authed/_app/index.tsx
+++ b/app/src/routes/_authed/_app/index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { useState } from "react";
 import { AgentCard } from "@/components/agents/agent-card";
 import { Composer, toAgentOptions } from "@/components/channels/composer";
+import { SidebarToggleBar } from "@/components/layout/sidebar-toggle";
 import { agentListQueryOptions } from "@/lib/agents/queries";
 import { routeMessage } from "@/lib/channels/route";
 import { useStartChannel } from "@/lib/channels/start";
@@ -22,89 +23,94 @@ function RouteComponent() {
   const fallback = explore?.[0] ?? agents?.[0];
 
   return (
-    <div className="flex-1 flex flex-col items-center justify-center w-full p-4 mt-8">
-      <div className="flex flex-col items-center">
-        <h2 className="text-sm uppercase text-muted-foreground font-medium tracking-tight text-center">
-          {appConfig.brand.productName}
-        </h2>
-        <h1 className="text-2xl font-bold tracking-tight mt-1.5 text-center">
-          Start a new channel
-        </h1>
-      </div>
-      <div className="mt-8 w-full flex flex-col items-center">
-        <Composer
-          agents={toAgentOptions(agents)}
-          className="w-full max-w-2xl"
-          disabled={!fallback}
-          onSubmit={async (draft) => {
-            // A channel is pinned to one coworker for the life of its thread, so the coworker is
-            // chosen now, before it is created. An `@` is an explicit choice and is honoured as-is.
-            // With no `@`, the message is routed to the coworker it is for; if that routing cannot
-            // run, it falls back to the same default the composer used to always use.
-            setError(null);
-            try {
-              let agentId: string | undefined = draft.agentId ?? undefined;
-              if (agentId) {
-                /*
-                 * Told to the server so the choice is recorded, and its answer thrown away: the
-                 * person already decided and nothing here may change that. Failing to write the
-                 * audit row must not stop the conversation, so a rejection is swallowed whole.
-                 */
-                await routeMessage(draft.text, agentId).catch(() => undefined);
-              } else {
-                try {
-                  agentId = (await routeMessage(draft.text)).agentId;
-                } catch {
-                  agentId = fallback?.id;
+    <>
+      <SidebarToggleBar />
+      <div className="flex-1 flex flex-col items-center justify-center w-full p-4 mt-8">
+        <div className="flex flex-col items-center">
+          <h2 className="text-sm uppercase text-muted-foreground font-medium tracking-tight text-center">
+            {appConfig.brand.productName}
+          </h2>
+          <h1 className="text-2xl font-bold tracking-tight mt-1.5 text-center">
+            Start a new channel
+          </h1>
+        </div>
+        <div className="mt-8 w-full flex flex-col items-center">
+          <Composer
+            agents={toAgentOptions(agents)}
+            className="w-full max-w-2xl"
+            disabled={!fallback}
+            onSubmit={async (draft) => {
+              // A channel is pinned to one coworker for the life of its thread, so the coworker is
+              // chosen now, before it is created. An `@` is an explicit choice and is honoured as-is.
+              // With no `@`, the message is routed to the coworker it is for; if that routing cannot
+              // run, it falls back to the same default the composer used to always use.
+              setError(null);
+              try {
+                let agentId: string | undefined = draft.agentId ?? undefined;
+                if (agentId) {
+                  /*
+                   * Told to the server so the choice is recorded, and its answer thrown away: the
+                   * person already decided and nothing here may change that. Failing to write the
+                   * audit row must not stop the conversation, so a rejection is swallowed whole.
+                   */
+                  await routeMessage(draft.text, agentId).catch(
+                    () => undefined,
+                  );
+                } else {
+                  try {
+                    agentId = (await routeMessage(draft.text)).agentId;
+                  } catch {
+                    agentId = fallback?.id;
+                  }
                 }
+                if (!agentId) return;
+                await start(agentId, draft.text);
+              } catch (caught) {
+                setError(
+                  caught instanceof Error
+                    ? caught.message
+                    : "Could not start the conversation.",
+                );
+                throw caught;
               }
-              if (!agentId) return;
-              await start(agentId, draft.text);
-            } catch (caught) {
-              setError(
-                caught instanceof Error
-                  ? caught.message
-                  : "Could not start the conversation.",
-              );
-              throw caught;
-            }
-          }}
-          pending={pending}
-        />
-        {fallback ? (
-          // Said out loud: a message that silently reaches somebody you did not choose is the
-          // kind of surprise that costs trust the first time it happens.
-          <p className="mt-2 w-full max-w-2xl text-xs text-muted-foreground text-center">
-            Sent to the coworker it is for. Type <code>@</code> to choose one
-            yourself.
-          </p>
-        ) : null}
-        {error ? (
-          <p
-            className="mt-2 w-full max-w-2xl text-sm text-destructive"
-            role="alert"
-          >
-            {error}
-          </p>
-        ) : null}
-      </div>
-      <div className="mt-10 w-full max-w-2xl">
-        <h2 className="font-bold text-lg">Explore agents</h2>
-        <div className="flex flex-row gap-4 mt-4">
-          {!!explore?.length &&
-            explore.map((agent) => (
-              <Link
-                key={agent.id}
-                to="/channel/new"
-                search={{
-                  agent: agent.id,
-                }}
-              >
-                <AgentCard agent={agent} />
-              </Link>
-            ))}
+            }}
+            pending={pending}
+          />
+          {fallback ? (
+            // Said out loud: a message that silently reaches somebody you did not choose is the
+            // kind of surprise that costs trust the first time it happens.
+            <p className="mt-2 w-full max-w-2xl text-xs text-muted-foreground text-center">
+              Sent to the coworker it is for. Type <code>@</code> to choose one
+              yourself.
+            </p>
+          ) : null}
+          {error ? (
+            <p
+              className="mt-2 w-full max-w-2xl text-sm text-destructive"
+              role="alert"
+            >
+              {error}
+            </p>
+          ) : null}
+        </div>
+        <div className="mt-10 w-full max-w-2xl">
+          <h2 className="font-bold text-lg">Explore agents</h2>
+          <div className="flex flex-row gap-4 mt-4">
+            {!!explore?.length &&
+              explore.map((agent) => (
+                <Link
+                  key={agent.id}
+                  to="/channel/new"
+                  search={{
+                    agent: agent.id,
+                  }}
+                >
+                  <AgentCard agent={agent} />
+                </Link>
+              ))}
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/app/src/routes/_authed/admin/playground.tsx
+++ b/app/src/routes/_authed/admin/playground.tsx
@@ -2,6 +2,7 @@ import { OpenGenerativeUIActivityRenderer } from "@copilotkit/react-core/v2";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useId, useState } from "react";
+import { SidebarToggle } from "@/components/layout/sidebar-toggle";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -127,12 +128,18 @@ function PlaygroundPage() {
      */
     <div className="flex h-screen flex-col">
       <header className="flex flex-wrap items-start justify-between gap-4 border-border border-b px-6 py-4">
-        <div>
-          <h1 className="font-bold text-2xl">Playground</h1>
-          <p className="mt-1 max-w-prose text-pretty text-muted-foreground text-sm leading-relaxed">
-            Write a component here and publish it without a deployment. What you
-            edit is a draft; a conversation only ever draws what is published.
-          </p>
+        {/* Inline rather than in a band of its own: this screen is an editor beside a live preview
+            and every 48px of height is taken from the thing being previewed. */}
+        <div className="flex items-start gap-2">
+          <SidebarToggle className="-ml-2 shrink-0" />
+          <div>
+            <h1 className="font-bold text-2xl">Playground</h1>
+            <p className="mt-1 max-w-prose text-pretty text-muted-foreground text-sm leading-relaxed">
+              Write a component here and publish it without a deployment. What
+              you edit is a draft; a conversation only ever draws what is
+              published.
+            </p>
+          </div>
         </div>
         <div className="flex gap-2">
           <Button

--- a/app/src/routes/_authed/admin/route.tsx
+++ b/app/src/routes/_authed/admin/route.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 import { AdminSidebar } from "@/components/admin/admin-sidebar";
-import { SidebarProvider } from "@/components/ui/sidebar";
+import { SidebarShell } from "@/components/layout/sidebar-shell";
 import { currentUserQueryOptions } from "../../../lib/auth/queries";
 
 export const Route = createFileRoute("/_authed/admin")({
@@ -17,22 +17,11 @@ export const Route = createFileRoute("/_authed/admin")({
 
 function RouteComponent() {
   return (
-    <SidebarProvider
-      /*
-       * The same 300px Settings uses: these two rails hold short nav labels, not the roster's
-       * two-line previews, so they earn less width than the app shell's 340px.
-       */
-      style={
-        {
-          "--sidebar-width": "300px",
-          "--sidebar-width-mobile": "20rem",
-        } as React.CSSProperties
-      }
-    >
+    <SidebarShell width="300px">
       <AdminSidebar />
       <main className="flex-1">
         <Outlet />
       </main>
-    </SidebarProvider>
+    </SidebarShell>
   );
 }

--- a/app/src/routes/_authed/settings/route.tsx
+++ b/app/src/routes/_authed/settings/route.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { SidebarShell } from "@/components/layout/sidebar-shell";
 import { SettingsSidebar } from "@/components/settings/settings-sidebar";
-import { SidebarProvider } from "@/components/ui/sidebar";
 
 export const Route = createFileRoute("/_authed/settings")({
   component: RouteComponent,
@@ -8,22 +8,11 @@ export const Route = createFileRoute("/_authed/settings")({
 
 function RouteComponent() {
   return (
-    <SidebarProvider
-      /*
-       * The same 300px admin uses: these two rails hold short nav labels, not the roster's
-       * two-line previews, so they earn less width than the app shell's 340px.
-       */
-      style={
-        {
-          "--sidebar-width": "300px",
-          "--sidebar-width-mobile": "20rem",
-        } as React.CSSProperties
-      }
-    >
+    <SidebarShell width="300px">
       <SettingsSidebar />
       <main className="flex-1">
         <Outlet />
       </main>
-    </SidebarProvider>
+    </SidebarShell>
   );
 }

--- a/app/tests/sidebar-preference.test.ts
+++ b/app/tests/sidebar-preference.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import {
+  applySidebarOpen,
+  parseStoredSidebarOpen,
+  SIDEBAR_STORAGE_KEY,
+} from "../src/lib/sidebar";
+
+describe("sidebar preference", () => {
+  test("only the stored collapsed value starts the sidebar closed", () => {
+    expect(parseStoredSidebarOpen("collapsed")).toBe(false);
+    expect(parseStoredSidebarOpen("expanded")).toBe(true);
+    expect(parseStoredSidebarOpen(null)).toBe(true);
+  });
+
+  /*
+   * The roster is this app's navigation, so an unreadable value opens the sidebar rather than
+   * guessing it shut. A shell that hides its own navigation on a stale key is a shell with no way
+   * back.
+   */
+  test("an unrecognised stored value leaves the sidebar open", () => {
+    expect(parseStoredSidebarOpen("")).toBe(true);
+    expect(parseStoredSidebarOpen("false")).toBe(true);
+    expect(parseStoredSidebarOpen("Collapsed")).toBe(true);
+  });
+
+  test("persists both states under the key the reader parses", () => {
+    const writes: Array<[string, string]> = [];
+    const effects = {
+      setStoredValue: (key: string, value: string) => writes.push([key, value]),
+    };
+
+    applySidebarOpen(false, effects);
+    applySidebarOpen(true, effects);
+
+    expect(writes).toEqual([
+      [SIDEBAR_STORAGE_KEY, "collapsed"],
+      [SIDEBAR_STORAGE_KEY, "expanded"],
+    ]);
+  });
+
+  /*
+   * The test that matters: the writer and the reader are two functions and nothing but this holds
+   * their vocabulary together. Drift here does not throw, it silently stops restoring the state.
+   */
+  test("a round trip through storage preserves the state", () => {
+    for (const open of [true, false]) {
+      let stored: string | null = null;
+      applySidebarOpen(open, {
+        setStoredValue: (_key, value) => {
+          stored = value;
+        },
+      });
+      expect(parseStoredSidebarOpen(stored)).toBe(open);
+    }
+  });
+});


### PR DESCRIPTION
![Let a person collapse the sidebar, and reach the roster on a phone](https://raw.githubusercontent.com/jerelvelarde/openbot/pr-media/gifs/openbot-collapsible-sidebar.gif)

## The problem

The sidebar has always been able to collapse. `components/ui/sidebar.tsx` arrived with the state, the width transition, an offcanvas mode and a Cmd/Ctrl+B listener, and with `SidebarTrigger` sitting in its exports. Nothing in `app/src` ever rendered that trigger — a grep for it returns the definition and nothing else. The only affordance any of the three shells offered was `SidebarRail`, a 16px transparent strip carrying `tabIndex={-1}`, so the eye could not find it and the keyboard could not reach it at all.

Under 768px that same component stops being a pane and becomes a `Sheet`, keyed on `openMobile`, which starts `false`. With no trigger, nothing ever set it true. The roster is this app's navigation — it is how you reach a channel, Skills, Agents and your own account — and on a phone all of it sat behind a control that did not exist. The trade a person made instead was to not open OpenBot on a phone.

The third piece is smaller and stranger. `setOpen` wrote a `sidebar_state` cookie on every toggle and `SidebarProvider` never read it back, because `defaultOpen` was hardcoded `true`. Whoever found the rail could collapse the sidebar, and the next reload undid it. The code recording the choice and the code ignoring it sat eleven lines apart.

## The approach

**The toggle is drawn in both states, in the chrome each screen already has.** A trigger living inside the sidebar disappears along with the sidebar it hid, so `layout/sidebar-toggle.tsx` goes into the header each screen already draws: the `h-12` bar on a channel and on a new channel, the `<header>` on the admin playground, and `PageShell`'s bar for the thirteen admin screens, five settings screens and two in the app shell. Its `aria-label` names the action rather than the state, and its tooltip carries the shortcut, because an accelerator nobody is told about is not a feature.

**A control that offers to toggle a sidebar survives there being none.** Every screen that draws `PageShell` today sits inside one of the three shells, so reading `useSidebar` unconditionally would work — but a screen that renders `PageShell` outside a provider is a reasonable layout choice, and it would have met a thrown error during render rather than a missing button. `useSidebar` throwing is right for a part **of** a sidebar, where its absence is a wiring bug; this is the other case, so the toggle reads the context optionally and draws nothing when there is none.

**`PageShell`'s bar is now drawn whenever it has something to hold, and that is the one cost worth naming.** It already drew an `h-14 px-3` bar for the five screens with a Back link; a sidebar is now reason enough on its own, because the toggle has to sit at the pane's left edge in both states and the prose column is centred — a control inside it would be 400px from the edge it belongs to on a wide screen. So the fifteen screens that had no Back link gain 40px of headroom above their heading, and those five are pixel-identical. `/assist` and `/link/slack` have neither a sidebar nor a Back link and so draw no bar at all, keeping the space they had.

**Three `_app` screens take a band of their own instead.** The app index and the agents list draw no chrome to put a control in. The Bot screen has a header, but its title row is `items-baseline`, where a 32px icon button aligns to nothing, so it takes the band too rather than have its heading and its description sit ragged. Each is the same 48px band the other `_app` screens already draw, which shifts the index and the agents list down by that much.

**Persistence moved out of the primitive.** The cookie existed so a server-rendered shell could paint the right width on its first byte, and nothing renders this app on a server. `lib/sidebar.ts` now holds the preference in the shape of `lib/theme.ts` beside it — a pure reader and writer with injected effects — and `layout/sidebar-shell.tsx` drives all three shells as controlled state seeded in a `useState` initializer, read before the first paint so a shell left collapsed never flashes open. The dead cookie write is deleted rather than left standing as a second, staler answer. One key is shared across the three shells: "I like my sidebar collapsed" reads as one preference, not three.

**Mobile needed no code of its own.** `toggleSidebar()` already branched on `isMobile` to `setOpenMobile`, so the same trigger opens the Sheet. Storage is deliberately not consulted there: a panel covering the screen it overlays has no business being open before anybody asked.

## What is not covered

- **No icon rail.** Collapsing is offcanvas only. The roster's header is a full-width search box and its rows are two-line previews; neither has a sensible 48px form, so an icon mode would be a second design rather than a narrower one.
- **`SidebarRail` is unchanged**, still invisible and still `tabIndex={-1}`. With a real labelled trigger it is a harmless secondary affordance, and it is a vendored shadcn file.
- **No committed render test for the toggle.** `app/tests/auth-client.test.ts` assigns `globalThis.window` with a plain `=` and `src/router.tsx` builds its router at module scope, so the suite's first happy-dom registration would arm exactly the order-dependent CI failure that pair produces. The toggle was verified with a throwaway harness; changing that `=` to `??=` is a separate change that would unblock render tests app-wide.
- **The `_app` shell still has no shared top bar**, which is why three screens needed a band at all. Extracting one is a layout refactor, not this.
- **The recording ran against a local stack with no Intelligence configured**, hence the empty transcripts; the resulting invalid-license banner was suppressed for the capture.

## Verification

`bun run format:check`, `bun run lint`, `bun run --cwd app typecheck` and `bun run --cwd app build` are clean. The full `bun test` against a local Postgres is 2068 pass, 23 skip, 0 fail across 171 files; `bun test app/tests` alone is 180 pass, 0 fail. Every file in the branch is under `app/`. Every screen sitting under a shell was audited for whether it actually has a toggle, which is how the admin playground — the one page that keeps its own geometry and so never adopted `PageShell` — was found.

`app/tests/sidebar-preference.test.ts` holds down the preference module: only the exact stored `collapsed` starts the sidebar closed, an unrecognised value opens it rather than guessing it shut, and a round trip through storage returns the state it was given. That last one is the test that matters — the reader and the writer are two functions, nothing else keeps their vocabulary aligned, and drift there does not throw, it silently stops restoring the choice.

The recording above is a browser session against this branch: collapse and reopen on a channel, the same control on Settings, a full reload with the choice remembered, and the roster opening at a 390px viewport.

## Merge notes

`PageShell` and `components/ui/sidebar.tsx` are both shared. A branch adding a `PageShell` screen inherits the toggle for free but will conflict on the header block if it touched that region, and a branch relying on the `sidebar_state` cookie will find it no longer written.
