### PR TITLE
Show the repository's Trendshift standing, not only its build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 ![Alpha](https://img.shields.io/badge/status-alpha-orange.svg)
 
+[![Trendshift: #3 Repository Of The Day](https://trendshift.io/api/badge/trendshift/repositories/175080/daily)](https://trendshift.io/repositories/175080)
+
 </div>
 
 https://github.com/user-attachments/assets/535ef7ee-1631-4a69-b839-564c56cf90b4


### PR DESCRIPTION
![Show the repository's Trendshift standing, not only its build status](https://raw.githubusercontent.com/jerelvelarde/openbot/pr-media/evidence/trendshift-badge-readme.png)

## The problem

The header carries four badges and all four are about the repository's own machinery: two workflow results, a licence, and an alpha marker. They tell a visitor that the build passes and the licence is MIT. They say nothing about whether anybody outside the project has looked at it.

That gap matters most for the reader this README is written for. The page asks a stranger to bring up a Docker Compose stack, supply their own model key, and hand an agent a browser carrying real logins. The only badge on the page that speaks to scale is the one reading `alpha`. That badge is honest and it should stay, but it is currently the entire answer to "has anybody else decided this was worth their time".

OpenBot reached #3 Repository Of The Day on Trendshift on 20 August 2026, and #2 TypeScript Repository Of The Day the same day. That is third-party evidence, already earned, and the header said nothing about it.

## The approach

One line in the centred header block, one blank line below the existing shields.

**Below the shields rather than among them.** The four existing badges are a status row — things a maintainer keeps green. A ranking is not a status, and at 250x55 it is an order of magnitude larger than the shields beside it. Dropping it into that row would break the row's rhythm and imply the rank is something CI keeps passing. A blank line makes it its own line, which is what an accolade should be.

**Trendshift's live endpoint rather than an image committed to `assets/`.** `api/badge/trendshift/repositories/175080/daily` draws the rank from Trendshift, so it stays correct without anybody editing this file again. The cost is worth naming: this puts a third-party image on the README's first screen, so if Trendshift goes down or retires the endpoint, the header shows a broken image. A committed SVG would trade that for a number that goes stale silently and a claim a reader cannot check against a source. The exposure is bounded in one useful way — `/daily` reports the best rank the repository has achieved, not today's rank, so the badge can only ever improve.

Markdown rather than the `<a><img>` snippet Trendshift hands out, matching the four badges already in the block. GitHub strips that snippet's `target` and `style` attributes anyway, and the SVG carries its own width and height.

## What is not covered

- Only the all-languages rank. The #2 TypeScript badge is the same URL plus `?language=TypeScript`; showing both would put two large badges above the fold.
- No dark-mode variant. Trendshift serves one light-background SVG, so it sits on white in both themes, as it does on every other README carrying it.
- Nothing to animate. The whole surface of this change is a static image in a header, so the evidence above is a still of GitHub rendering this branch rather than a recording.
- The rank is not pinned. If Trendshift recomputes its history, the badge follows it.

## Verification

- **No gate applies to this diff, and none was run.** The repository has no markdown linter, formatter, or hook covering `.md` — `biome.json` includes only TS/TSX sources, and there are no lefthook, husky, or active `.git/hooks` entries. No test files added.
- **The endpoint was checked rather than assumed.** `curl` returns 200 `image/svg+xml` at 250x55, with text nodes `TRENDSHIFT` and `#3 Repository Of The Day`, and `aria-label="Trendshift: number 3 repository of the day"`.
- **Two near-miss URLs, recorded because they are the ones most sources hand you.** `trendshift.io/api/badge/repositories/175080` returns **500** and `.../repositories/175080/daily` returns **404**. Either would have merged a broken image into the first screen of the README.
- **The evidence image is this branch rendered by GitHub**, which also confirms the SVG survives GitHub's camo image proxy — the last way an external badge can fail only after merge.
