### PR TITLE
Record a Bot's decline only against a Bot the caller may reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A Bot's own decline is only recorded against a Bot the caller may reach
+
+A Bot reports that it declined a request through the person's session, and the audit row says
+`reportedBy: the Bot itself`. The route wrote that row for any agent id in the path, without asking
+whether the caller could reach that Bot, so any signed-in person could put a decline, in any words,
+against any coworker, one they cannot see included, and an administrator reading the trail would take
+it for something the Bot said. The route now asks the store first, as every other route on a Bot
+does, and answers not found for a Bot the caller cannot reach, writing nothing.
+
 ### The engine socket the supervisor is given can be pointed somewhere else
 
 Compose mounted `/var/run/docker.sock` into the supervisor as a fixed path. That is correct for

--- a/server/src/agents/routes.ts
+++ b/server/src/agents/routes.ts
@@ -215,6 +215,21 @@ export function createAgentRoutes(
       return context.json({ error: "A reason is required." }, 400);
     }
 
+    /*
+     * The same question every other route here asks first: is this a Bot the caller may reach?
+     *
+     * The row says "reportedBy: the Bot itself", and the Bot reports through the person's session,
+     * so the trail's only way of knowing the report came from a Bot is that the person could have
+     * been talking to that Bot. Without this check, any signed-in person could write a decline
+     * against any id at all, a coworker they cannot see included, and an administrator reading the
+     * trail would take it for something the Bot said. Not found rather than forbidden, as the store
+     * answers everywhere else, so the check does not confirm which ids exist.
+     */
+    const agent = await store.get(context.var.actor, agentId);
+    if (!agent) {
+      return context.json({ error: "Agent not found." }, 404);
+    }
+
     if (auditStore) {
       const actor = context.var.actor;
       await recordAuditEvent(auditStore, {

--- a/server/tests/bot-lifecycle-audit.test.ts
+++ b/server/tests/bot-lifecycle-audit.test.ts
@@ -26,6 +26,8 @@ function app(overrides: Record<string, unknown> = {}) {
   };
 
   const store = {
+    get: async (_actor: unknown, id: string) =>
+      id === "bot-1" ? { id: "bot-1", name: "Sales" } : null,
     create: async () => ({ id: "bot-1", name: "Sales" }),
     update: async () => ({ id: "bot-1", name: "Sales" }),
     duplicate: async () => ({ id: "bot-2", name: "Sales copy" }),
@@ -206,6 +208,42 @@ describe("what a Bot is, on the trail", () => {
       method: "PATCH",
     });
 
+    expect(rows).toHaveLength(0);
+  });
+
+  test("a decline is recorded against a Bot the caller may reach", async () => {
+    // The Bot reports through the person's session, so the row is only worth what that session
+    // could reach: a decline on a Bot the caller may talk to is the Bot's own word.
+    const { rows, hono } = app();
+
+    const response = await hono.request("http://t/api/agents/bot-1/declined", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ reason: "It asked me to delete the ledger." }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(rows[0]?.eventType).toBe("bot.declined");
+    expect(rows[0]?.targetId).toBe("bot-1");
+    expect(rows[0]?.payload.reportedBy).toBe("the Bot itself");
+  });
+
+  test("a decline against a Bot the caller cannot reach is not found, and writes nothing", async () => {
+    // Every other route here asks the store first. Without the same question, a signed-in person
+    // could write "the Bot itself declined" against any id at all and an administrator would read
+    // it as something the Bot said.
+    const { rows, hono } = app();
+
+    const response = await hono.request(
+      "http://t/api/agents/somebody-elses-bot/declined",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ reason: "Forged." }),
+      },
+    );
+
+    expect(response.status).toBe(404);
     expect(rows).toHaveLength(0);
   });
 


### PR DESCRIPTION
## What this changes

`POST /api/agents/:agentId/declined` writes a `bot.declined` row, marked `reportedBy: the Bot itself`, for whatever id is in the path. Every other route on a Bot in `agents/routes.ts` asks the store first and answers 404 for a Bot the caller cannot reach (`store.get` runs `findAccessibleProfile`). This one did not.

The Bot reports through the person's session (`report_refusal` in `computer-tools.tsx` posts to `/api/agents/${bot.current}/declined`), so the trail's only basis for calling the row the Bot's own word is that the person could have been talking to that Bot. Without the check, any signed-in person can write a decline, in any words, against any agent id: a coworker they cannot see, a system-owned one, or an id that does not exist. An administrator reading the trail sees `The Bot declined` with the reason the person typed. The comment on the route already says this row is evidence rather than enforcement; this makes the evidence at least come from somebody who could reach the Bot.

The route now calls `store.get(actor, agentId)` before recording and answers `Agent not found.` (404, the same wording the other routes use, so the check does not confirm which ids exist), writing nothing. A legitimate report is unchanged: the Bot's own id is one the person can reach.

## Where it runs

- **New state that outlives a request?** None.
- **What happens on the second replica?** Nothing new: one read on the agents table, the same one every other route on a Bot does.
- **Anything serialised?** No.
- **Anything fanned out to a browser?** No.
- **New listener, port, or schedule?** No.

## Boundary and audit

- Every acting call still goes through the gateway: this route acts on nothing, it only records.
- New refusals and new failures each write a row: a report against a Bot the caller cannot reach is not a Bot's refusal, it is a request that is not found, so it writes nothing, as `a refused change writes nothing` already expects for the other routes.
- Nothing new is trusted from the client: the id in the path is now checked against the store rather than recorded as-is.

## Changelog

A line under `Unreleased`.

## Proof

`bot-lifecycle-audit.test.ts` gains two tests: a decline against a reachable Bot records `bot.declined` with `reportedBy: the Bot itself`; a decline against an id the store does not return answers 404 and writes nothing. The fake store in that file gains a `get`, which the route did not call before.

```
bun test server/tests/bot-lifecycle-audit.test.ts server/tests/agent-routes.test.ts
 70 pass, 0 fail
```

`bunx tsc --noEmit` in `server` and `bunx biome check` on the changed files are clean.
