### PR TITLE
Make the supervisor work on Podman: reach the socket, and wait for healthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A Bot's computer is waited for properly on Podman, and the supervisor can reach the engine there
+
+Two things stopped OpenBot running on Podman, which nothing had tried before.
+
+The supervisor could not reach the engine at all: `The supervisor could not reach Docker`. The socket
+is there and the mount is right, but Podman's virtual machine runs SELinux and labels the socket in a
+way a container is not allowed to read. The supervisor now declares `label=disable`, which is what
+that needs and which changes nothing on Docker.
+
+Then every cold start of a computer raced the first request to it. Readiness was read off the image's
+`HEALTHCHECK`, and Podman does not report one: its images are OCI-manifest, the OCI image config has
+no healthcheck field, and the instruction is dropped both when Podman builds an image and when it
+pulls one that has it. With no health to read, the supervisor fell back to accepting a container that
+was merely running, and a running container is not a browser that is answering, so the first request
+arrived at a port nothing was listening on and came back as a computer that is not running. The
+supervisor now states the healthcheck when it creates a computer instead of inheriting it, so
+readiness no longer depends on how the image was built. On Docker the behaviour is unchanged.
+
 ## 0.0.7
 
 ### The published service images are zstd rather than gzip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -223,6 +223,9 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       # To register an entry per Bot as each computer is created.
       - spire-server-socket:/tmp/spire-server/private
+    security_opt:
+      # The engine socket carries an SELinux label this container is not allowed to read.
+      - label=disable
     healthcheck:
       test: ["CMD-SHELL", "bun -e \"await fetch('http://localhost:4300/health')\""]
       interval: 10s

--- a/supervisor/src/docker.ts
+++ b/supervisor/src/docker.ts
@@ -61,7 +61,7 @@ const COMPUTER_HEALTHCHECK = {
   Timeout: 3_000_000_000,
   StartPeriod: 2_000_000_000,
   Retries: 30,
-} as const;
+};
 
 /**
  * How many times `ensure` will build a computer before giving up.

--- a/supervisor/src/docker.ts
+++ b/supervisor/src/docker.ts
@@ -33,6 +33,37 @@ const docker = new Docker(
 const COMPUTER_PORT = "4100/tcp";
 
 /**
+ * Readiness, stated at create time rather than read off the image.
+ *
+ * `agent-computer/Dockerfile` declares the same HEALTHCHECK, and under Docker that was enough: the
+ * image carried it, the daemon ran it, and {@link waitUntilAnswering} could ask. Podman does not
+ * report it. Its images are OCI-manifest, the OCI image config has no healthcheck field, and the
+ * instruction is dropped, both when Podman builds the image and when it pulls one that has it. The
+ * published `agent-computer` config does carry it; `podman inspect` of that same image reports
+ * none.
+ *
+ * Silently, and into the one branch that cannot tell the difference: with no health to read,
+ * `waitUntilAnswering` accepts `Running`, and a container that is running is not a Chromium that
+ * is answering. Every cold start of a computer then raced the first request, which arrived at a
+ * port nothing was listening on yet and was reported as a computer that is not running.
+ *
+ * Passed here, the engine is told what to run instead of asked what it inherited, which is also
+ * true on Docker and one less thing that depends on how an image was built. Podman honours an
+ * explicit healthcheck: it is how every service in `docker-compose.yml` reports healthy there.
+ */
+const COMPUTER_HEALTHCHECK = {
+  Test: [
+    "CMD-SHELL",
+    `bun -e "const r = await fetch('http://localhost:${COMPUTER_PORT.split("/")[0]}/health'); process.exit(r.ok ? 0 : 1)"`,
+  ],
+  // Nanoseconds, which is what the API takes. The same numbers the Dockerfile states.
+  Interval: 2_000_000_000,
+  Timeout: 3_000_000_000,
+  StartPeriod: 2_000_000_000,
+  Retries: 30,
+} as const;
+
+/**
  * How many times `ensure` will build a computer before giving up.
  *
  * One retry, because the only thing being retried is losing a race to another request for the same
@@ -262,8 +293,9 @@ async function waitUntilAnswering(
     try {
       const info = await docker.getContainer(container).inspect();
       const health = info.State?.Health?.Status;
-      // An image without a HEALTHCHECK reports nothing. Waiting forever for an answer that will
-      // never come would be worse than going ahead, so running is accepted as the best available.
+      // Nothing to read. Every computer this supervisor creates is given a healthcheck, so this is
+      // an engine that does not report one rather than an image that does not carry one, and
+      // waiting forever for an answer that will never come would be worse than going ahead.
       if (!health) {
         if (info.State?.Running) return;
       } else if (health === "healthy") {
@@ -432,6 +464,7 @@ export async function ensure(
           Labels: labelsFor(names),
           Env: options.environment,
           ExposedPorts: { [COMPUTER_PORT]: {} },
+          Healthcheck: COMPUTER_HEALTHCHECK,
           HostConfig: hostConfig(names, options),
         });
       } catch (error) {


### PR DESCRIPTION
S1 of the OpenBot Desktop build: prove the stack on Podman. It did not work. Two defects, both fixed here.

## 1. The supervisor could not reach the engine

`The supervisor could not reach Docker (Error: Was there a typo in the url or port?). A computer cannot be started without it.`

Not a path problem. Podman's VM already symlinks `/var/run/docker.sock` to the rootless socket, so the existing compose mount is correct and needs no change. The VM runs **SELinux enforcing** and labels the socket `user_tmp_t`:

```
srw-rw----. 1 core core unconfined_u:object_r:user_tmp_t:s0 /run/user/501/podman/podman.sock
```

`security_opt: [label=disable]` on the supervisor is the whole fix. No-op on Docker Desktop; understood by Docker on SELinux hosts.

## 2. Every cold start of a computer raced the first request

After the socket worked, the supervisor created the computer and the request still failed, now with `The assistant's computer is not running.`

The computer was running, and answering `/health` with 200. What was missing was the health *status*: **Podman reports no `HEALTHCHECK`.** Its images are OCI-manifest, the OCI image config has no healthcheck field, and the instruction is dropped both when Podman builds an image and when it pulls one that has it.

Read straight from the registry, the published image has it:

```
"Healthcheck": { "Test": ["CMD-SHELL", "bun -e \"...\/health...\""], "Interval": 2000000000, ... }
```

`podman inspect` of that same pulled image: `NONE`.

With no health to read, `waitUntilAnswering` took the branch that accepts a merely-running container. A running container is not a Chromium that is answering, so the first request hit a port nothing was listening on. That branch's own comment called this out as the worse-but-necessary option; on Podman it was not the exception, it was every time.

The supervisor now passes the healthcheck when it creates the computer instead of inheriting it. Readiness stops depending on how the image was built. Podman honours an explicit healthcheck: it is how every service in `docker-compose.yml` reports healthy there. Docker is unchanged, because the numbers are the ones `agent-computer/Dockerfile` already declares.

### This one collides with 0.0.7's zstd images

zstd layers **require** OCI media types. An OCI image cannot carry a HEALTHCHECK that Podman will report. So zstd and image-declared readiness could not both be had while readiness was read off the image. Stating it at create time is what makes them independent.

## Verified on Podman, not reasoned about

Rootless Podman 6.1.1, `applehv`, macOS arm64. Isolated stack: own Compose project, `COMPUTER_NAMESPACE`, database and ports.

| | before | after |
| --- | --- | --- |
| cold start | **fail**, twice | **5 pass, 0 fail** |
| created computer's health | `<none>` | `healthy` |
| image's own healthcheck | `NONE` | `NONE`, still |

That last row is the point: the computer reports healthy while the image it came from carries nothing, so it is the explicit healthcheck doing the work.

The full journey passes on Podman: compose up, supervisor holding the rootless socket, a per-Bot computer created through it, and a harness answering a live AG-UI run through the gateway with the trail recording it.

`format:check`, `lint` and the supervisor unit tests are clean. `supervisor typecheck` reports the same five pre-existing `TS7006` errors as `main`, byte-identical apart from shifted line numbers; this change adds none.

## Three doc corrections this also produced

Not in this PR, they are build-doc edits:

- `--provider applehv` is a no-op on 6.1.1: it is the default on Apple silicon. The pin was written against 5.7.x when libkrun was the default.
- No socket remapping is needed. Podman supplies the `/var/run/docker.sock` symlink in the VM.
- Dynamic port forwarding works: gvproxy forwarded the computer's published port to macOS, 200 from the host, so the host-native core reaching computers over loopback holds on Podman.