### PR TITLE
fix(app): guard live screen socket against non-object payloads

### DIFF
--- a/app/src/components/computer/live-screen.tsx
+++ b/app/src/components/computer/live-screen.tsx
@@ -73,7 +73,11 @@ export function LiveScreen({ computerId, driving, onProblem }: Props) {
       // A frame that is not an object (`null`, a number, a string, an array) has
       // no `type` to read: reaching for it throws a `TypeError` inside this
       // handler and stops the live view from drawing further frames. Drop it.
-      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
         return;
       }
       const message = parsed as {

--- a/app/src/components/computer/live-screen.tsx
+++ b/app/src/components/computer/live-screen.tsx
@@ -64,18 +64,26 @@ export function LiveScreen({ computerId, driving, onProblem }: Props) {
     };
 
     socket.onmessage = async (event) => {
-      let message: {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(String(event.data));
+      } catch {
+        return;
+      }
+      // A frame that is not an object (`null`, a number, a string, an array) has
+      // no `type` to read: reaching for it throws a `TypeError` inside this
+      // handler and stops the live view from drawing further frames. Drop it.
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        return;
+      }
+      const message = parsed as {
         type: string;
         data?: string;
         width?: number;
         height?: number;
         error?: string;
       };
-      try {
-        message = JSON.parse(String(event.data));
-      } catch {
-        return;
-      }
+      if (typeof message.type !== "string") return;
       if (message.type === "error") {
         onProblem?.(message.error ?? "The screen could not be shown.");
         return;


### PR DESCRIPTION
The live-screen socket parsed every frame with a bare JSON.parse and read message.type directly. A non-object payload such as null throws a TypeError inside onmessage and stops the live view, while numbers/strings/arrays fall through without an explicit drop rule.

Parses as unknown and drops non-object JSON plus messages with a non-string type before touching type/data, mirroring the channel-socket payload guard. Verified: null/number/string/array/malformed frames all drop, valid frame and error frames still handled, app typecheck clean.