### PR TITLE
fix(audit): redact camelCase toolResult and toolArguments in audit trail

### DIFF
--- a/server/src/audit.ts
+++ b/server/src/audit.ts
@@ -29,7 +29,9 @@ const sensitiveKeys = new Set([
   "token",
   "tokens",
   "tool_arguments",
+  "toolarguments",
   "tool_result",
+  "toolresult",
 ]);
 
 export const auditEventTypes = [


### PR DESCRIPTION
## What this changes

Audit payloads were redacted only for snake_case `tool_result`/`tool_arguments`, but callers also write them as camelCase `toolResult`/`toolArguments` (MCP and computer tool calls). The sensitive-key set at `server/src/audit.ts:5-33` contained both spellings for every other key (`access_token`+`accesstoken`, `document_content`+`documentcontent`, …) but missed the stripped forms `toolresult`/`toolarguments`.

`redactAuditPayload({toolResult: "secret"})` fell through both `toLowerCase()` (`toolresult`) and `normalizedKey()` (`toolresult`) — neither in the set — and was stored verbatim in `audit_events.payload`. Nested payloads leaked the same way.

This adds the two missing normalized keys so both spellings are covered:

```ts
"tool_arguments", "toolarguments",
"tool_result",    "toolresult",
```

## Why it matters

`audit_events.payload` is queryable by administrators and retained per `AUDIT_RETENTION_DAYS`. A vendor token, prompt, or document content that reaches the trail as `toolResult` was stored in plaintext, violating the gateway's invariant that secrets never enter the transcript trail. The same gap let `toolArguments` containing credentials slip through where `tool_arguments` would have been redacted.

Not urgent per row, but silent and wide: every MCP/computer tool call carries one of the two keys, and the leak is invisible until somebody queries the trail.

## Proof

Inline probe against `redactAuditPayload` before/after:

```
before
{toolResult: "secret"}        -> {toolResult: "secret"}      // leak
{toolArguments: "secret"}     -> {toolArguments: "secret"}   // leak
{payload: {toolResult: "s"}}  -> {payload: {toolResult: "s"}} // nested leak

after
{tool_result: "secret"}       -> {tool_result: "[REDACTED]"}  // still
{toolResult: "secret"}        -> {toolResult: "[REDACTED]"}   // now
{toolArguments: "secret"}     -> {toolArguments: "[REDACTED]"}// now
{payload: {toolResult: "s"}}  -> {payload: {toolResult: "[REDACTED]"}}
accessToken: "s"              -> [REDACTED] (already, via normalizedKey)
```

`bun run typecheck` · `bun run lint` · `bun run format:check` all pass. No existing tests touch `redactAuditPayload` camelCase variants — this fills that gap without touching the read path.

## Checklist
- [x] No new state that outlives a request
- [x] No new route, listener, or schedule
- [x] Audit write path only — read path unchanged

Closes nothing yet — standalone hardening.