### PR TITLE
fix(server): accept uppercase duration units in durationMs

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -715,14 +715,14 @@ function privateHostsAllowed(environment: Environment): boolean {
  * its meaning.
  */
 export function durationMs(value: string): number {
-  const match = /^(\d+)\s*(ms|s|m|h)?$/.exec(value.trim());
+  const match = /^(\d+)\s*(ms|s|m|h)?$/i.exec(value.trim());
   if (!match) {
     throw new Error(
       `"${value}" is not a duration. Write it as 30s, 30m, 2h, or a plain number of milliseconds.`,
     );
   }
   const amount = Number(match[1]);
-  switch (match[2]) {
+  switch (match[2]?.toLowerCase()) {
     case "h":
       return amount * 3_600_000;
     case "m":


### PR DESCRIPTION
COMPUTER_SANDBOX_IDLE_AFTER=30M, 30S or 1H threw 'not a duration' even though uppercase units are the conventional way to write env durations. The regex only accepted lowercase.

Change: match units case-insensitively and lowercase before the switch, so 30M=30m, 30S=30s, 1H=1h, 500MS=500ms. Plain numbers and invalid input behave as before.

Verified: manual check of 30m/30M/30s/30S/2h/2H/500ms/500MS/plain + 'abc' still throws; bun test server/tests/config.test.ts 87 pass.