### PR TITLE
Fix/transcript anchor on first token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### The transcript stays with the question when an answer starts arriving
+
+Sending a message carried it up to the top of the view, correctly, and then the Bot's first token
+threw the conversation back to its very first message, with the answer being written several
+screens below the fold. It happened on every turn, from wherever the reader happened to be
+scrolled, so every answer began with a scroll back down to find it. The transcript now holds the
+question in place for the whole turn, and the scroll that puts it there is animated rather than a
+jump — unless the reader has asked their system for reduced motion.
+
 ### Coworkers are made in a wizard and managed in a dialog
 
 Creating a coworker is now a three-step wizard — who it is, who may see it, then where it runs,

--- a/app/src/components/channels/chat-transcript.tsx
+++ b/app/src/components/channels/chat-transcript.tsx
@@ -5,7 +5,7 @@ import {
 } from "@copilotkit/react-core/v2";
 import { IconBox } from "@tabler/icons-react";
 import { motion, useReducedMotion } from "motion/react";
-import { memo, useEffect, useMemo, useRef } from "react";
+import { memo, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { Streamdown } from "streamdown";
 import { Bubble, BubbleContent } from "@/components/ui/bubble";
 import {
@@ -618,6 +618,42 @@ function ServerToolLine({ name, result }: { name: string; result?: string }) {
   );
 }
 
+const SEND_SCROLL_MS = 700;
+
+function useSmoothSendScroll(
+  viewport: React.RefObject<HTMLDivElement | null>,
+  newestUserMessageId: string | null,
+) {
+  const reducedMotion = useReducedMotion();
+  const seenRef = useRef<string | null>(null);
+
+  useLayoutEffect(() => {
+    const element = viewport.current;
+    const previous = seenRef.current;
+    seenRef.current = newestUserMessageId;
+
+    if (
+      element === null ||
+      newestUserMessageId === null ||
+      previous === null ||
+      previous === newestUserMessageId ||
+      reducedMotion
+    ) {
+      return;
+    }
+
+    element.style.scrollBehavior = "smooth";
+    const timer = window.setTimeout(() => {
+      element.style.scrollBehavior = "";
+    }, SEND_SCROLL_MS);
+
+    return () => {
+      window.clearTimeout(timer);
+      element.style.scrollBehavior = "";
+    };
+  }, [newestUserMessageId, reducedMotion, viewport]);
+}
+
 export function ChatTranscript({
   busy = false,
   commandNames = "",
@@ -651,6 +687,12 @@ export function ChatTranscript({
   const waitingOnFirstToken =
     busy && lastItem?.kind === "text" && lastItem.role === "user";
 
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const newestUserMessageId =
+    items.findLast((item) => item.kind === "text" && item.role === "user")
+      ?.id ?? null;
+  useSmoothSendScroll(viewportRef, newestUserMessageId);
+
   /*
    * One decider per mounted transcript, so opening a different channel starts the cascade over and
    * a message never inherits a delay from a conversation it was not in.
@@ -678,18 +720,30 @@ export function ChatTranscript({
   return (
     <MessageScrollerProvider autoScroll scrollPreviousItemPeek={48}>
       <MessageScroller>
-        <MessageScrollerViewport>
+        <MessageScrollerViewport ref={viewportRef}>
           <MessageScrollerContent
             aria-busy={busy}
             className="mx-auto w-full max-w-2xl px-4 py-6"
+            spacerClassName="order-2"
           >
-            {/*
-             * The memo boundary is INSIDE the scroller item, not around it. `MessageScrollerItem`
-             * reads the scroller's context, so it re-renders whenever the scroll state moves and
-             * memoising it would achieve nothing. Its child is what costs — markdown parsing and
-             * chart SVGs — and that is what is skipped.
-             */}
-            {/* Instead of the rows, never alongside them: one real message and this is a lie. */}
+            <div className="contents [&>*]:order-1">
+              {stopped ? (
+                <Stopped reason={stopped} />
+              ) : waitingOnFirstToken ? (
+                <Thinking />
+              ) : null}
+            {queued.map((message) => (
+                <Queued
+                  key={message.id}
+                  onRemove={
+                    onRemoveQueued
+                      ? () => onRemoveQueued(message.id)
+                      : undefined
+                  }
+                  text={message.text}
+                />
+              ))}
+            </div>
             {items.length === 0 && restoring ? <RestoringTranscript /> : null}
             {items.map((item, index) =>
               item.kind === "tool" ? (
@@ -724,35 +778,6 @@ export function ChatTranscript({
                 </MessageScrollerItem>
               ),
             )}
-            {/*
-             * Outside the item list, so neither of these is a message. Each has no id, is never
-             * anchored, and is gone by the next turn — giving one a `MessageScrollerItem` would ask
-             * the scroller to measure and anchor something that exists for a second and a half.
-             *
-             * One or the other, never both: a turn that ended has stopped being in flight, and a
-             * shimmering "Thinking" under a line saying the Bot stopped would contradict it.
-             */}
-            {stopped ? (
-              <Stopped reason={stopped} />
-            ) : waitingOnFirstToken ? (
-              <Thinking />
-            ) : null}
-            {/*
-             * Below the thinking line, and outside the item list for the same reason it is: these
-             * are not yet turns. They have ids of their own, but they are this tab's ids and not the
-             * thread's, so handing them to the scroller would ask it to anchor on something that is
-             * about to be replaced by a message with a different id — and the replacement is the
-             * one worth scrolling to.
-             */}
-            {queued.map((message) => (
-              <Queued
-                key={message.id}
-                onRemove={
-                  onRemoveQueued ? () => onRemoveQueued(message.id) : undefined
-                }
-                text={message.text}
-              />
-            ))}
           </MessageScrollerContent>
         </MessageScrollerViewport>
         <MessageScrollerButton />

--- a/app/src/components/channels/chat-transcript.tsx
+++ b/app/src/components/channels/chat-transcript.tsx
@@ -732,7 +732,7 @@ export function ChatTranscript({
               ) : waitingOnFirstToken ? (
                 <Thinking />
               ) : null}
-            {queued.map((message) => (
+              {queued.map((message) => (
                 <Queued
                   key={message.id}
                   onRemove={


### PR DESCRIPTION
Fixes #338.

## What this changes

Keeps the transcript where the reader left it when a Bot's first token arrives. Today it jumps to the first message of the conversation on every turn, because `MessageScroller` counts the element children of its content to work out what changed, and `Thinking`, `Stopped` and the queued lines sit in that list alongside the messages. A turn's first token swaps one for the other, the count holds, the scroller reads that as the list having been rewritten and re-anchors on the top of the conversation.

Those three are moved into a single always-rendered wrapper, placed ahead of the message rows so the scroller's append arithmetic still lines up, and put back visually with `order`. The scroller's own spacer is given a later order so it stays below them rather than between them and the last message.

Also in here: the send scroll animates instead of jumping. The scroller calls `scrollTo` with `behavior: "auto"`, which defers to the element's CSS, so the viewport is switched to `scroll-behavior: smooth` for the 700ms around a send and switched back. Only the send — an answer streaming in re-anchors on every resize, and smoothing that produces a scroll that never catches up with its own text. `prefers-reduced-motion` opts out.

## Where it runs

- [x] **New state that outlives a request?** None. One `useRef` holding the last user message id, per mounted transcript, in the browser.
- [x] **What happens on the second replica?** Nothing differs. No server code is touched; this is render order and a CSS property in one component.
- [x] **Anything serialised?** None.
- [x] **Anything fanned out to a browser?** None. The transcript renders the messages it is already given.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: unchanged, no acting call is touched.
- [x] New refusals and new failures each write a row: none added.
- [x] Nothing new is trusted from the client: nothing new is read from the client.

## Changelog

- [x] A line under `Unreleased`: *The transcript stays with the question when an answer starts arriving*.

## Proof

Reproduced and verified in Chromium against an isolated harness running the real `@shadcn/react@0.3.0` `MessageScroller` with the transcript's own child structure — eight messages of history, 600px viewport — reading the position of the question just sent.

Before, on `main`:

| step | `scrollTop` | question, relative to viewport top |
| --- | --- | --- |
| after send | 600 | 72px |
| first token | 0 | 672px below the fold |
| send while scrolled up | 812 | 72px |
| first token | 114 | 770px below the fold |

After:

| step | `scrollTop` | question, relative to viewport top |
| --- | --- | --- |
| after send | 600 | 72px |
| first token | 600 | 72px |
| send while scrolled up | 812 | 72px |
| first token | 812 | 72px |
| send from the bottom | 1023 | 72px |
| first token | 1023 | 72px |

Every send lands identically regardless of the reader's scroll position, and holds through the answer.

The `Thinking` line now sits 24px under the question — one `gap-6` — with the scroller's spacer below it, rather than 529px down with the spacer in between.

The send scroll was sampled mid-animation to confirm it eases rather than jumps: `85, 155, 386, 494, 536, 570, 589, 596, 600, 600`.

`bun run typecheck` and `bunx biome check` are clean. `bun test` shows no new failures — the suite has pre-existing failures in the scheduler tests that need a database, nine with this change and eleven on stock `main`.


https://github.com/user-attachments/assets/3a007497-05ec-443d-915d-02c22c86b3aa

