### PR TITLE
Cap a reported message's time at the server's clock, so a browser that runs ahead cannot hide what a routine said

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A browser clock that runs ahead no longer hides what a routine said
+
+The roster line and unread dot for a channel are moved by the last report that arrived, and only
+ever forwards. A browser whose clock was ahead stamped its report into the future, and then every
+report from a correct clock — a routine's reply, a relayed handoff answer, another member's browser
+— was dropped without a word until the real time caught up: the reply was in the thread, and the
+roster never said so. A reported time is now capped at the server's own clock.
+
 ### Coworkers are made in a wizard and managed in a dialog
 
 Creating a coworker is now a three-step wizard — who it is, who may see it, then where it runs,

--- a/server/src/channels/routes.ts
+++ b/server/src/channels/routes.ts
@@ -908,10 +908,22 @@ type ActivityInputParseResult =
 /**
  * Parse a reported message.
  *
- * `at` comes from the client that saw the message, because only it knows when the message arrived, * but it is never trusted as a clock: the store compares it against what is stored and only ever
- * moves forwards, so a wrong one can lose a report, not corrupt the row.
+ * `at` comes from the client that saw the message, because only it knows when the message arrived,
+ * and it may say when, but not later than now. The store compares it against what is stored and
+ * only ever moves forwards, and that guard is shared with every other clock in the deployment:
+ * the routine runner's, a relayed handoff answer's, every other member's browser. A browser whose
+ * clock ran seven minutes ahead used to stamp the row seven minutes into the future, and it was
+ * not that report that got lost — every correct one for the next seven minutes was, silently: a
+ * routine's reply landed in the thread and never on the roster. Clamped rather than refused,
+ * because clocks are a little ahead all the time and a report a second early is still the report.
+ * A stamp in the past is kept as it is, so a person's message and the reply, reported separately
+ * by the same clock, still land in the order that clock saw them.
  */
-export function parseActivityInput(input: unknown): ActivityInputParseResult {
+export function parseActivityInput(
+  input: unknown,
+  /** The server's own clock, injectable so a test can be about a specific gap. */
+  now: Date = new Date(),
+): ActivityInputParseResult {
   if (!isChannelInputObject(input)) {
     return { ok: false, error: "Activity must be a JSON object." };
   }
@@ -926,10 +938,11 @@ export function parseActivityInput(input: unknown): ActivityInputParseResult {
   if (typeof object.at !== "string") {
     return { ok: false, error: "Timestamp is required." };
   }
-  const at = new Date(object.at);
-  if (Number.isNaN(at.getTime())) {
+  const reported = new Date(object.at);
+  if (Number.isNaN(reported.getTime())) {
     return { ok: false, error: "Timestamp must be an ISO-8601 date." };
   }
+  const at = reported.getTime() > now.getTime() ? now : reported;
 
   return {
     ok: true,

--- a/server/tests/channel-activity-input.test.ts
+++ b/server/tests/channel-activity-input.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { parseActivityInput } from "../src/channels/routes";
+
+/**
+ * The moment a browser says a message arrived is the browser's clock, and the row it lands on is
+ * compared against by every other clock in the deployment: the routine runner's, a relayed
+ * handoff answer's, and every other member's browser. `recordActivity` only moves forwards, so a
+ * report stamped in the future is not the report that gets lost — every correct one after it is.
+ */
+describe("parsing a reported message", () => {
+  const now = new Date("2026-09-03T10:00:00.000Z");
+
+  test("keeps a timestamp that is not ahead of the server", () => {
+    const at = "2026-09-03T09:59:30.000Z";
+    const parsed = parseActivityInput(
+      { text: "hello", agentId: null, at },
+      now,
+    );
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.value.at.toISOString()).toBe(at);
+  });
+
+  test("clamps a timestamp from a clock that runs ahead to now", () => {
+    const parsed = parseActivityInput(
+      { text: "hello", agentId: null, at: "2026-09-03T10:07:00.000Z" },
+      now,
+    );
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.value.at.toISOString()).toBe(now.toISOString());
+  });
+
+  test("still refuses a timestamp that is not a date", () => {
+    const parsed = parseActivityInput(
+      { text: "hello", agentId: null, at: "yesterday" },
+      now,
+    );
+    expect(parsed).toEqual({
+      ok: false,
+      error: "Timestamp must be an ISO-8601 date.",
+    });
+  });
+
+  test("keeps the rest of the report as it was", () => {
+    const parsed = parseActivityInput(
+      { text: "hello", agentId: " agent-1 ", at: "2026-09-03T09:00:00.000Z" },
+      now,
+    );
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.value.text).toBe("hello");
+    expect(parsed.value.agentId).toBe("agent-1");
+  });
+});


### PR DESCRIPTION
## What this changes

`POST /api/channels/:channelId/activity` takes `at` from the browser — `new Date().toISOString()` in `channel-chat.tsx`'s `report` — and `ChannelStore.recordActivity` applies it with a forward-only guard (`lastMessageAt IS NULL OR lastMessageAt < at`), returning silently when nothing moved. The parser's comment said a wrong clock "can lose a report, not corrupt the row". It loses the wrong report only when the clock is behind. When it is *ahead*, the wrong report lands, the row is stamped into the future, and every correct report after it loses — silently — until real time catches up:

- the routine runner (`server/src/routines/runner.ts`, `say` → `recordActivity` with server `new Date()`), whose whole job, per its own header, is that one report because no browser is open. The reply is in the thread; the roster line and unread dot never move; the run is recorded `succeeded`;
- a relayed handoff answer (`announce` in `server/src/index.ts`, also server time);
- every other member's browser, on a channel with more than one person in it.

A browser seven minutes ahead — a laptop that woke up before NTP did — hides seven minutes of everybody else's messages from the roster.

The parser now caps `at` at the server's own clock: a report may say when, but not later than now. Clamped rather than refused, because clocks are a little ahead all the time and a report a second early is still the report. A stamp in the past is kept as it is, so a person's message and the reply, reported separately by the same clock, still land in the order that clock saw them. `now` is an injectable parameter with a default, so the test can be about a specific gap.

## Where it runs

- [x] **New state that outlives a request?** None.
- [x] **What happens on the second replica?** Each replica caps against its own clock; the store's forward-only guard is unchanged and still decides in Postgres. Skew between replicas is seconds at worst and was already the ordering this guard tolerated.
- [x] **Anything serialised?** Unchanged — the conditional update in `recordActivity`.
- [x] **Anything fanned out to a browser?** Unchanged — `pg_notify` inside the same transaction.
- [x] **New listener, port, or schedule?** No.

## Boundary and audit

- [x] Every acting call still goes through the gateway: this is a roster report, not an action.
- [x] New refusals and new failures each write a row: nothing new is refused; a future stamp is capped, not rejected.
- [x] Nothing new is trusted from the client that the server can resolve itself — this is the reverse: one thing the client was trusted with, its clock, is now bounded by what the server knows.

## Changelog

- [x] A section under `Unreleased`.

## Proof

New `server/tests/channel-activity-input.test.ts`, no database needed. The clamp case fails before the change and passes after:

```
# before (parser unchanged)
error: expect(received).toBe(expected)
Expected: "2026-09-03T10:00:00.000Z"
Received: "2026-09-03T10:07:00.000Z"
(fail) parsing a reported message > clamps a timestamp from a clock that runs ahead to now
 3 pass
 1 fail

# after
 4 pass
 0 fail
```

`bun run format:check`, `bun run lint`, and the server typecheck pass.
