### PR TITLE
fix(agent-endpoint): correctly handle bracketed IPv6 hosts with port in allowed list

### DIFF
--- a/server/src/agents/endpoint.ts
+++ b/server/src/agents/endpoint.ts
@@ -49,7 +49,7 @@ function namedAsAllowed(
     return false;
   }
   const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  const host = url.host.toLowerCase().replace(/^\[/, "").replace(/\]/, "");
+  const host = url.port ? `${hostname}:${url.port}` : hostname;
   return allowedHosts.has(host) || allowedHosts.has(hostname);
 }
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -634,9 +634,23 @@ function agentEndpointAllowedHosts(
         `AGENT_ENDPOINT_ALLOWED_HOSTS entry "${entry}" must name one host. Patterns are not accepted: list each address instead.`,
       );
     }
-    hosts.add(host.replace(/^\[/, "").replace(/\]$/, ""));
+    hosts.add(normalizeAllowedHost(host));
   }
   return hosts;
+}
+
+function normalizeAllowedHost(host: string): string {
+  // IPv6 is bracketed as [host] or [host]:port. Strip the brackets and keep the port.
+  if (host.startsWith("[")) {
+    const close = host.indexOf("]");
+    if (close === -1) return host.replace(/^\[/, "").replace(/\]$/, "");
+    const ipv6 = host.slice(1, close).toLowerCase();
+    const rest = host.slice(close + 1);
+    if (!rest) return ipv6;
+    if (rest.startsWith(":")) return `${ipv6}${rest.toLowerCase()}`;
+    return `${ipv6}${rest.toLowerCase()}`;
+  }
+  return host;
 }
 
 function privateHostsAllowed(environment: Environment): boolean {


### PR DESCRIPTION
## What this changes

`AGENT_ENDPOINT_ALLOWED_HOSTS` is the narrow allow-list that lets a deployment reach a private agent address without opening the whole network (`AGENT_COMPUTER_ALLOW_PRIVATE_HOSTS`). For IPv6 the host is written bracketed as `[::1]:8080` or `[::1]`.

The previous normalization did:

```ts
host.replace(/^\[/, "").replace(/\]$/, "")
```

For `[::1]:8080` that stripped the leading `[` to `::1]:8080` and left the `]` because the string ends with `0`, not `]`. The stored entry became `::1]:8080`.

`endpoint.ts:52` did a different strip:

```ts
url.host.replace(/^\[/, "").replace(/\]/, "")
```

which for `[::1]:8080` produced `::1:8080`. The two sides never matched, so a named IPv6 endpoint was `refused` with "inside this deployment's own network" even though the deployment had explicitly named it. A deployment reaching its own LangGraph or BYO agent over IPv6 loopback or ULA could not be configured at all.

This normalizes both sides consistently:

* **Config** (`server/src/config.ts:619`): parse `[host]:port` explicitly — find the closing `]`, take the IPv6 inside and the optional `:port` after it. `[::1]:8080` stores as `::1:8080`, `[::1]` as `::1`.
* **Endpoint check** (`server/src/agents/endpoint.ts:51`): derive `hostname` as `url.hostname` stripped of brackets, and `host` as `hostname + (port ? :port)` rather than string-replacing `url.host`. This matches the stored form on both Bun (hostname `[::1]`) and Node.

Behaviour after:

* `AGENT_ENDPOINT_ALLOWED_HOSTS=[::1]:8080` allows `http://[::1]:8080/ag-ui` and refuses `http://[::1]:9090/ag-ui` (port pinned).
* `AGENT_ENDPOINT_ALLOWED_HOSTS=[::1]` allows any port on `::1` — the existing "host without port covers any port" rule.
* IPv4/hostname paths unchanged: `10.0.0.42:9000` pins that port, `10.0.0.42` and `agents.internal` cover any port, exactly as before.

## Why it matters

Private IPv6 loopback (`::1`) and ULAs (`fc00::/7`) are the IPv6 answers to `10/8`/`192.168/16`. A deployment whose BYO agent or LangGraph runs in a container reached over `http://[::1]:4201` had no way to name that address — the one host it legitimately needs is the one the check rejected. The failure is silent at config time and surfaces as a refused agent at runtime, with nothing in the trail naming the mis-normalization.

## Proof

Before:

```
AGENT_ENDPOINT_ALLOWED_HOSTS=[::1]:8080, check http://[::1]:8080/ag-ui => refused (inside network)
stored entry was "::1]:8080" vs derived "::1:8080" => never equal
```

After (verified inline against `loadConfig` + `checkAgentEndpoint`):

```
[::1]:8080 => stored ["::1:8080"], check http://[::1]:8080/ag-ui => allowed: true
[::1]:8080 => check http://[::1]:9090/ag-ui => allowed: false (pinned)
[::1]      => stored ["::1"], check http://[::1]:9090/ag-ui => allowed: true (covers any port)
10.0.0.42:9000 => stored, check :9000 => true, :9001 => false (unchanged)
agents.internal (non-private) => always allowed (unchanged)
```

`bun test server/tests/config.test.ts` — 72 pass, 0 fail. `bun run typecheck` · `bun run lint` · `bun run format:check` clean. No other caller uses the stripped form.

## Checklist
- [x] No new state, route, or schedule
- [x] Private-host floor still checked first via `checkNavigationTarget`
- [x] `AGENT_ENDPOINT_ALLOWED_HOSTS` exact-match semantics preserved (host with port pins, without covers any port)
- [x] IPv4 and hostname paths untouched