### PR TITLE
Read an empty Bot PORT as unset, so NaN never reaches Bun.serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### An empty Bot `PORT` is unset, so NaN never reaches Bun.serve
+
+`PORT=` on `agent-bot` and `agent-langgraph` used to parse as `NaN` (`??` does not treat empty as absent) and `Bun.serve` bound an ephemeral port while compose still published 4200/4201. A prefix typo (`42o0`) started on 42. Empty now means the shipped default; anything that is not a whole port number refuses to start.
+
 ### The server connects to Postgres on Windows, and `localhost` is no longer a coin toss
 
 Two separate faults, both of which stop a deployment reaching its own database and neither of which

--- a/agent-bot/src/index.ts
+++ b/agent-bot/src/index.ts
@@ -3,6 +3,7 @@ import { EventEncoder } from "@ag-ui/encoder";
 import { serve } from "bun";
 import OpenAI from "openai";
 import { hasManagedAgentToken } from "../../shared/agent-authorisation";
+import { listenPort } from "../../shared/listen-port";
 import { toProviderMessages } from "./history";
 
 /**
@@ -16,7 +17,12 @@ import { toProviderMessages } from "./history";
  * running where its effects are visible to the person watching.
  */
 
-const PORT = Number.parseInt(process.env.PORT ?? "4200", 10);
+const resolvedPort = listenPort(process.env.PORT, 4200);
+if (!resolvedPort.ok) {
+  console.error(resolvedPort.reason);
+  process.exit(1);
+}
+const PORT = resolvedPort.port;
 const MANAGED_AGENT_TOKEN = process.env.MANAGED_AGENT_TOKEN?.trim();
 if (!MANAGED_AGENT_TOKEN) {
   console.error(

--- a/agent-langgraph/src/index.ts
+++ b/agent-langgraph/src/index.ts
@@ -12,6 +12,7 @@ import {
 import { ChatOpenAI } from "@langchain/openai";
 import { serve } from "bun";
 import { hasManagedAgentToken } from "../../shared/agent-authorisation";
+import { listenPort } from "../../shared/listen-port";
 import { toLangChainMessages } from "./history";
 import { readReasoningEffort } from "./model-options";
 import { streamRun } from "./stream";
@@ -36,7 +37,12 @@ import { streamRun } from "./stream";
  * The graph provides model orchestration without changing that contract.
  */
 
-const PORT = Number.parseInt(process.env.PORT ?? "4201", 10);
+const resolvedPort = listenPort(process.env.PORT, 4201);
+if (!resolvedPort.ok) {
+  console.error(resolvedPort.reason);
+  process.exit(1);
+}
+const PORT = resolvedPort.port;
 const MANAGED_AGENT_TOKEN = process.env.MANAGED_AGENT_TOKEN?.trim();
 if (!MANAGED_AGENT_TOKEN) {
   console.error(

--- a/shared/listen-port.test.ts
+++ b/shared/listen-port.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { listenPort } from "./listen-port";
+
+/**
+ * Empty PORT must not become NaN / an ephemeral bind. Same empty-string trap as the supervisor.
+ */
+describe("Bot listen port", () => {
+  test("unset and empty string fall back", () => {
+    expect(listenPort(undefined, 4200)).toEqual({ ok: true, port: 4200 });
+    expect(listenPort("", 4201)).toEqual({ ok: true, port: 4201 });
+    expect(listenPort("   ", 4200)).toEqual({ ok: true, port: 4200 });
+  });
+
+  test("a whole number in range is accepted", () => {
+    expect(listenPort("4200", 4200)).toEqual({ ok: true, port: 4200 });
+    expect(listenPort("4500", 4200)).toEqual({ ok: true, port: 4500 });
+    expect(listenPort("1", 4200)).toEqual({ ok: true, port: 1 });
+    expect(listenPort("65535", 4200)).toEqual({ ok: true, port: 65535 });
+  });
+
+  test("prefix typos and out-of-range values are refused", () => {
+    expect(listenPort("42o0", 4200).ok).toBe(false);
+    expect(listenPort("0", 4200).ok).toBe(false);
+    expect(listenPort("65536", 4200).ok).toBe(false);
+    expect(listenPort("-1", 4200).ok).toBe(false);
+    expect(listenPort("1.5", 4200).ok).toBe(false);
+  });
+});

--- a/shared/listen-port.ts
+++ b/shared/listen-port.ts
@@ -1,0 +1,30 @@
+/**
+ * Listen port for a Bot process.
+ *
+ * An empty `PORT=` (compose blank, leftover `.env` line) is unset, not zero — the same empty-string
+ * trap #96/#114/#312/#343 found for the server, computer, and supervisor. `??` only fires on
+ * undefined, so `Number.parseInt("", 10)` used to be `NaN` and `Bun.serve({ port: NaN })` bound an
+ * ephemeral port while compose still published 4200/4201. Prefix typos (`42o0`) also used to start
+ * on 42 via parseInt.
+ */
+export function listenPort(
+  raw: string | undefined,
+  fallback: number,
+): { ok: true; port: number } | { ok: false; reason: string } {
+  const trimmed = raw?.trim();
+  if (!trimmed) return { ok: true, port: fallback };
+  if (!/^\d+$/.test(trimmed)) {
+    return {
+      ok: false,
+      reason: `PORT must be a whole number from 1 to 65535 (got ${JSON.stringify(raw)}).`,
+    };
+  }
+  const value = Number.parseInt(trimmed, 10);
+  if (value < 1 || value > 65535) {
+    return {
+      ok: false,
+      reason: `PORT must be a whole number from 1 to 65535 (got ${JSON.stringify(raw)}).`,
+    };
+  }
+  return { ok: true, port: value };
+}


### PR DESCRIPTION
## What this changes

`PORT=` on `agent-bot` / `agent-langgraph` used to parse as `NaN` and `Bun.serve` bound an ephemeral port while compose still published 4200/4201. Empty now means the shipped default; a non-digit value refuses to start. Same trap as supervisor #343.

## Where it runs

- [x] **New state that outlives a request?** None.
- [x] **What happens on the second replica?** Each process reads its own `PORT` at boot. No shared state.
- [x] **Anything serialised?** No.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** No. Existing listen ports only, parsed the same way as the supervisor.

## Boundary and audit

- [x] Every acting call still goes through the gateway: resolve, decide, audit, then act.
- [x] New refusals and new failures each write a row. Boot refusal is process exit before serve; no new acting path.
- [x] Nothing new is trusted from the client that the server can resolve itself.

## Changelog

- [x] A line in `CHANGELOG.md` under `Unreleased`.

## Proof

Shared `listenPort` tests: empty/whitespace → fallback; digits in range accepted; `42o0` / `0` / `65536` refused.