### PR TITLE
Record who a coworker was opened to, not only where it was pointed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### The trail says who a coworker was opened to
+
+Making a coworker public admits every signed-in person to it, and being admitted to a coworker is
+being allowed to act as it — with the connectors, the tools and the browser it was granted. It is one
+click in the coworker dialog. The `bot.created` and `bot.updated` rows recorded the name, the
+endpoint and whether a key was set, and said nothing about this, so an edit that opened a coworker to
+the whole deployment was byte-identical on the audit page to one that corrected its title. Both rows
+now carry the visibility, on every edit rather than only the edit that moved it, so reading the trail
+forward says who could reach each coworker at any point.
+
 ### Duplicating a coworker keeps the endpoint it was copied from
 
 Duplicate used to point every copy at this deployment's own managed Bot, whatever the coworker being

--- a/server/src/agents/routes.ts
+++ b/server/src/agents/routes.ts
@@ -358,9 +358,15 @@ export function createAgentRoutes(
       /*
        * The endpoint, because that is where conversation content will be sent, and whether a key was
        * attached, because "this Bot authenticates" is a fact and the key itself never is.
+       *
+       * And who may reach it. `visibility` is not a display preference: `accessFilter` admits a
+       * `public` coworker to every signed-in person, and `canRunAgent` is `canAccessAgent`, so public
+       * means everybody in the deployment may act as this Bot and spend the grants it holds. A row
+       * that cannot say which it was cannot reconstruct who could use this coworker at the time.
        */
       await record(context, "bot.created", agent.id, {
         name: parsed.value.name,
+        visibility: parsed.value.visibility,
         ...(parsed.value.endpoint ? { endpoint: parsed.value.endpoint } : {}),
         hasKey: Boolean(parsed.value.auth),
       });
@@ -385,10 +391,22 @@ export function createAgentRoutes(
         context.req.param("agentId"),
         parsed.value,
       );
-      // What changed, not the new values. Repointing the endpoint is the dangerous edit and is worth
-      // naming; a replaced key is worth knowing about and is never worth recording.
+      /*
+       * What changed, not the new values. Repointing the endpoint is the dangerous edit and is worth
+       * naming; a replaced key is worth knowing about and is never worth recording.
+       *
+       * `visibility` is carried the way `name` is — on every row, whether or not this edit moved it —
+       * because it is the second dangerous edit and the route has no before to compare against.
+       * Public admits every signed-in person to this coworker, and `canRunAgent` is `canAccessAgent`,
+       * so it hands them the right to act as it and spend what it was granted. Without the value on
+       * each row, an edit that opened a coworker to the whole deployment is byte-identical to one
+       * that corrected its title, and the trail cannot say when it was opened or by whom. Recorded on
+       * every row rather than only on the row that changed it, so reading the trail forward tells you
+       * what was reachable at any point, which is what an incident asks.
+       */
       await record(context, "bot.updated", agent.id, {
         name: parsed.value.name,
+        visibility: parsed.value.visibility,
         ...(parsed.value.endpoint ? { endpoint: parsed.value.endpoint } : {}),
         ...(parsed.value.auth ? { keyReplaced: true } : {}),
       });

--- a/server/tests/bot-lifecycle-audit.test.ts
+++ b/server/tests/bot-lifecycle-audit.test.ts
@@ -89,6 +89,48 @@ describe("what a Bot is, on the trail", () => {
     expect(rows[0]?.payload.endpoint).toBe("https://elsewhere.example/ag-ui");
   });
 
+  /*
+   * The other dangerous edit, and the one the trail was silent about.
+   *
+   * `visibility` is not a display preference. `accessFilter` admits a public coworker to every
+   * signed-in person, and `canRunAgent` is `canAccessAgent`, so public hands everybody in the
+   * deployment the right to act as this Bot and spend the connector grants it holds. It is one click
+   * in the coworker dialog.
+   */
+  test("creating one records who may reach it", async () => {
+    const { rows, hono } = app();
+
+    await hono.request("http://t/api/agents", json({ visibility: "private" }));
+
+    expect(rows[0]?.eventType).toBe("bot.created");
+    expect(rows[0]?.payload.visibility).toBe("private");
+  });
+
+  test("opening one to the whole deployment says so", async () => {
+    const { rows, hono } = app();
+
+    await hono.request("http://t/api/agents/bot-1", {
+      ...json({ visibility: "public" }),
+      method: "PATCH",
+    });
+
+    expect(rows[0]?.eventType).toBe("bot.updated");
+    expect(rows[0]?.payload.visibility).toBe("public");
+  });
+
+  test("an edit that leaves it private says that too", async () => {
+    // Carried on every row rather than only on the row that moved it: reading the trail forward has
+    // to tell you what was reachable at each point, and the route has no before to compare against.
+    const { rows, hono } = app();
+
+    await hono.request("http://t/api/agents/bot-1", {
+      ...json({ visibility: "private", title: "Sales assistant, revised" }),
+      method: "PATCH",
+    });
+
+    expect(rows[0]?.payload.visibility).toBe("private");
+  });
+
   test("a replaced key is noted and never recorded", async () => {
     const { rows, hono } = app();
 


### PR DESCRIPTION
## What this changes

`visibility` is not a display preference.

```ts
// server/src/agents/profile-policy.ts
export function canAccessAgent(actor, agent) {
  return agent.visibility === "public" || agent.ownerUserId === actor.id || actor.role === "admin";
}
export const canRunAgent = canAccessAgent;
```

So `public` admits every signed-in person to a coworker, and being admitted to a coworker is being
allowed to **act as it** — with the connectors, the tools and the browser it was granted
(`server/src/app.ts` routes "may this person act as this Bot" through the same read). Since the
coworker dialogs landed in #317 it is one click, saved on pick
(`app/src/components/agents/agent-dialog.tsx:299`).

`bot.created` and `bot.updated` record the name, the endpoint and whether a key was set. They say
nothing about this. An edit that opened a coworker to the whole deployment was byte-identical on the
audit page to one that corrected its title, and the trail could not answer "who made this Bot
available to everybody, and when".

`server/src/audit.ts:322-333` already gives the reason these event types exist, and it applies here
word for word:

> The trail recorded every mouse movement a Bot made and could not answer "who pointed this Bot at
> that host, and when", which is the first question asked in an incident.

Both rows now carry `visibility`.

**Why on every row and not only on the row that moved it.** The route has no *before* to compare
against — `store.update` is handed the new input and returns the result — so recording only a change
would mean an extra read purely to shape a log line. Recording the value on each row is also the more
useful trail: read forward, it says what was reachable at every point, which is the question an
incident actually asks. `name` is already carried this way, so the shape is not new.

Nothing else moves. The endpoint and the key are still recorded as *what changed* rather than as new
values, and the key itself is still never recorded.

## Where it runs

- [x] **New state that outlives a request?** None. One extra field on a payload the route already
      writes.
- [x] **What happens on the second replica?** Identical. `record()` writes through the same
      `recordAuditEvent` into the same Postgres table from whichever replica served the edit.
- [x] **Anything serialised?** Nothing. No new read, no new write, no ordering requirement.
- [x] **Anything fanned out to a browser?** No. The route's response is unchanged.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: no acting path is touched.
- [x] New refusals and new failures each write a row: no new refusal. This makes an existing row able
      to reconstruct a decision it could not.
- [x] Nothing new is trusted from the client. `parsed.value.visibility` is the value the parser
      already validated to `"public" | "private"` before the store was allowed to write it, and it is
      the same value the store applied — not a separate claim from the body.
- [x] Nothing sensitive added. `visibility` is one of two enum words; it is not a secret and it is
      already returned to every browser in the agent DTO.

## Proof

Three tests in `server/tests/bot-lifecycle-audit.test.ts`, which runs without a database. Fail-before
confirmed by removing the two `visibility:` lines from the payloads:

```
(fail) what a Bot is, on the trail > creating one records who may reach it
(fail) what a Bot is, on the trail > opening one to the whole deployment says so
(fail) what a Bot is, on the trail > an edit that leaves it private says that too

 16 pass
 3 fail
```

With the fix:

```
$ bun test server/tests/bot-lifecycle-audit.test.ts server/tests/agent-routes.test.ts
 68 pass
 0 fail
 123 expect() calls
```

Gates:

```
$ bun run format:check   Checked 515 files. No fixes applied.
$ bun run lint           Checked 518 files. No fixes applied.
$ bun run typecheck      app / server / worker: Exited with code 0
```

## Changelog

- [x] `The trail says who a coworker was opened to`, under `Unreleased`.
