### PR TITLE
fix(worker): refuse a SERVER_INTERNAL_URL that is not a valid http(s) URL

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -48,6 +48,16 @@ export function loadWorkerEnv(
       "SERVER_INTERNAL_URL is not set, so this worker does not know where to hand a routine run.",
     );
   }
+  try {
+    const parsed = new URL(serverInternalUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error("not http(s)");
+    }
+  } catch {
+    throw new Error(
+      "SERVER_INTERNAL_URL must be a valid http(s) URL, so this worker knows where to hand a routine run.",
+    );
+  }
 
   const databaseUrl = environment.DATABASE_URL?.trim();
   if (!databaseUrl) {


### PR DESCRIPTION
loadWorkerEnv only refused an empty or all-slash SERVER_INTERNAL_URL, so values like not-a-url or ftp://files/x passed boot and then failed every 30s sweep tick with a fetch TypeError logged as routine-sweep-tick-failed instead of a boot error.

Validates the normalised URL with new URL() and requires http(s), throwing a fail-fast boot error otherwise. Verified: all 17 existing worker env tests pass; not-a-url, ://bad, ftp: and padded junk are refused, http/https/trailing-slash URLs accepted.