### PR TITLE
Read the example package by a path the host accepts, not a URL pathname

### DIFF
--- a/app/tests/skill-creator-slug.test.ts
+++ b/app/tests/skill-creator-slug.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { parse } from "yaml";
 import { SKILL_CREATOR_SLUG } from "@/lib/skills/proposal";
 
@@ -15,7 +16,9 @@ import { SKILL_CREATOR_SLUG } from "@/lib/skills/proposal";
  * Read from the file rather than from a fixture, because the file is what ships.
  */
 
-const packageDir = new URL("../../examples/fintech", import.meta.url).pathname;
+const packageDir = fileURLToPath(
+  new URL("../../examples/fintech", import.meta.url),
+);
 
 const shipped = parse(readFileSync(`${packageDir}/skills.yaml`, "utf8")) as {
   skills: { slug: string; title: string; instructions: string }[];

--- a/server/tests/tenant-package.test.ts
+++ b/server/tests/tenant-package.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
 import { and, eq } from "drizzle-orm";
 import { createDatabase } from "../src/db/client";
 import {
@@ -288,7 +289,7 @@ describe("tenant YAML validation", () => {
 
   test("loads the mounted fintech package without a theme file", async () => {
     const tenantPackage = await loadTenantPackage(
-      new URL("../../examples/fintech", import.meta.url).pathname,
+      fileURLToPath(new URL("../../examples/fintech", import.meta.url)),
     );
 
     expect(tenantPackage.tenantId).toBe("openbot");


### PR DESCRIPTION
## What this changes

Two tests read the fintech example through `new URL(...).pathname`, which is not a path on Windows:

```ts
const packageDir = new URL("../../examples/fintech", import.meta.url).pathname;
```

A `file:` URL's pathname keeps its leading separator and its URL escaping, so on Windows that is
`/C:/Users/...` rather than `C:\Users\...`, and the read fails:

```
ENOENT: no such file or directory, open '/C:/Users/.../openbot/examples/fintech/skills.yaml'
      at app/tests/skill-creator-slug.test.ts:20:23

ENOENT: no such file or directory, open '\C:\Users\...\openbot\examples\fintech\brand.yaml'
      at loadTenantPackage (server/src/tenant-package.ts:533:34)
```

`fileURLToPath` is the conversion that handles the drive letter, the separators and any escaped
character. The other nine `import.meta.url` sites in the repository are already fine: they hand the
`URL` straight to `readFileSync`, which does the conversion itself. Only these two took `.pathname`.

CI runs on Linux, where the pathname happens to be a usable path, so neither failure is visible
there. A contributor on Windows sees them on the first `bun test`.

## Where it runs

- [x] **New state that outlives a request?** None. Test files only.
- [x] **What happens on the second replica?** Nothing; no shipped code changes.
- [x] **Anything serialised?** No.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: untouched.
- [x] New refusals and new failures each write a row: no new outcomes.
- [x] Nothing new is trusted from the client: no runtime change.

## Changelog

- [x] No entry: a deployment behaves no differently afterwards. This is two test files reading the
      same fixture by a path the host accepts.

## Proof

On Windows 11, `bun test app/tests` before and after:

```
before   319 pass, 1 fail, 1 error
after    322 pass, 0 fail
```

The three extra passes are the file that could not be collected at all, since the read is at module
scope. And the server test that hits the same conversion:

```
bun test server/tests/tenant-package.test.ts -t "loads the mounted fintech package without a theme file"
before   0 pass, 1 fail   (ENOENT on brand.yaml)
after    1 pass, 0 fail
```

`bun run typecheck` passes in all four workspaces, and `bunx biome check` is clean on both files.

The rest of `server/tests` still needs a Postgres this machine does not have, so those failures are
unrelated and unchanged.
