### PR TITLE
Give a duplicated coworker the endpoint it was copied from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### Duplicating a coworker keeps the endpoint it was copied from
+
+Duplicate used to point every copy at this deployment's own managed Bot, whatever the coworker being
+copied ran on. Duplicating one you host yourself gave back something that looked identical on every
+screen, carried the same name, title and role, and answered from a different process. The copy's
+connection tab then said it ran here and stopped showing an endpoint at all, so the swap was
+invisible in the one place you would have checked. A copy now runs where its original ran, and the
+managed Bot is used only when the coworker being copied had no endpoint of its own, which is the
+same fallback that applies when you create one without an endpoint. It does not inherit the
+original's key: that is a reference into the vault, and two coworkers sharing one credential would
+mean rotating either one's key silently changed the other's, so a copy starts without one. On a
+deployment with no managed Bot configured, duplicating a coworker that brought its own endpoint now
+works instead of being refused with advice to give it an endpoint it already had.
+
 ### Coworkers are made in a wizard and managed in a dialog
 
 Creating a coworker is now a three-step wizard — who it is, who may see it, then where it runs,

--- a/server/src/agents/profile-store.ts
+++ b/server/src/agents/profile-store.ts
@@ -437,7 +437,12 @@ export function createAgentProfileStore(
         const source = await findAccessibleProfile(transaction, actor, id);
         if (!source) throw new AgentNotFoundError(id);
 
-        if (!managedConfiguration) {
+        // The endpoint alone: `auth` is a vault reference, and copying it shares one credential.
+        const configuration = source.endpoint
+          ? { endpoint: source.endpoint }
+          : managedConfiguration;
+        // After the source read, so a source with its own endpoint needs no managed Bot to fall back to.
+        if (!configuration) {
           throw new ManagedAgentUnavailableError();
         }
         const duplicateId = newAgentId();
@@ -445,7 +450,7 @@ export function createAgentProfileStore(
           id: duplicateId,
           name: source.name,
           type: "remote_ag_ui",
-          configuration: managedConfiguration,
+          configuration,
         });
         await transaction.insert(agentProfiles).values({
           agentId: duplicateId,

--- a/server/tests/agent-profile-store.integration.test.ts
+++ b/server/tests/agent-profile-store.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { and, eq, sql } from "drizzle-orm";
+import { authFromConfiguration } from "../src/agents/auth-header";
 import {
   AgentNotFoundError,
   AgentNotManageableError,
@@ -589,6 +590,85 @@ describe("agent profile store integration", () => {
     expect(sourceMappings).not.toHaveLength(0);
     expect(duplicateChannelAgents).toHaveLength(0);
     expect(duplicateMappings).toHaveLength(0);
+  });
+
+  test("copies the source's own endpoint rather than repointing the copy at the managed Bot", async () => {
+    const owner = await createUser();
+    const source = await createProfileFixture({
+      owner,
+      configuration: { endpoint: "https://hosted.example.test/ag-ui" },
+    });
+
+    const duplicate = await store.duplicate(owner, source.agentId);
+    createdAgentIds.push(duplicate.id);
+
+    expect(duplicate.endpoint).toBe("https://hosted.example.test/ag-ui");
+    expect(duplicate.endpoint).not.toBe(managedAgentAgUiUrl.toString());
+  });
+
+  test("gives a copy of an endpoint-less source the managed Bot, as its source had", async () => {
+    const owner = await createUser();
+    const created = await store.create(owner, {
+      name: `Created ${randomUUID()}`,
+      title: "Created Title",
+      roleDescription: "Created role description.",
+      visibility: "private",
+    } as CreateAgentInput);
+    createdAgentIds.push(created.id);
+
+    const duplicate = await store.duplicate(owner, created.id);
+    createdAgentIds.push(duplicate.id);
+
+    expect(duplicate.endpoint).toBe(managedAgentAgUiUrl.toString());
+  });
+
+  test("does not carry the source's stored key onto the copy", async () => {
+    const owner = await createUser();
+    const source = await createProfileFixture({
+      owner,
+      configuration: {
+        endpoint: "https://hosted.example.test/ag-ui",
+        auth: { header: "Authorization", credentialId: "credential-1" },
+      },
+    });
+    expect((await profileById(owner, source.agentId)).hasAuth).toBe(true);
+
+    const duplicate = await store.duplicate(owner, source.agentId);
+    createdAgentIds.push(duplicate.id);
+
+    expect(duplicate.hasAuth).toBe(false);
+    const [row] = await database
+      .select({ configuration: agents.configuration })
+      .from(agents)
+      .where(eq(agents.id, duplicate.id));
+    expect(authFromConfiguration(row?.configuration)).toBeNull();
+  });
+
+  test("duplicates a coworker with its own endpoint on a deployment with no managed Bot", async () => {
+    const unmanagedStore = createAgentProfileStore(database, undefined);
+    const owner = await createUser();
+    const source = await createProfileFixture({
+      owner,
+      configuration: { endpoint: "https://hosted.example.test/ag-ui" },
+    });
+
+    const duplicate = await unmanagedStore.duplicate(owner, source.agentId);
+    createdAgentIds.push(duplicate.id);
+
+    expect(duplicate.endpoint).toBe("https://hosted.example.test/ag-ui");
+  });
+
+  test("refuses to duplicate an endpoint-less coworker with no managed Bot to fall back to", async () => {
+    const unmanagedStore = createAgentProfileStore(database, undefined);
+    const owner = await createUser();
+    const source = await createProfileFixture({
+      owner,
+      configuration: {},
+    });
+
+    await expect(
+      unmanagedStore.duplicate(owner, source.agentId),
+    ).rejects.toBeInstanceOf(ManagedAgentUnavailableError);
   });
 
   test("soft deletes a profile from reads and lists while retaining its raw rows", async () => {


### PR DESCRIPTION
Closes #327.

## What this changes

Duplicating a coworker now gives back a copy that runs where the original ran.

`duplicate()` wrote the managed Bot's address into every copy without reading the source, so duplicating a coworker hosted at its own AG-UI endpoint produced one answering from a different process under the same name, title and role. The copy's `builtIn` flipped to true as a result, and the connection section hides the endpoint entirely once that is set, so the swap was invisible on the one screen somebody would check.

The managed address is the fallback `create()` already applies to a coworker given no endpoint. This makes `duplicate()` treat it the same way rather than as a rule, which fixes three things at once:

- A copy of a coworker with its own endpoint keeps that endpoint.
- A copy of an endpoint-less coworker still runs on the managed Bot, as its source did.
- Duplicate works on a deployment with no managed Bot when the source brought its own endpoint. It refused there before, telling the person to give the coworker an endpoint it already had.

The endpoint alone is inherited, never the rest of the configuration. `auth` is a reference into the vault, so copying it would leave two coworkers sharing one credential, where rotating either one's key silently changes the other's. A copy starts with no key and fails closed at its endpoint until somebody gives it one.

Not changed here: `avatarSeed` is copied from the source and is pinned by an existing test, so a copy still renders the source's avatar. That is worth deciding on its own rather than inside this change.

## Where it runs

- [x] **New state that outlives a request?** None. One `INSERT` gains a value read from the row being copied, inside the transaction that already reads it.
- [x] **What happens on the second replica?** No change. `duplicate()` reads its source and writes its copy in one transaction, and the value it now writes comes from that transaction's own read rather than from process configuration. Two replicas duplicating the same source produce two copies with distinct minted ids, exactly as before.
- [x] **Anything serialised?** Nothing new. The existing transaction is unchanged, and the added read is of the row it already selected.
- [x] **Anything fanned out to a browser?** No. The agent list is refetched by the client after a create or duplicate as it was.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: unchanged, no acting call is added or moved.
- [x] New refusals and new failures each write a row: no new refusal is introduced. `ManagedAgentUnavailableError` still fires, on a strictly smaller set of cases (no managed Bot **and** no endpoint on the source), and is mapped by the same `mapStoreError` path as before.
- [x] Nothing new is trusted from the client that the server can resolve itself: the endpoint is read from the stored source row, not accepted from the request.

## Changelog

- [x] Added under `Unreleased`.

## Proof

Five tests added to `server/tests/agent-profile-store.integration.test.ts`, which exercises the real store against Postgres.

Run against the unfixed code first, two fail and three pass. The two that fail are the proof; the three that pass pin behaviour this change must not break.

```
(fail) copies the source's own endpoint rather than repointing the copy at the managed Bot
  Expected: "https://hosted.example.test/ag-ui"
  Received: "https://managed.example.test/ag-ui"

(fail) duplicates a coworker with its own endpoint on a deployment with no managed Bot
  ManagedAgentUnavailableError: This deployment has no managed Bot. Give the coworker its own AG-UI endpoint.

 18 pass, 2 fail
```

After the change:

```
 20 pass, 0 fail
```

The three that passed both before and after:

- an endpoint-less source still gets the managed Bot,
- the source's stored key is not carried onto the copy (asserted on the copy's `hasAuth` and on `authFromConfiguration` over its stored row),
- duplicate still refuses when there is no managed Bot and no endpoint on the source to inherit.

Verified end to end against a running server as well, not only in tests. A coworker created at `http://localhost:4201/ag-ui` duplicates to a copy at `http://localhost:4201/ag-ui` with `builtIn: false`; an endpoint-less coworker duplicates to the managed address with `builtIn: true`; and a second server started with both `MANAGED_AGENT_*` variables unset returns `201` for the first case where it returned `400` before.

Full server suite run with the local dev server and worker stopped, since they contend on the same database and make the lease tests flap. The set of failing tests is identical with and without this change (six, all pre-existing, in `routine-sweep.integration.test.ts` and `agent-handoff-*.integration.test.ts`); compared by test name rather than by count. `typecheck`, `lint` and `format` are clean.
