### PR TITLE
fix(mcp): name null parts instead of throwing in resultText

### DIFF
--- a/server/src/plugins/mcp.ts
+++ b/server/src/plugins/mcp.ts
@@ -49,6 +49,7 @@ export function resultText(content: unknown): {
   const parts = Array.isArray(content) ? content : [];
   const joined = parts
     .map((part) => {
+      if (!part || typeof part !== "object") return "[unknown]";
       const item = part as { type?: string; text?: string };
       if (item.type === "text" && typeof item.text === "string") {
         return item.text;

--- a/server/tests/mcp-result.test.ts
+++ b/server/tests/mcp-result.test.ts
@@ -63,6 +63,13 @@ describe("a result with something in it", () => {
     expect(resultText([{}]).text).toBe("[unknown]");
   });
 
+  test("names a null or non-object part rather than throwing", () => {
+    // Content arrives from a vendor's server; a null entry must not throw.
+    expect(resultText([null]).text).toBe("[unknown]");
+    expect(resultText([undefined]).text).toBe("[unknown]");
+    expect(resultText([42]).text).toBe("[unknown]");
+  });
+
   test("a part that is only whitespace still counts as something being there", () => {
     // One blank part beside a real one must not make the whole result look empty.
     expect(


### PR DESCRIPTION
resultText cast each part to an object then read item.type. A null/undefined entry from a vendor MCP server threw TypeError (verified: resultText([null]) throws). Primitives were safe, null was not.

Fix returns [unknown] for non-object parts, consistent with the existing naming-not-dropping policy.

Tests: added null/undefined/number cases to server/tests/mcp-result.test.ts (10 pass). Biome clean.