### PR TITLE
Let the engine socket be somewhere other than /var/run/docker.sock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### The engine socket the supervisor is given can be pointed somewhere else
+
+Compose mounted `/var/run/docker.sock` into the supervisor as a fixed path. That is correct for
+Docker, and for Podman on macOS, where `podman machine` symlinks it to the rootless socket inside the
+virtual machine. It is wrong for rootless Podman on Linux, where the path is either absent or, with
+`podman-docker` installed, a symlink to `/run/podman/podman.sock`, the rootful socket, which is not
+the one running. The supervisor held a dead socket and every attempt to give a Bot a computer failed
+with a message about not reaching Docker.
+
+The mount source is now `ENGINE_SOCKET`, defaulting to `/var/run/docker.sock`, so nothing changes
+unless it is set. On rootless Podman on Linux, set it to `$XDG_RUNTIME_DIR/podman/podman.sock`.
+
 ### A Bot's computer is waited for properly on Podman, and the supervisor can reach the engine there
 
 Two things stopped OpenBot running on Podman, which nothing had tried before.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,7 +160,7 @@ services:
       - spire-agent-socket:/tmp/spire-agent/public
       - spire-agent-data:/opt/spire/data
       # Read-only, and only so the docker workload attestor can see which container is asking.
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ${ENGINE_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock:ro
 
   # One computer per Bot.
   #
@@ -220,7 +220,15 @@ services:
     volumes:
       # Read-only because this service only ever needs to ask; it is still root-equivalent, which is
       # the whole reason nothing else here gets it.
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      #
+      # The source is a setting because the default is wrong on one of the engines this runs on.
+      # Docker puts its socket at this path, and so does Podman on macOS, where `podman machine`
+      # symlinks it to the rootless socket inside the virtual machine. Rootless Podman on Linux does
+      # not: the path is either absent or, with podman-docker installed, a symlink to
+      # /run/podman/podman.sock, which is the *rootful* socket and is not the one running. The
+      # supervisor then holds a dead socket and reports that it cannot reach Docker. Point
+      # ENGINE_SOCKET at $XDG_RUNTIME_DIR/podman/podman.sock there.
+      - ${ENGINE_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock:ro
       # To register an entry per Bot as each computer is created.
       - spire-server-socket:/tmp/spire-server/private
     security_opt:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -303,6 +303,14 @@ The supervisor also reads:
 - `COMPUTER_MEMORY_BYTES`
 - `DOCKER_SOCKET`
 
+`ENGINE_SOCKET` is separate from those, because it is read by Compose rather than by the supervisor:
+it is the host path mounted into the supervisor as `/var/run/docker.sock`. Unset, it is
+`/var/run/docker.sock`, which is right for Docker and for Podman on macOS, where `podman machine`
+symlinks that path to the rootless socket. Rootless Podman on Linux needs
+`ENGINE_SOCKET=$XDG_RUNTIME_DIR/podman/podman.sock`: there the default path is either missing or a
+symlink to the rootful socket, which is not the one running, and the supervisor reports that it
+cannot reach Docker.
+
 `COMPUTER_NAMESPACE` defaults to `openbot` and names the deployment a computer belongs to. It is part
 of every container and volume name the supervisor derives, and the supervisor acts only on computers
 carrying it, so two deployments on one Docker host never adopt each other's.


### PR DESCRIPTION
Completes S1 of the OpenBot Desktop build: the stack proven on Podman on **both** macOS and Linux.

## The defect

Compose mounted `/var/run/docker.sock` into the supervisor as a fixed source. Correct on Docker, and correct on Podman on macOS, where `podman machine` symlinks that path to the rootless socket inside the VM. That is why the mount needed no change there.

Wrong on rootless Podman on Linux. The path is either absent or, with `podman-docker` installed, a symlink to `/run/podman/podman.sock` — the **rootful** socket, which is not the one running:

```
/var/run/docker.sock -> /run/podman/podman.sock          # root:root, not running
/run/user/501/podman/podman.sock                          # the rootless socket, live
```

The supervisor is handed a dead socket, and every request for a Bot's computer fails:

```
The supervisor could not reach Docker (Error: Was there a typo in the url or port?).
A computer cannot be started without it.
```

The mount source is now `${ENGINE_SOCKET:-/var/run/docker.sock}`, so nothing changes for anyone who does not set it.

## Verified on Linux, red then green

Ubuntu 24.04 aarch64, rootless Podman 4.9.3, real Intelligence credentials, `start.sh` unmodified.

| | result |
| --- | --- |
| before | **4 pass, 1 fail** — `could not reach Docker` |
| after, `ENGINE_SOCKET=$XDG_RUNTIME_DIR/podman/podman.sock` | **5 pass, 0 fail** |

After: `openbot-computer-risk-analyst Up 3 seconds`, and the navigate test took 3.5s because it waited for the computer to be healthy rather than racing it — the fix from #372 doing its job on a second engine.

## S1 is now answered on both platforms

macOS, Podman 6.1.1, `applehv`: 5 pass, 0 fail. Linux, Podman 4.9.3, native rootless: 5 pass, 0 fail. On both, compose came up, the supervisor held the rootless socket, it created a per-Bot computer through it, and a harness answered a live AG-UI run through the gateway with the trail recording it.

### What the two platforms disagree about

Worth stating, because the build doc treats them as one row:

| | macOS | Linux |
| --- | --- | --- |
| Podman version | 6.1.1 (brew) | 4.9.3 (Ubuntu 24.04 LTS) |
| `/var/run/docker.sock` | symlink to the rootless socket, works | symlink to the **rootful** socket, dead |
| `ENGINE_SOCKET` needed | no | **yes** |
| SELinux | Enforcing, so `label=disable` required | none, AppArmor instead; `label=disable` is a no-op and harmless |
| port forwarding | gvproxy forwards the computer's published port to the host | native loopback, nothing to forward |

`format:check` and `lint` clean; `docker compose config` valid.