### PR TITLE
Send a stored MCP token with the scheme it names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A custom MCP server token is sent with the scheme it names
+
+Every token stored against a custom MCP server went out as `Bearer`, whatever the vendor asked for.
+A server that forwards the header to an API speaking Basic auth still answers the handshake and the
+tool listing, so the Plugins page showed the connector connected and its tools offered, and every
+real call came back 401. DataForSEO's hosted server behaves exactly this way.
+
+A token that begins with `Basic ` or `Bearer ` is now sent as written, so paste the credential the
+vendor gives you, scheme and all. A bare token is still sent as `Bearer`, so nothing already
+working needs to change.
+
 ### Coworkers are made in a wizard and managed in a dialog
 
 Creating a coworker is now a three-step wizard — who it is, who may see it, then where it runs,

--- a/server/src/plugins/mcp.ts
+++ b/server/src/plugins/mcp.ts
@@ -199,6 +199,22 @@ function vendorFailure(error: unknown): string {
 }
 
 /**
+ * The Authorization header a stored token becomes.
+ *
+ * Bearer by default, which is what an MCP server's own token usually is. A token that already
+ * names its scheme is sent as written, because some vendors forward the header straight to an API
+ * that only speaks Basic: DataForSEO's hosted server answers the handshake and the tool listing to
+ * anything, then returns 401 on every real call made with Bearer, so a deployment that could only
+ * say Bearer looked connected and never worked. The scheme travels with the credential rather than
+ * as a setting on the server row, so rotating a token can change how it is presented and nothing
+ * else has to know.
+ */
+export function authorizationHeader(token: string): string {
+  const trimmed = token.trim();
+  return /^(basic|bearer)\s+\S/i.test(trimmed) ? trimmed : `Bearer ${trimmed}`;
+}
+
+/**
  * Build, use and close a client.
  *
  * The `finally` closes the transport whatever happened, because a thrown error is the case where a
@@ -210,7 +226,7 @@ async function withClient<T>(
 ): Promise<T> {
   const transport = new StreamableHTTPClientTransport(new URL(connection.url), {
     requestInit: connection.token
-      ? { headers: { Authorization: `Bearer ${connection.token}` } }
+      ? { headers: { Authorization: authorizationHeader(connection.token) } }
       : undefined,
   });
   const client = new Client({ name: "openbot", version: "1.0.0" });

--- a/server/tests/plugin-mcp-authorization.test.ts
+++ b/server/tests/plugin-mcp-authorization.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { authorizationHeader } from "../src/plugins/mcp";
+
+describe("authorizationHeader", () => {
+  test("a bare token is sent as Bearer", () => {
+    expect(authorizationHeader("abc123")).toBe("Bearer abc123");
+  });
+  test("a token that names Basic is sent as written", () => {
+    expect(authorizationHeader("Basic dXNlcjpwYXNz")).toBe(
+      "Basic dXNlcjpwYXNz",
+    );
+  });
+  test("a token that names Bearer is not doubled", () => {
+    expect(authorizationHeader("Bearer abc123")).toBe("Bearer abc123");
+  });
+  test("the scheme is matched without regard to case, and whitespace is trimmed", () => {
+    expect(authorizationHeader("  basic dXNlcjpwYXNz  ")).toBe(
+      "basic dXNlcjpwYXNz",
+    );
+  });
+  test("a scheme word with nothing after it is treated as a bare token", () => {
+    expect(authorizationHeader("Basic")).toBe("Bearer Basic");
+  });
+});


### PR DESCRIPTION
## The problem

Every token stored against a custom MCP server is sent as `Authorization: Bearer <token>`, with no
way to say otherwise. Some vendors forward that header straight through to an API that only speaks
Basic auth. Those servers still answer `initialize` and `tools/list` to anything, so the Plugins
page reports the connector connected, the tools are listed and offered to Bots, and then every real
tool call comes back 401. DataForSEO's hosted MCP server behaves exactly this way, and the failure
is invisible until somebody reads a tool result.

There was no workaround from the UI: whatever the operator pasted, the header said Bearer.

## What changed

`authorizationHeader()` in `server/src/plugins/mcp.ts` decides the header a stored token becomes.
A token that already names its scheme, meaning it starts with `Basic ` or `Bearer ` followed by a
credential, is sent as written. A bare token is still sent as `Bearer <token>`, so every connector
that works today keeps working and nothing needs re-entering.

The scheme travels with the credential instead of becoming another column on the server row. That
keeps rotation to one field: pasting a new token can change how it is presented and no other part
of the connector has to know.

A scheme word with nothing after it is treated as a bare token, since that is far more likely to be
a credential that happens to read like the word than a header with a missing value.

## How it was verified

- `server/tests/plugin-mcp-authorization.test.ts` covers the five cases: a bare token, a token
  already carrying `Basic`, one already carrying `Bearer`, surrounding whitespace, and a scheme
  word with no credential after it. 5 pass, 0 fail.
- `bun run typecheck` clean across app, server and worker.
- `bunx biome check` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
