### PR TITLE
fix(audit): redact payloads in store insert as last defence

### DIFF
--- a/server/src/audit.ts
+++ b/server/src/audit.ts
@@ -485,7 +485,10 @@ export async function recordAuditEvent(
 export function createAuditStore(database: Database): AuditStore {
   return {
     insert: async (event) => {
-      await database.insert(auditEvents).values(event);
+      await database.insert(auditEvents).values({
+        ...event,
+        payload: redactAuditPayload(event.payload) as Record<string, unknown>,
+      });
     },
   };
 }

--- a/server/tests/audit.test.ts
+++ b/server/tests/audit.test.ts
@@ -3,6 +3,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { createApp } from "../src/app";
 import {
   auditEventTypes,
+  createAuditStore,
   recordAuditEvent,
   redactAuditPayload,
 } from "../src/audit";
@@ -94,6 +95,30 @@ describe("audit payload redaction", () => {
         payload: { apiKey: "[REDACTED]", provider: "openai" },
       },
     ]);
+  });
+
+  test("a direct store insert is redacted too", async () => {
+    // Redaction used to live only in recordAuditEvent, so a direct insert()
+    // stored secrets in cleartext. The store is the last line of defence.
+    let stored: unknown;
+    const store = createAuditStore({
+      insert: () => ({
+        values: async (event: unknown) => {
+          stored = event;
+        },
+      }),
+    } as never);
+
+    await store.insert({
+      eventType: "credential.created",
+      targetType: "credential",
+      targetId: "credential-1",
+      payload: { apiKey: "plaintext-key", provider: "openai" },
+    } as never);
+
+    expect(stored).toMatchObject({
+      payload: { apiKey: "[REDACTED]", provider: "openai" },
+    });
   });
 });
 


### PR DESCRIPTION
Redaction lived only in recordAuditEvent. createAuditStore.insert wrote the event verbatim, so any direct insert() caller stored secrets in cleartext. All current callers use the wrapper, but the exported store invites direct use.

Fix applies redactAuditPayload inside insert too (idempotent, so the wrapper path is unchanged).

Tests: added direct-insert redaction case to server/tests/audit.test.ts (7 pass). Biome clean.