### PR TITLE
fix(skills): reject whitespace-only title and instructions in POST /skills

### DIFF
--- a/server/src/plugins/routes.ts
+++ b/server/src/plugins/routes.ts
@@ -574,7 +574,7 @@ export function createPluginRoutes(
       global?: boolean;
       tools?: unknown;
     } | null;
-    if (!body?.slug || !body.title || !body.instructions) {
+    if (!body?.slug || !body?.title?.trim() || !body?.instructions?.trim()) {
       return context.json(
         { error: "A slug, a title and instructions are required." },
         400,
@@ -617,9 +617,9 @@ export function createPluginRoutes(
     try {
       await store.installSkill({
         slug: body.slug,
-        title: body.title,
+        title: body.title.trim(),
         summary: body.summary ?? "",
-        instructions: body.instructions,
+        instructions: body.instructions.trim(),
         ownerUserId: body.global ? null : actor.id,
         ...(tools === undefined ? {} : { tools }),
         by: actorEmail(context),


### PR DESCRIPTION
POST /skills only rejected missing title/instructions, so '   ' created empty-looking skills stored verbatim by installSkill. Only slug had a shape check.

Change: require trimmed non-empty title/instructions (400 otherwise) and store trimmed values.

Verified: tsc clean; bun test server/tests/plugin-catalogue.test.ts + config.test.ts 130 pass. plugin-store integration failures are pre-existing Postgres-connection failures, identical on clean upstream/main.