### PR TITLE
Restore stored history when it is ahead of the join snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### Reopening a channel no longer hides the end of the last conversation
+
+Opening a channel joins the realtime gateway, and the snapshot the join returns can lag the durable
+store. When it did, the last exchange of a finished turn was missing from the transcript on every
+reload, with no unread marker or anything else to explain the gap, and the stored copy never got a
+chance to replace it because history was only restored into an empty channel.
+
+The stored thread now wins whenever it holds more than the channel does and holds everything the
+channel already shows. A message typed while history is still loading is not in the store yet, and
+a run still streaming has messages the store has not seen, so neither is rolled back.
+
 ### Coworkers are made in a wizard and managed in a dialog
 
 Creating a coworker is now a three-step wizard — who it is, who may see it, then where it runs,

--- a/app/src/components/channels/channel-chat.tsx
+++ b/app/src/components/channels/channel-chat.tsx
@@ -161,12 +161,26 @@ export function ChannelChat({
           channel.threadId,
           runtimeAgentId,
         );
-        // Never overwrite local messages that arrived while history was loading.
-        if (
-          current &&
-          stored.messages.length > 0 &&
-          agent.messages.length === 0
-        ) {
+        /*
+         * The durable store wins when it is ahead of what the join delivered.
+         *
+         * The join replaces the agent's messages with the realtime gateway's snapshot of the thread,
+         * and that snapshot can lag the store: a turn that finished, was persisted and answered in
+         * full came back from the join without its last exchange, on every reload, with no
+         * unreadable count to explain the gap. Restoring only into an empty agent kept that stale
+         * snapshot for good.
+         *
+         * So the store is applied when it holds more than the agent does AND everything the agent
+         * holds is in the store. The second half is the guard this replaced: a message typed while
+         * history was loading is not in the store yet, so it is never overwritten, and a run still
+         * streaming has messages the store has not seen, so its snapshot is never rolled back.
+         */
+        const local = agent.messages;
+        const storedIds = new Set(stored.messages.map((m) => m.id));
+        const storeIsAhead =
+          stored.messages.length > local.length &&
+          local.every((m) => storedIds.has(m.id));
+        if (current && stored.messages.length > 0 && storeIsAhead) {
           agent.setMessages(stored.messages);
         }
         /*


### PR DESCRIPTION
## The problem

Opening a channel does two things: it loads the thread from the durable store, and it joins the
realtime gateway. The join replaces the agent's messages with the gateway's own snapshot of that
thread, and that snapshot can lag the store.

When it did, the transcript came back missing the end of the last conversation: a turn that had
finished, been persisted, and been answered in full, gone from the view. Stored history was only
restored into an *empty* agent, a guard written to protect a message typed while history was still
loading, so the stale snapshot won every time. The gap was there on every reload, and nothing on
screen explained it, since there was no unreadable count to mark the missing messages.

## What changed

`ChannelChat` applies the stored thread when the store is ahead of the agent: it holds more messages
than the agent does, and every message the agent holds is in the store.

The second half of that condition is exactly what the old empty-agent check was protecting, stated
directly rather than by proxy. A message typed while history was loading has not been persisted yet,
so it is not in the store, so the store is not applied and the message is not overwritten. A run
still streaming has messages the store has not seen, so its snapshot is never rolled back either.

## How it was verified

- `bun run --cwd app typecheck` clean.
- `bun test app/tests/channel-event-patch.test.ts app/tests/channel-unread.test.ts
  app/tests/chat-messages.test.ts app/tests/repair-history.test.ts` gives 35 pass, 0 fail.
- `bunx biome check app/src/components/channels/channel-chat.tsx` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
