### PR TITLE
Say Did not happen about a call the audit page had been calling Allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A tool call that failed no longer reads as one that worked
+
+The audit page draws a row it does not recognise as `Allowed`, which is right for the many rows that
+are neither a refusal nor a failure. Two rows that are failures were falling through to it: a
+connector tool call this deployment permitted and the vendor did not complete, and a component's
+data read that was granted and then broke. Both were drawn in the same muted colour as a call that
+went through, and neither appeared under `Did not happen`, so the view an administrator opens to ask
+what did not work here was short by exactly the rows they came for. A per-person connector fails on
+this path every time somebody's token expires, so this was the most common failure the product has
+and the one the trail was quietest about. Both now read as `Did not happen`, and both are in that
+saved view. Neither is filed as a refusal: nothing was forbidden on either row.
+
 ### Duplicating a coworker keeps the endpoint it was copied from
 
 Duplicate used to point every copy at this deployment's own managed Bot, whatever the coworker being

--- a/app/src/lib/audit/outcome.ts
+++ b/app/src/lib/audit/outcome.ts
@@ -61,6 +61,27 @@ export const DID_NOT_HAPPEN_EVENT_TYPES = [
   "agent.handoff_failed",
   /** A question that reached nobody: the Bot stopped, and the person was never asked. */
   "agent.escalation_failed",
+  /*
+   * A tool call this deployment permitted and the vendor did not complete.
+   *
+   * The direct sibling of `computer.action_failed`, written by the same decide-record-then-act
+   * order on the other acting surface: `callTool` writes the decision row first, attempts the
+   * call, and then writes this instead of `mcp.call_succeeded` when the vendor answers `isError`
+   * or the attempt throws. Every failure of a per-person connector lands here — no connection for
+   * the asker, a refresh token the vendor stopped accepting, an API not enabled for the project —
+   * which makes it the row somebody most often comes to this page to find, and it was the one row
+   * of the family drawn in the same muted colour as a call that worked.
+   */
+  "mcp.call_failed",
+  /*
+   * A component's read that was granted and then broke.
+   *
+   * `server/src/audit.ts` says this one is "deliberately not a refusal", and that is right: nothing
+   * was forbidden. But it is not an allowance either. The row exists precisely because the read did
+   * not happen, and the page already labels it "Could not be read" while colouring it as though it
+   * had been.
+   */
+  "component.function_failed",
 ] as const;
 
 export type AuditOutcome = "refused" | "did-not-happen" | "allowed";

--- a/app/tests/audit-outcome.test.ts
+++ b/app/tests/audit-outcome.test.ts
@@ -53,6 +53,30 @@ describe("what the trail says a row was", () => {
     expect(outcomeOf("agent.stream_stalled")).toBe("did-not-happen");
   });
 
+  /*
+   * The two acting surfaces have to answer this the same way.
+   *
+   * A browser action that was permitted and then failed was already drawn as "Did not happen". The
+   * same shape on the other two surfaces — a tool call the vendor did not complete, a component read
+   * that broke — fell through to "Allowed", which is what the page says about a call that worked.
+   */
+  test("tells a permitted call that failed from one that went through", () => {
+    // Written by `callTool` after the policy allowed the call and the vendor answered `isError` or
+    // the attempt threw. A per-person connector fails here on every expired refresh token.
+    expect(outcomeOf("mcp.call_failed")).toBe("did-not-happen");
+    // Granted, attempted, and the read broke. Not a refusal, and not an allowance either.
+    expect(outcomeOf("component.function_failed")).toBe("did-not-happen");
+    // The surface that already got this right, kept here so the three cannot drift apart again.
+    expect(outcomeOf("computer.action_failed")).toBe("did-not-happen");
+  });
+
+  test("a failed call is not filed as something this deployment refused", () => {
+    // The other wrong answer. Nothing was forbidden on either row, and filing a broken call as a
+    // policy event teaches a reader to distrust the policy events that are real.
+    expect(outcomeOf("mcp.call_failed")).not.toBe("refused");
+    expect(outcomeOf("component.function_failed")).not.toBe("refused");
+  });
+
   test("still calls something that went through allowed", () => {
     for (const eventType of [
       "computer.action_allowed",
@@ -99,6 +123,20 @@ describe("the saved views ask the same question the rows do", () => {
     for (const eventType of filtered) {
       expect(outcomeOf(eventType)).toBe("did-not-happen");
     }
+  });
+
+  /*
+   * The half of the failure that is harder to see. A row drawn in the wrong colour is at least on
+   * the page; a row missing from this view is absent from the answer to "what did not happen here",
+   * and the view is not empty, it is just short.
+   */
+  test("Did not happen names the calls that were permitted and failed", () => {
+    const filtered = eventTypeFilter(DID_NOT_HAPPEN_EVENT_TYPES)
+      .replace("?eventType=", "")
+      .split(",");
+
+    expect(filtered).toContain("mcp.call_failed");
+    expect(filtered).toContain("component.function_failed");
   });
 
   test("no event type is in both families", () => {


### PR DESCRIPTION
## What this changes

The audit page draws a row it does not recognise as `Allowed`. That is right for the many rows that
are neither a refusal nor a failure — a credential saved, a person's role changed. Two rows that
*are* failures were falling through to it.

**`mcp.call_failed`.** Written by `callTool` (`server/src/plugins/store.ts:2957` and `:2992`) after
the policy allowed the call: the vendor answered `isError`, or the attempt threw. It is the direct
sibling of `computer.action_failed` — same decide, record, then act order, on the other acting
surface — and `computer.action_failed` was already in the family. Every failure of a per-person
connector lands on this row: no connection for the asker, a refresh token the vendor stopped
accepting, an API not enabled for the project. So this is the most common failure the product has,
and it was the one row of the family drawn in the same muted colour as a call that worked.

**`component.function_failed`.** Written at `server/src/components/routes.ts:278` when a granted
data read throws. `server/src/audit.ts:279` says it is "deliberately not a refusal", and that is
right — nothing was forbidden. It is not an allowance either. The page already labels it
"Could not be read" while colouring it as though it had been.

Both were also absent from the `Did not happen` saved view, which is the half that is harder to
notice: the view an administrator opens to ask what did not work here is not empty, it is just
short by exactly the rows they came for.

Neither is filed as a refusal. Nothing was forbidden on either row, and filing a broken call as a
policy event teaches a reader to distrust the policy events that are real.

This is the same drift `#302` was about, on the two surfaces `#302` did not reach. The file's own
header says the lists exist so "a new refusal is added in one place or in none" — that held for
refusals and not for failures.

**Deliberately left alone:** `connector.sync_failed` matches the same shape and is declared in the
same union, but nothing writes it — the worker sync is not wired — so classifying a row that cannot
exist would be a guess. It needs the same line the day it is wired.

## Where it runs

- [x] **New state that outlives a request?** None. Two entries added to a frozen array of string
      literals in `app/src/lib/audit/outcome.ts`.
- [x] **What happens on the second replica?** Identical. This is a pure classifier in the browser
      bundle; the rows it classifies were already written by the server, unchanged.
- [x] **Anything serialised?** Nothing.
- [x] **Anything fanned out to a browser?** No. The `Did not happen` view's `?eventType=` query
      grows by two names; the audit read path already accepts a comma list (`server/src/audit.ts:515`).
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: no acting path is touched.
- [x] New refusals and new failures each write a row: both rows were already written. This changes
      only what the page says they mean, and nothing is reclassified as a refusal.
- [x] Nothing new is trusted from the client.

## Changelog

- [x] `A tool call that failed no longer reads as one that worked`, under `Unreleased`.

## Proof

Fail before, pass after, confirmed by reverting the fix in `outcome.ts` and re-running.

With `mcp.call_failed` not in the list:

```
66 |     expect(outcomeOf("mcp.call_failed")).toBe("did-not-happen");
error: expect(received).toBe(expected)
Expected: "did-not-happen"
Received: "allowed"

138 |     expect(filtered).toContain("mcp.call_failed");
error: expect(received).toContain(expected)
Expected to contain: "mcp.call_failed"
Received: [ "computer.action_failed", "agent.stream_stalled", "agent.handoff_failed",
  "agent.escalation_failed" ]

 12 pass
 2 fail
```

And with only `component.function_failed` removed:

```
68 |     expect(outcomeOf("component.function_failed")).toBe("did-not-happen");
Expected: "did-not-happen"
139 |     expect(filtered).toContain("component.function_failed");
Received: [ "computer.action_failed", "agent.stream_stalled", "agent.handoff_failed",
  "agent.escalation_failed", "mcp.call_failed" ]
```

With the fix:

```
$ bun test app/tests/audit-outcome.test.ts
 14 pass
 0 fail
 52 expect() calls
```

Gates:

```
$ bun run format:check   Checked 515 files in 808ms. No fixes applied.
$ bun run lint           Checked 518 files in 882ms. No fixes applied.
$ bun run typecheck      app / server / worker: Exited with code 0
```
