### PR TITLE
fix(server): align TRUSTED_ORIGINS fallback with app default port 3010

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -502,7 +502,7 @@ function authConfig(
     secret,
     trustedOrigins: commaSeparated(environment, "TRUSTED_ORIGINS").length
       ? commaSeparated(environment, "TRUSTED_ORIGINS")
-      : ["http://localhost:3000"],
+      : ["http://localhost:3010"],
     initialAdminEmails,
     ...(google ? { google } : {}),
     ...(microsoft ? { microsoft } : {}),

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -196,7 +196,7 @@ describe("deployment configuration", () => {
         clientId: "google-client-id",
         clientSecret: "google-client-secret",
       },
-      trustedOrigins: ["http://localhost:3000"],
+      trustedOrigins: ["http://localhost:3010"],
       initialAdminEmails: ["admin@openbot.test", "owner@openbot.test"],
     });
   });


### PR DESCRIPTION
### Problem

`server/src/config.ts:503-505` fell back to `["http://localhost:3000"]`:

```ts
trustedOrigins: commaSeparated(environment, "TRUSTED_ORIGINS").length
  ? commaSeparated(environment, "TRUSTED_ORIGINS")
  : ["http://localhost:3000"],
```

Every other default in the repo is `3010`:

- `.env.example:94` `TRUSTED_ORIGINS=http://localhost:3010`
- `app/vite.config.ts:15` `APP_PORT 3010`
- `scripts/start.sh:28` `APP_PORT 3010`
- `server/src/config.ts:875-876` `appUrl` reads `TRUSTED_ORIGINS[0]` as fallback, so the wrong value propagates to OAuth `appUrl`

With `TRUSTED_ORIGINS` unset (valid when `singleUser` is on or in a minimal staging env), Better-Auth validates OAuth against a port nothing listens on (`3000`); Google/Microsoft/Okta redirects 404 while `BETTER_AUTH_URL` stays on `3001`. Silent until first sign-in, and `singleUser` hides it locally.

### Fix

- `server/src/config.ts:505`: fallback → `["http://localhost:3010"]`
- `server/tests/config.test.ts:199`: align expectation

### Verification

`bun run lint` — pass
`bun run format:check` — pass
`bun test server/tests/config.test.ts` — 72 pass, 0 fail
`grep -rn "localhost:3000" server/src/app` — 0 hits after fix (remaining hits are unrelated test fixtures in `computer-*.test.ts` that intentionally test private-host blocking)
No schema/migration/dependency changes.