### PR TITLE
Reference the release checks by the repository's own syntax

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -100,7 +100,7 @@ jobs:
   checks:
     needs: [metadata, verify]
     if: needs.metadata.outputs.is_release == 'true'
-    uses: ./.github/workflows/ci.yml
+    uses: $/.github/workflows/ci.yml
     permissions:
       contents: read
 


### PR DESCRIPTION
## What this changes

One line in `publish-release.yml`. The release gate calls CI as a reusable workflow, and it named it
`./.github/workflows/ci.yml`. GitHub resolves both that and `$/.github/workflows/ci.yml` the same
way, from the caller's own commit, but the relative form is the same spelling a path on disk takes
and hides the fact that it is resolved against the repository rather than the checkout.

## Why now

zizmor 0.6.3 added the `self-repository` audit, which flags exactly this. It is low severity and has
an auto-fix, but the security workflow exits non-zero on any finding, so #300 (the bump to 0.6.3)
cannot go green until this lands.

Verified against GitHub's own reusable-workflow documentation: `$/` is the supported syntax for a
workflow in the same repository. The one caveat is that it is not available on GitHub Enterprise
Server, which does not apply here.