### PR TITLE
Trim NODE_ENV before the key gate reads it, so a stray space cannot ship the public key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A stray space in NODE_ENV no longer lets the public example key through
+
+A deployment that never changed `KEY_ENCRYPTION_KEY` encrypts its credential vault with the key
+printed in `.env.example`, so the server refuses to start with it under `NODE_ENV=production`. That
+refusal compared the variable exactly as written, while the other production refusal beside it —
+private-host browsing — trimmed first. Both read the same env file, and a trailing space there is
+invisible: Docker's `env_file` preserves it and so does every hosting dashboard with a text box. So
+`NODE_ENV=production ` tripped one refusal, slipped past the other, and started the deployment on the
+public key with only a warning at boot. Both gates now ask the same question the same way.
+
 ### Duplicating a coworker keeps the endpoint it was copied from
 
 Duplicate used to point every copy at this deployment's own managed Bot, whatever the coworker being

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -323,6 +323,27 @@ function optional(environment: Environment, name: string): string | undefined {
 }
 
 /**
+ * Whether this deployment says it is in production, which is what the two hard refusals turn on.
+ *
+ * ONE PLACE, BECAUSE THE TWO GATES DID NOT AGREE. Both refuse a local-only setting on a deployed
+ * server — the example encryption key, and private-host browsing — and both compare `NODE_ENV`
+ * against `"production"`. The private-hosts gate read it through `optional`, so the comparison
+ * trimmed; the key gate compared `environment.NODE_ENV` raw.
+ *
+ * Both sides of that comparison come out of the same file. `NODE_ENV=production ` with a trailing
+ * space — invisible in an env file, and preserved verbatim by Docker's `env_file` and by every
+ * hosting dashboard with a text box — therefore tripped one refusal and slipped past the other. The
+ * one it slipped past is the one that decides whether the credential vault may be encrypted with a
+ * key printed in this repository.
+ *
+ * A helper rather than a second `optional` call, so the next gate that needs this question cannot
+ * pick the wrong way to ask it.
+ */
+function isProduction(environment: Environment): boolean {
+  return optional(environment, "NODE_ENV") === "production";
+}
+
+/**
  * The key in `.env.example`, which every clone of this repository starts with.
  *
  * It is a valid key, which is the whole problem: it is the right length and the right encoding, so
@@ -344,7 +365,7 @@ function keyEncryptionKey(environment: Environment): string {
    * in any deployment.
    */
   if (value === PLACEHOLDER_KEY) {
-    if (environment.NODE_ENV === "production") {
+    if (isProduction(environment)) {
       throw new Error(
         "KEY_ENCRYPTION_KEY is still the example key from .env.example, which is public. Generate one with: openssl rand -base64 32",
       );
@@ -660,9 +681,9 @@ function privateHostsAllowed(environment: Environment): boolean {
     return false;
   }
 
-  // Through `optional`, so the comparison trims. Read raw, `NODE_ENV="production "` out of an env
-  // file would slip past a gate that the switch beside it, which does trim, would still trip.
-  if (optional(environment, "NODE_ENV") === "production") {
+  // Through `isProduction`, so the comparison trims. Read raw, `NODE_ENV="production "` out of an
+  // env file would slip past a gate that the switch beside it, which does trim, would still trip.
+  if (isProduction(environment)) {
     throw new Error(
       "AGENT_COMPUTER_ALLOW_PRIVATE_HOSTS=true is for local development only: it lets a Bot reach this deployment's own network. Remove it from this deployment's environment.",
     );

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -179,6 +179,67 @@ describe("deployment configuration", () => {
     ).toThrow("KEY_ENCRYPTION_KEY must be a base64-encoded 32-byte key");
   });
 
+  /*
+   * The key in `.env.example`, refused on a deployed server.
+   *
+   * It is a valid key — right length, right encoding — so nothing else about it fails a check. A
+   * deployment that never changed it encrypts its credential vault with a value printed in a public
+   * repository and looks exactly like one that did, which is why this refusal is the only thing
+   * standing between "copied the example file" and that outcome.
+   */
+  test("refuses the example encryption key on a production deployment", () => {
+    expect(() =>
+      loadConfig({
+        ...baseEnvironment,
+        NODE_ENV: "production",
+      }),
+    ).toThrow("KEY_ENCRYPTION_KEY is still the example key");
+  });
+
+  /*
+   * The same trim the private-hosts gate below already gets, on the gate that matters more.
+   *
+   * Both sides of the comparison come out of one env file, and a trailing space there is invisible:
+   * Docker's `env_file` preserves it verbatim and so does every hosting dashboard with a text box.
+   * Compared raw, `NODE_ENV="production "` downgraded this refusal to a warning nobody reads at boot
+   * and started the deployment on the public key.
+   */
+  test("refuses the example key when NODE_ENV carries whitespace", () => {
+    expect(() =>
+      loadConfig({
+        ...baseEnvironment,
+        NODE_ENV: "production ",
+      }),
+    ).toThrow("KEY_ENCRYPTION_KEY is still the example key");
+  });
+
+  // The local workflow is the reason the example key is usable at all, so off production it still
+  // does exactly what it did: warns, and starts.
+  test.each(["development", undefined])(
+    "warns about the example key and still starts under NODE_ENV=%p",
+    (nodeEnv) => {
+      const consoleWarn = spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        expect(() =>
+          loadConfig({
+            ...baseEnvironment,
+            ...(nodeEnv ? { NODE_ENV: nodeEnv } : {}),
+          }),
+        ).not.toThrow();
+
+        const warning = consoleWarn.mock.calls
+          .map(([first]) => String(first))
+          .find((line) => line.includes("KEY_ENCRYPTION_KEY"));
+
+        expect(warning).toBeDefined();
+        expect(warning).toContain("which is public");
+      } finally {
+        consoleWarn.mockRestore();
+      }
+    },
+  );
+
   test("enables Google authentication when its complete deployment contract is present", () => {
     const config = loadConfig({
       ...baseEnvironment,


### PR DESCRIPTION
## What this changes

`server/src/config.ts` has two hard refusals that turn a local-only setting into a boot failure on a
deployed server. Both compare `NODE_ENV` against `"production"`. They did not compare it the same way.

```ts
// keyEncryptionKey, before this change
if (value === PLACEHOLDER_KEY) {
  if (environment.NODE_ENV === "production") { throw ... }
```

```ts
// privateHostsAllowed, ~300 lines below, and its comment
// Through `optional`, so the comparison trims. Read raw, `NODE_ENV="production "` out of an env
// file would slip past a gate that the switch beside it, which does trim, would still trip.
if (optional(environment, "NODE_ENV") === "production") { throw ... }
```

The comment is exactly right, and it was describing the gate above it. Both sides of the comparison
come out of one env file, and a trailing space there is invisible: Docker's `env_file` preserves the
value verbatim, and so does every hosting dashboard with a text box. `NODE_ENV=production ` trips the
private-hosts refusal and slips past the key refusal.

What slips past matters more than what trips. `PLACEHOLDER_KEY` is the key in `.env.example`, and the
file says why it is dangerous: it is a *valid* key — right length, right encoding — so nothing else
about it fails a check, and a deployment that never changed it encrypts its whole credential vault
with a value printed in this public repository while looking exactly like one that did. With the
space, that deployment starts. The only sign is a `console.warn` at boot, in the same stream as
everything else a container prints on startup.

**The fix.** The question moves into one `isProduction(environment)` used by both gates, so a third
gate that needs it cannot pick the wrong way to ask. `environment.NODE_ENV` was the only raw
environment read left in the file — every other read already goes through `required`, `optional` or
`commaSeparated` — so this closes the class, not just the instance.

`Dockerfile:208` and `charts/openbot/templates/_helpers.tpl:128` both set `NODE_ENV` cleanly, so the
whitespace has to come from a hand-written source: a `.env`, a `docker compose` `environment:` entry,
a manifest somebody typed, or a PaaS text box. Those are the deployments least likely to have
rotated the key.

## Where it runs

- [x] **New state that outlives a request?** None. One pure predicate over the environment map, read
      at boot inside `loadConfig`.
- [x] **What happens on the second replica?** Every replica reads the same environment and now
      answers the same way. Before this, every replica agreed too — they all agreed on the wrong
      answer. The concrete outcome of the change is that such a deployment refuses to start at all,
      on every replica, instead of starting on the public key.
- [x] **Anything serialised?** Nothing.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: no acting path is touched.
- [x] New refusals and new failures each write a row: this is a boot-time refusal that throws before
      the audit store exists, which is how the sibling refusal beside it already behaves.
- [x] Nothing new is trusted from the client.

## Changelog

- [x] `A stray space in NODE_ENV no longer lets the public example key through`, under `Unreleased`.

## Proof

Three tests added to `server/tests/config.test.ts`, next to the ones that already pin the
private-hosts gate. Fail-before confirmed by restoring `environment.NODE_ENV === "production"` and
re-running:

```
(fail) deployment configuration > refuses the example key when NODE_ENV carries whitespace
  at server/tests/config.test.ts:213

 85 pass
 1 fail
```

With the fix:

```
$ bun test server/tests/config.test.ts
 86 pass
 0 fail
 116 expect() calls
```

Honest note on the other two: `refuses the example encryption key on a production deployment` and
`warns about the example key and still starts under NODE_ENV=%p` pass before and after. They are
here because that gate had no test of its own at all, which is part of why it drifted from the one
beside it.

Gates:

```
$ bun run format:check   Checked 515 files. No fixes applied.
$ bun run lint           Checked 518 files. No fixes applied.
$ bun run typecheck      app / server / worker: Exited with code 0
```
