### PR TITLE
Record which coworker a person chose on /channel/new, not only in the home composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A conversation started from the sidebar is recorded like one started from the home screen
+
+The trail had a `channel.routed` row for every conversation begun in the home composer — the
+coworker it went to and why, whether inferred or named with `@` — and nothing at all for one begun
+from the sidebar's +, a coworker's card or its profile, which read exactly like a row that failed
+to write. Picking a coworker in that To: field is now recorded the same way an `@` is.
+
 ### Coworkers are made in a wizard and managed in a dialog
 
 Creating a coworker is now a three-step wizard — who it is, who may see it, then where it runs,

--- a/app/src/lib/channels/start.ts
+++ b/app/src/lib/channels/start.ts
@@ -3,6 +3,31 @@ import { useNavigate } from "@tanstack/react-router";
 import { stashFirstMessage } from "@/components/channels/transcript-messages";
 import { createChannelMutationOptions } from "./mutations";
 import { channelKeys } from "./queries";
+import { routeMessage } from "./route";
+
+/**
+ * Start a channel with a coworker the person chose themselves, and say so first.
+ *
+ * A conversation that was routed has a `channel.routed` row saying where it went and why; one whose
+ * coworker the person picked must have one too, or the trail reads as if the row failed to write.
+ * The home composer told the server about an `@` choice; a coworker picked in the To: field of
+ * `/channel/new` — the sidebar's +, a coworker's card, its profile — was never told to anybody. The
+ * two screens now share this one sequence: record, then start.
+ *
+ * The record is told before the channel exists, the way the routed path records before a channel is
+ * pinned, and its answer is thrown away: the person already decided and nothing here may change
+ * that. Failing to write the row must not stop the conversation, so a rejection is swallowed whole.
+ * Pure so the sequence can be tested; the hook below binds it to the real calls.
+ */
+export async function startWithChosen(input: {
+  agentId: string;
+  text: string;
+  record: (text: string, agentId: string) => Promise<unknown>;
+  start: (agentId: string, text: string) => Promise<void>;
+}): Promise<void> {
+  await input.record(input.text, input.agentId).catch(() => undefined);
+  await input.start(input.agentId, input.text);
+}
 
 /**
  * Start a channel from a just-submitted first message, then navigate there.
@@ -15,17 +40,22 @@ export function useStartChannel() {
   const navigate = useNavigate();
   const createChannel = useMutation(createChannelMutationOptions(queryClient));
 
+  const start = async (agentId: string, text: string) => {
+    const channel = await createChannel.mutateAsync([agentId]);
+    queryClient.setQueryData(channelKeys.detail(channel.id), channel);
+    stashFirstMessage(channel.id, text);
+    await navigate({
+      params: { channelId: channel.id },
+      replace: true,
+      to: "/channel/$channelId",
+    });
+  };
+
   return {
     pending: createChannel.isPending,
-    start: async (agentId: string, text: string) => {
-      const channel = await createChannel.mutateAsync([agentId]);
-      queryClient.setQueryData(channelKeys.detail(channel.id), channel);
-      stashFirstMessage(channel.id, text);
-      await navigate({
-        params: { channelId: channel.id },
-        replace: true,
-        to: "/channel/$channelId",
-      });
-    },
+    start,
+    /** `start`, for a coworker the person chose: the choice is recorded first. */
+    startChosen: (agentId: string, text: string) =>
+      startWithChosen({ agentId, text, record: routeMessage, start }),
   };
 }

--- a/app/src/routes/_authed/_app/channel/new.tsx
+++ b/app/src/routes/_authed/_app/channel/new.tsx
@@ -38,7 +38,7 @@ export const Route = createFileRoute("/_authed/_app/channel/new")({
 function RouteComponent() {
   const { agent } = Route.useSearch();
   const navigate = Route.useNavigate();
-  const { start, pending } = useStartChannel();
+  const { startChosen, pending } = useStartChannel();
   const { data: profiles } = useQuery(agentListQueryOptions());
 
   const [error, setError] = useState<string | null>(null);
@@ -135,7 +135,9 @@ function RouteComponent() {
           setSent(seedMessage(draft.text, newId()));
 
           try {
-            await start(recipient.id, draft.text);
+            // Recorded, then started: a coworker picked here is as much a choice as an `@` on the
+            // home screen, and the trail has to say so for both.
+            await startChosen(recipient.id, draft.text);
           } catch (caught) {
             // Preserve the unsent draft when channel creation fails.
             setSent(null);

--- a/app/src/routes/_authed/_app/index.tsx
+++ b/app/src/routes/_authed/_app/index.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute("/_authed/_app/")({
 function RouteComponent() {
   const { data: agents } = useQuery(agentListQueryOptions());
   const explore = agents?.filter((a) => !a.mine && a.visibility === "public");
-  const { start, pending } = useStartChannel();
+  const { start, startChosen, pending } = useStartChannel();
   const [error, setError] = useState<string | null>(null);
 
   /** Default recipient when the composer draft has no mention. */
@@ -46,22 +46,17 @@ function RouteComponent() {
               // run, it falls back to the same default the composer used to always use.
               setError(null);
               try {
-                let agentId: string | undefined = draft.agentId ?? undefined;
-                if (agentId) {
-                  /*
-                   * Told to the server so the choice is recorded, and its answer thrown away: the
-                   * person already decided and nothing here may change that. Failing to write the
-                   * audit row must not stop the conversation, so a rejection is swallowed whole.
-                   */
-                  await routeMessage(draft.text, agentId).catch(
-                    () => undefined,
-                  );
-                } else {
-                  try {
-                    agentId = (await routeMessage(draft.text)).agentId;
-                  } catch {
-                    agentId = fallback?.id;
-                  }
+                if (draft.agentId) {
+                  // Recorded and started as one sequence, shared with `/channel/new`: the person
+                  // already decided, and the trail has to say so wherever they decided it.
+                  await startChosen(draft.agentId, draft.text);
+                  return;
+                }
+                let agentId: string | undefined;
+                try {
+                  agentId = (await routeMessage(draft.text)).agentId;
+                } catch {
+                  agentId = fallback?.id;
                 }
                 if (!agentId) return;
                 await start(agentId, draft.text);

--- a/app/tests/start-chosen.test.ts
+++ b/app/tests/start-chosen.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "bun:test";
+import { startWithChosen } from "../src/lib/channels/start";
+
+/**
+ * A conversation whose coworker the person picked themselves has to reach the trail the same way a
+ * routed one does. `/channel/new` — the sidebar's +, a coworker's card, its profile — started the
+ * channel and told nobody; the home composer told the server about an `@`. Both now run this one
+ * sequence, so what it does is what the trail sees.
+ */
+
+function harness(record: (text: string, agentId: string) => Promise<unknown>) {
+  const calls: string[] = [];
+  return {
+    calls,
+    record: (text: string, agentId: string) => {
+      calls.push(`record ${agentId} ${text}`);
+      return record(text, agentId);
+    },
+    start: async (agentId: string, text: string) => {
+      calls.push(`start ${agentId} ${text}`);
+    },
+  };
+}
+
+test("tells the server the choice before the channel is made", async () => {
+  const { calls, record, start } = harness(async () => ({
+    agentId: "risk-analyst",
+  }));
+
+  await startWithChosen({
+    agentId: "risk-analyst",
+    text: "hello",
+    record,
+    start,
+  });
+
+  expect(calls).toEqual([
+    "record risk-analyst hello",
+    "start risk-analyst hello",
+  ]);
+});
+
+test("a record that fails to write does not stop the conversation", async () => {
+  const { calls, record, start } = harness(async () => {
+    throw new Error("Could not choose a coworker.");
+  });
+
+  await startWithChosen({
+    agentId: "risk-analyst",
+    text: "hello",
+    record,
+    start,
+  });
+
+  expect(calls).toEqual([
+    "record risk-analyst hello",
+    "start risk-analyst hello",
+  ]);
+});
+
+test("the server's answer cannot change who the person chose", async () => {
+  const { calls, record, start } = harness(async () => ({
+    agentId: "somebody-else",
+  }));
+
+  await startWithChosen({
+    agentId: "risk-analyst",
+    text: "hello",
+    record,
+    start,
+  });
+
+  expect(calls[1]).toBe("start risk-analyst hello");
+});
+
+test("a channel that cannot be started still fails the send", async () => {
+  const { record } = harness(async () => undefined);
+  const start = async () => {
+    throw new Error("Could not start a channel");
+  };
+
+  await expect(
+    startWithChosen({ agentId: "risk-analyst", text: "hello", record, start }),
+  ).rejects.toThrow("Could not start a channel");
+});


### PR DESCRIPTION
## What this changes

`server/src/routing/routes.ts` records a `channel.routed` row for both ways a message finds a coworker, and says why the named case is recorded at all: "without that the trail answered 'why did this go to Risk Analyst' for routed conversations and said nothing at all for chosen ones, which reads exactly like a row that failed to write." The home composer honours that — `routes/_authed/_app/index.tsx` calls `routeMessage(text, agentId)` for an `@` choice before `start`.

`/channel/new` never did. It is where the sidebar's **+** (`app-sidebar.tsx`), a coworker's card on the home screen, and a coworker's profile all lead; the person picks a coworker in the To: field and the screen calls `start` alone. `routeMessage` is referenced from `index.tsx` and nowhere else, so every conversation begun from those three places has no `channel.routed` row: a trail with rows for some conversations and none for others, on the surface people use most.

The fix is one shared sequence, `startWithChosen` in `lib/channels/start.ts`: record the choice, swallowing a failure to write it (the person already decided and a missing row must not stop the conversation — the same stance `index.tsx` already took), then start. `useStartChannel` exposes it as `startChosen`, bound to `routeMessage`; `/channel/new` calls it, and `index.tsx`'s `@` branch calls it too so the two screens cannot drift. The routed branch of `index.tsx` is unchanged.

Not covered, and said out loud: a hidden coworker reached through a profile link is not on the roster `POST /api/route` reads, so it answers 404 and the row is still not written; that is the server's call to make and is outside this change.

#296 moves the recording into a routing service; it keeps `POST /api/route` with `agentId` and touches nothing under `app/`, so this composes with it either way.

## Where it runs

- [x] **New state that outlives a request?** None.
- [x] **What happens on the second replica?** The row is written by whichever replica answers `POST /api/route`, into `audit_events`, as today.
- [x] **Anything serialised?** No.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** No.

## Boundary and audit

- [x] Every acting call still goes through the gateway: this adds the audit write that one surface was missing, before the act.
- [x] New refusals and new failures each write a row: nothing new is refused; a `channel.routed` row now exists for a conversation that previously wrote none.
- [x] Nothing new is trusted from the client: the server still reads the roster for the person asking and refuses a coworker not on it.

## Changelog

- [x] A section under `Unreleased`.

## Proof

Before: `grep -rn routeMessage app/src` — `lib/channels/route.ts` (the definition) and `routes/_authed/_app/index.tsx` only; `channel/new.tsx` calls `start(recipient.id, draft.text)` with no record.

After: `app/tests/start-chosen.test.ts` pins the sequence both screens now run — record before start, with the message and the coworker; a record that fails does not stop the conversation; the server's answer cannot change who was chosen; a channel that cannot be started still fails the send.

```
$ cd app && bun test tests/start-chosen.test.ts
 4 pass
 0 fail
```

`bun run format:check`, `bun run lint`, and the app typecheck pass. Hook glue is left untested, as elsewhere in `app/`.
