### PR TITLE
fix(channels): reject whitespace-only agentId with 400

### DIFF
--- a/server/src/channels/routes.ts
+++ b/server/src/channels/routes.ts
@@ -935,6 +935,12 @@ export function parseActivityInput(
   if (object.agentId !== null && typeof object.agentId !== "string") {
     return { ok: false, error: "Agent ID must be a string or null." };
   }
+  if (
+    typeof object.agentId === "string" &&
+    object.agentId.trim().length === 0
+  ) {
+    return { ok: false, error: "Agent ID must be a string or null." };
+  }
   if (typeof object.at !== "string") {
     return { ok: false, error: "Timestamp is required." };
   }

--- a/server/tests/channel-activity-input.test.ts
+++ b/server/tests/channel-activity-input.test.ts
@@ -52,4 +52,17 @@ describe("parsing a reported message", () => {
     expect(parsed.value.text).toBe("hello");
     expect(parsed.value.agentId).toBe("agent-1");
   });
+
+  test("refuses a whitespace-only agent ID rather than looking it up", () => {
+    // "   " used to trim to "" and fall through to a 404 "Agent not found";
+    // a malformed field is a 400 naming the field.
+    const parsed = parseActivityInput(
+      { text: "hello", agentId: "   ", at: "2026-09-03T09:00:00.000Z" },
+      now,
+    );
+    expect(parsed).toEqual({
+      ok: false,
+      error: "Agent ID must be a string or null.",
+    });
+  });
 });


### PR DESCRIPTION
parseActivityInput accepted `"   "` as a valid agentId, trimmed it to `""`, then recordActivity treated it as a lookup and returned 404 Agent not found. A malformed field should be a 400 naming the field, consistent with the existing text validation.

Repro: POST /api/channels/:id/activity with {"text":"hi","agentId":"   ","at":now} -> 404 before, 400 after.

Tests: added whitespace-only case to server/tests/channel-activity-input.test.ts (5 pass). Biome format+lint clean.