### PR TITLE
Show where OpenBot stands on Trendshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 [**copilotkit.ai/openbot**](https://copilotkit.ai/openbot) · [**Quick start**](#quick-start) · [**Features**](#features) · [**Bring your own agent**](#bring-your-own-agent) · [**Architecture**](#architecture) · [**Docs**](docs/README.md)
 
+<a href="https://trendshift.io/repositories/175080"><img src="https://trendshift.io/api/badge/trendshift/repositories/175080/daily" alt="CopilotKit/OpenBot on Trendshift" width="250" height="55"/></a>
+
 [![CI](https://github.com/CopilotKit/openbot/actions/workflows/ci.yml/badge.svg)](https://github.com/CopilotKit/openbot/actions/workflows/ci.yml)
 [![security](https://github.com/CopilotKit/openbot/actions/workflows/security_zizmor.yml/badge.svg)](https://github.com/CopilotKit/openbot/actions/workflows/security_zizmor.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)


### PR DESCRIPTION
![Show where OpenBot stands on Trendshift](https://raw.githubusercontent.com/jerelvelarde/openbot/pr-media/gifs/trendshift-badge.png)

## The problem

OpenBot has been on Trendshift's daily list since 20 August, and it is currently sitting in the top
three repositories of the day. A reader arriving at the README has no way to know that. The header
carries four badges, and every one of them is about the machinery: CI is green, the security workflow
is green, the licence is MIT, the status is alpha. All four are things a maintainer needs. None of
them is a reason for a stranger to keep reading.

That gap matters more for an alpha than it would for a settled project. The README opens by admitting
rough edges and active development, which is honest and also a reason to bounce. The thing that
earns a second look from somebody who has never heard of this repository is that other people are
already looking, and right now the README says nothing about that at all.

## The approach

One badge, added to the centred header block between the navigation line and the existing badge row.

**The badge is live rather than a written-down number.** Trendshift serves the rank as an SVG that it
re-renders, so the README reflects the current standing without anybody editing it again. A hardcoded
"#2" would be wrong within a day and would stay wrong until somebody noticed. This is the whole reason
the change is two lines and not a recurring chore.

**It sits on its own line, above the small badges, rather than joining the row.** The Trendshift badge
is 250x55 against roughly 20px for a shields.io badge. Dropped into the same row it would tower over
its neighbours and force a ragged wrap. On its own line the size reads as deliberate, and the
machinery badges stay grouped as a set.

**It is an `<img>` tag with explicit `width` and `height`, not markdown image syntax.** GitHub proxies
the SVG through camo, and without the dimensions the badge renders at whatever intrinsic size camo
reports, which is not reliably the 250x55 the artwork is drawn for. The rest of the header uses
markdown badge syntax; this one line does not, and the inconsistency buys a stable render.

**The URL is `/api/badge/trendshift/repositories/175080/daily`.** The shorter
`/api/badge/repositories/175080` form, which Trendshift's own embed dialog hands out, returns a 500
and would render as a broken image in the header of the README. I verified both by hand before
choosing.

The cost is worth naming: the header now depends on a third party staying up. If Trendshift goes
down or drops the endpoint, the first thing under the navigation line is a broken image, in the most
visible place in the repository. The four existing badges already carry that exposure to
github.com and shields.io, so this is one more host rather than a new kind of risk, but it is a real
one and it is the reason to keep the badge count from growing further.

## What is not covered

- The badge shows the **daily** rank only. Trendshift also runs a weekly list that OpenBot has
  trended on, and that standing is not surfaced anywhere.
- Nothing pins or caches the artwork. The README is at the mercy of Trendshift's uptime and of
  whatever they decide the badge should look like next.
- The rank in the screenshot above is **#3**, which is what the endpoint returned while I was
  building this. It moves on its own; the point of the change is that the README moves with it.
- No dark-mode variant. The badge draws its own white background with a purple border, so it does
  not disappear on a dark theme, but it does sit as a light rectangle against a dark page.
- The fork's `main` has diverged from this branch's base and does not pick the badge up until it
  next syncs from here.

## Verification

Documentation only, two added lines in `README.md`, no code and no new tests. The baseline suite is
untouched by this branch, so I did not run it.

What I checked instead, by hand:

- `GET /api/badge/trendshift/repositories/175080/daily` returns `200 image/svg+xml`, 3691 bytes, with
  an `aria-label` of "Trendshift: number 3 repository of the day".
- `GET /api/badge/repositories/175080` returns `500` with an empty body, which is why that form is not
  the one in the diff.
- The screenshot at the top is the README header rendered through GitHub's own markdown API against
  this branch's `README.md`, not a mockup, so the badge placement and wrap are the real ones.
