### PR TITLE
fix(audit): return 400 for invalid from/to dates and strict-parse limit

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -8,6 +8,7 @@ import { createAgentRoutes } from "./agents/routes";
 import {
   type AuditReader,
   type AuditStore,
+  AuditQueryError,
   auditQueryFromUrl,
   recordAuditEvent,
 } from "./audit";
@@ -456,9 +457,16 @@ export function createApp(
       return context.json({ error: "Audit logging is not configured." }, 503);
     }
 
-    return context.json(
-      await auditReader.list(auditQueryFromUrl(new URL(context.req.url))),
-    );
+    try {
+      return context.json(
+        await auditReader.list(auditQueryFromUrl(new URL(context.req.url))),
+      );
+    } catch (error) {
+      if (error instanceof AuditQueryError) {
+        return context.json({ error: error.message }, 400);
+      }
+      throw error;
+    }
   });
   /*
    * Who is here, and what they may do.

--- a/server/src/audit.ts
+++ b/server/src/audit.ts
@@ -599,9 +599,7 @@ export function auditQueryFromUrl(url: URL): AuditEventQuery {
 
   const from = optional("from");
   if (from !== undefined && Number.isNaN(Date.parse(from))) {
-    throw new AuditQueryError(
-      'Query parameter "from" must be a valid date.',
-    );
+    throw new AuditQueryError('Query parameter "from" must be a valid date.');
   }
   const to = optional("to");
   if (to !== undefined && Number.isNaN(Date.parse(to))) {

--- a/server/src/audit.ts
+++ b/server/src/audit.ts
@@ -579,15 +579,34 @@ export function createAuditReader(database: Database): AuditReader {
   };
 }
 
+export class AuditQueryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuditQueryError";
+  }
+}
+
 export function auditQueryFromUrl(url: URL): AuditEventQuery {
-  const requestedLimit = Number.parseInt(
-    url.searchParams.get("limit") ?? "50",
-    10,
-  );
+  const rawLimit = url.searchParams.get("limit") ?? "50";
+  const trimmedLimit = rawLimit.trim();
+  const requestedLimit = /^\d+$/.test(trimmedLimit)
+    ? Number.parseInt(trimmedLimit, 10)
+    : Number.NaN;
   const limit = Number.isFinite(requestedLimit)
     ? Math.min(Math.max(requestedLimit, 1), 100)
     : 50;
   const optional = (name: string) => url.searchParams.get(name) ?? undefined;
+
+  const from = optional("from");
+  if (from !== undefined && Number.isNaN(Date.parse(from))) {
+    throw new AuditQueryError(
+      'Query parameter "from" must be a valid date.',
+    );
+  }
+  const to = optional("to");
+  if (to !== undefined && Number.isNaN(Date.parse(to))) {
+    throw new AuditQueryError('Query parameter "to" must be a valid date.');
+  }
 
   return {
     cursor: optional("cursor"),
@@ -596,7 +615,7 @@ export function auditQueryFromUrl(url: URL): AuditEventQuery {
     actorUserId: optional("actorUserId"),
     targetType: optional("targetType"),
     targetId: optional("targetId"),
-    from: optional("from"),
-    to: optional("to"),
+    from,
+    to,
   };
 }


### PR DESCRIPTION
?from=not-a-date fed an Invalid Date into drizzle gt/lt with no try/catch in the route, surfacing a 500. parseInt also accepted '50abc' as 50 and '3.9' as 3.

Change: auditQueryFromUrl throws AuditQueryError on unparseable from/to (route maps to 400), and strict-parses limit (digits-only, else default 50, still clamped 1-100). Valid queries behave as before.

Verified: manual checks (limit 10/50abc/3.9, valid + invalid from/to); bun test server/tests/audit.test.ts + config.test.ts 94 pass.