### PR TITLE
fix(servers): reject whitespace-only id, title and url in POST /servers/custom

### DIFF
--- a/server/src/plugins/routes.ts
+++ b/server/src/plugins/routes.ts
@@ -232,7 +232,7 @@ export function createPluginRoutes(
       url?: string;
       credentialId?: string;
     } | null;
-    if (!body?.id || !body.title || !body.url) {
+    if (!body?.id?.trim() || !body?.title?.trim() || !body?.url?.trim()) {
       return context.json(
         { error: "A name, a title and a URL are required." },
         400,
@@ -241,9 +241,9 @@ export function createPluginRoutes(
 
     try {
       const server = await store.addCustomServer({
-        id: body.id,
-        title: body.title,
-        url: body.url,
+        id: body.id.trim(),
+        title: body.title.trim(),
+        url: body.url.trim(),
         credentialId: body.credentialId,
         by: actorEmail(context),
       });


### PR DESCRIPTION
POST /servers/custom checked truthiness only, so id/title/url of '   ' passed validation and reached the store. The sibling oauth-client route in the same file already trims, so this aligns the two.

Change: require trimmed non-empty id/title/url (400 otherwise) and pass trimmed values to addCustomServer.

Verified: tsc clean; bun test server/tests/plugin-catalogue.test.ts 43 pass.