### PR TITLE
fix(server): reject whitespace-only and non-string slug and title in POST /sandboxed

### DIFF
--- a/server/src/components/sandboxed-routes.ts
+++ b/server/src/components/sandboxed-routes.ts
@@ -63,14 +63,19 @@ export function createSandboxedRoutes(
       sampleArguments?: Record<string, unknown>;
     } | null;
 
-    if (!body?.slug || !body.title) {
+    if (
+      typeof body?.slug !== "string" ||
+      !body.slug.trim() ||
+      typeof body?.title !== "string" ||
+      !body.title.trim()
+    ) {
       return context.json({ error: "A name and a title are required." }, 400);
     }
 
     try {
       const component = await store.save({
-        slug: body.slug,
-        title: body.title,
+        slug: body.slug.trim(),
+        title: body.title.trim(),
         description: body.description ?? "",
         html: body.html ?? "",
         css: body.css ?? "",


### PR DESCRIPTION
POST /api/sandboxed accepted a whitespace-only or non-string slug/title: the truthiness guard let `"   "` and `123` through, storing a blank title verbatim or failing later with a misleading error (or a 500 on a non-string title).

Rejects non-string and whitespace-only slug/title with 400 and trims both before save, mirroring the POST /servers/custom validation. Verified with an 8-case guard script (whitespace, numeric, null, padded inputs) and server typecheck.