### PR TITLE
fix(components): drop whitespace-only and empty entries in PUT /catalogue

### DIFF
--- a/server/src/components/routes.ts
+++ b/server/src/components/routes.ts
@@ -95,11 +95,13 @@ export function createComponentRoutes(
       >;
       if (
         typeof name !== "string" ||
-        !name ||
+        !name.trim() ||
         typeof title !== "string" ||
+        !title.trim() ||
         typeof kind !== "string" ||
+        !kind.trim() ||
         typeof description !== "string" ||
-        !description
+        !description.trim()
       ) {
         return [];
       }


### PR DESCRIPTION
PUT /catalogue rejected '' for name/description but not '   ', and never checked title/kind at all, so blank rows reached syncCatalogue.

Change: require trimmed non-empty name/title/kind/description, otherwise skip the entry as with other invalid rows.

Verified: tsc clean; logic check keeps 1 of 4 mixed entries; bun test server/tests/component-decision.test.ts 5 pass. channel-routes 29 failures are pre-existing on clean upstream/main.