### PR TITLE
Tell the channel that was running that it has stopped, not the one just opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,18 @@ to authenticate. In the same spirit, the handoff panel explains once when a cowo
 work on (it runs as its own agent, outside this deployment's loop) instead of offering switches the
 server can only refuse; its existing grants stay visible so they can still be revoked.
 
+### A channel stops showing a working indicator once its turn has ended
+
+Sending a message and then opening another channel before the reply arrived left the first channel
+showing three bouncing dots on the roster, and they stayed there after the answer had landed and
+been drawn into its preview, until the roster was refetched for some unrelated reason. A person's
+own turn is reported by the browser, because the server is not told when one begins, and that
+reporting was keyed on state belonging to the channel screen: opening another channel replaced the
+screen, and the replacement reported the channel it had just opened rather than the one still
+working. The report now belongs to the turn instead of to the screen, so the channel that was
+running is the channel told when it stops. Opening a channel also no longer announces that it is
+idle twice before anything has run in it.
+
 ### A hop the boundary refused now names the Bot that was refused
 
 The audit page renders its Bot column from `payload.bot` and nothing else. `agent.handoff_offered`

--- a/app/src/components/channels/channel-chat.tsx
+++ b/app/src/components/channels/channel-chat.tsx
@@ -16,7 +16,7 @@ import {
 import { agentListQueryOptions } from "@/lib/agents/queries";
 import {
   recordChannelActivityMutationOptions,
-  setChannelBusyMutationOptions,
+  setChannelBusy,
 } from "@/lib/channels/mutations";
 import {
   type AgentChannel,
@@ -291,6 +291,8 @@ export function ChannelChat({
    * first one to finish declare the conversation idle.
    */
   const [turnsInFlight, setTurnsInFlight] = useState(0);
+  /* Authoritative once this screen unmounts, where `setTurnsInFlight` becomes a no-op. */
+  const turnsRef = useRef(0);
   const [runsInFlight, setRunsInFlight] = useState(0);
 
   /**
@@ -298,23 +300,6 @@ export function ChannelChat({
    */
   const recordActivity = useMutation(recordChannelActivityMutationOptions());
 
-  /*
-   * Show this channel as working on the roster while its own turn runs.
-   *
-   * The server cannot see a person's turn begin — the runtime does not tell it — so the browser
-   * reports it, keyed on whether a turn is in flight. The server broadcasts it to every member, so
-   * the row shows the dots even on a tab that has since navigated elsewhere; a run that outlives
-   * this tab clears itself when the roster next refetches, which is the acceptable failure for a
-   * transient hint. Not cleared on unmount on purpose: a turn keeps running server-side after the
-   * person leaves the channel, and clearing here would drop the indicator while the work goes on.
-   */
-  const setBusy = useMutation(setChannelBusyMutationOptions());
-  const busy = turnsInFlight > 0;
-  // Keyed on the busy transition alone; `setBusy.mutate` is a stable handle, not a dependency.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: firing on the busy transition only.
-  useEffect(() => {
-    setBusy.mutate({ channelId: channel.id, busy });
-  }, [busy, channel.id]);
   const report = (text: string, agentId: string | null) => {
     const trimmed = text.trim();
     if (!trimmed) return;
@@ -411,11 +396,21 @@ export function ChannelChat({
     const trimmed = text.trim();
     if (!trimmed) return;
 
-    setTurnsInFlight((count) => count + 1);
+    turnsRef.current += 1;
+    setTurnsInFlight(turnsRef.current);
+    if (turnsRef.current === 1) {
+      void setChannelBusy({ channelId: channel.id, busy: true });
+    }
     try {
       await deliver(trimmed, skillInstructions);
     } finally {
-      setTurnsInFlight((count) => count - 1);
+      turnsRef.current -= 1;
+      setTurnsInFlight(turnsRef.current);
+      // Sent from here rather than from an effect on `turnsInFlight`: this runs after unmount, that
+      // does not, and the last turn out is what takes the roster's working indicator down.
+      if (turnsRef.current === 0) {
+        void setChannelBusy({ channelId: channel.id, busy: false });
+      }
     }
   };
 

--- a/app/src/lib/channels/mutations.ts
+++ b/app/src/lib/channels/mutations.ts
@@ -76,12 +76,6 @@ export async function setChannelBusy(variables: {
   });
 }
 
-export function setChannelBusyMutationOptions() {
-  return mutationOptions({
-    mutationFn: setChannelBusy,
-  });
-}
-
 /** Pin or unpin a channel for this member. A marker, not a reorder, so no optimistic sort. */
 export function setChannelPinnedMutationOptions(queryClient: QueryClient) {
   return mutationOptions({

--- a/app/src/lib/channels/mutations.ts
+++ b/app/src/lib/channels/mutations.ts
@@ -62,15 +62,23 @@ export function recordChannelActivityMutationOptions() {
  * worth nothing next to the run itself, and a person is never shown an error for it. The server
  * broadcasts it to the channel's members, so the row shows a working dot even on a tab that has
  * navigated elsewhere.
+ *
+ * A plain function, not a mutation handle: the turn it reports on outlives the screen that started
+ * it, and `mutate` on an unmounted component is a no-op.
  */
+export async function setChannelBusy(variables: {
+  channelId: string;
+  busy: boolean;
+}) {
+  await tryClient(`/api/channels/${variables.channelId}/busy`, {
+    method: "POST",
+    body: { busy: variables.busy },
+  });
+}
+
 export function setChannelBusyMutationOptions() {
   return mutationOptions({
-    mutationFn: async (variables: { channelId: string; busy: boolean }) => {
-      await tryClient(`/api/channels/${variables.channelId}/busy`, {
-        method: "POST",
-        body: { busy: variables.busy },
-      });
-    },
+    mutationFn: setChannelBusy,
   });
 }
 


### PR DESCRIPTION
## What this changes

A channel stops showing a working indicator once its turn has ended, including when the person has
moved to another channel in the meantime.

`busy` was reported from an effect keyed on `[busy, channel.id]`, where `busy` came from component
state. `ChannelChat` remounts per channel, so opening another one left the running turn's
`busy: true` with nothing to revoke it: the new instance posts `busy: false` for the channel just
opened, and the old instance's decrement lands on an unmounted component, where `setState` is a
no-op and the effect never re-runs. Nothing else sends it. `onRunBusy` fires only inside `threadLock`
(`copilot.ts:1177`, `copilot.ts:1218`) and its one consumer is the handoff delivery at
`index.ts:883`, which a person's run does not pass through.

The signal now comes from the turn rather than from the screen. `say` holds the count in a ref, posts
`busy: true` on the first turn in and `busy: false` on the last turn out, and does it through a plain
function rather than a mutation handle, because the async continuation survives unmount even though
the state update does not. Opening a channel also stops posting a redundant `busy: false` twice
before anything has run in it.

Fixes #314.

## Where it runs

- [x] **New state that outlives a request?** None. The counter is a ref inside one component,
      replacing state that was already there. `busy` remains what it was: never queried, never
      stored, announced only.
- [x] **What happens on the second replica?** Unchanged. The POST may land on any replica and fans
      out over `channel_activity` exactly as before, and nothing new is read or written on the way.
- [x] **Anything serialised?** Nothing new. No two processes contend over anything here.
- [x] **Anything fanned out to a browser?** Only the existing busy event over the existing Postgres
      `NOTIFY`. This changes which moments produce one, not how one travels.
- [x] **New listener, port, or schedule?** None. Strictly fewer requests than before: two fewer per
      channel opened, one more only where one was previously missing.

## Boundary and audit

- [x] Every acting call still goes through the gateway. No acting path is touched.
- [x] New refusals and new failures each write a row. Neither is introduced.
- [x] Nothing new is trusted from the client. The same channel id and boolean as before, against the
      same membership check.

## Changelog

- [x] A line in `CHANGELOG.md` under `Unreleased`.

## Proof

Run against the local stack, with `fetch` wrapped in the page to record every `/busy` and `/activity`
call. Same steps both times: send a message, switch channel immediately, wait for the reply.

Before:

```
db0bab97/busy :: {"busy":false}     <- on opening the channel
db0bab97/busy :: {"busy":false}
db0bab97/busy :: {"busy":true}      <- turn starts
db0bab97/activity :: {"agentId":null,...}
47f93ad9/busy :: {"busy":false}     <- the channel moved to, clearing itself
47f93ad9/busy :: {"busy":false}
```

No `false` for `db0bab97`. Dots still showing 45 seconds after the reply completed.

After:

```
db0bab97/busy :: {"busy":true}
db0bab97/activity :: {"agentId":null,...}
db0bab97/activity :: {"agentId":"general-assistant",...}
db0bab97/busy :: {"busy":false}     <- sent from the turn, after the screen was gone
```

Dots cleared, preview correct, and the two mount-time posts are gone.

No unit test. The defect is which component emits the signal, and there is no component-test harness
here: every file in `app/tests` tests a module directly, and standing one up for this would be a
larger change than the fix. `bun run typecheck`, `bun run lint` and `bunx biome format .` are clean,
and 206 app tests plus `server/tests/channel-events.integration.test.ts` pass.
