### PR TITLE
Say which part of DATABASE_URL is not percent-encoded, instead of failing as URI error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A password with a `%` in it says so, instead of failing as `URI error`
+
+`DATABASE_URL` is taken apart before it reaches Bun, and each part is percent-decoded. A part
+holding a `%` that starts no escape -- `postgres://openbot:100%pure@host:5432/openbot`, which a
+generated password produces often enough -- is a string `new URL` accepts and `decodeURIComponent`
+rejects, so the server stopped with `URIError: URI error` and named neither the variable nor the
+part. It now refuses with the same kind of sentence as every other malformed address: which part is
+wrong, and that a literal `%` must be written `%25`.
+
+A correctly encoded password is unaffected.
+
 ### The server connects to Postgres on Windows, and `localhost` is no longer a coin toss
 
 Two separate faults, both of which stop a deployment reaching its own database and neither of which

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -3,11 +3,25 @@ import { drizzle } from "drizzle-orm/bun-sql";
 import * as schema from "./schema";
 
 /**
- * `max` is exposed so tests can pin the pool to a single connection. Code that opens a transaction
- * and then reads on a second connection deadlocks once every pooled connection is inside such a
- * transaction; a pool of one turns that from a load-dependent production hang into an immediate,
- * reproducible failure.
+ * One percent-decoded part of the address, or a refusal that names it.
+ *
+ * A password is where this bites. `postgres://openbot:100%pure@host:5432/openbot` is a string
+ * `new URL` accepts without complaint, and `decodeURIComponent` then rejects with `URIError: URI
+ * error` -- a message that names neither `DATABASE_URL` nor which part of it was wrong, thrown out
+ * of the one function whose whole job is to make a connection failure legible. A `%` that starts no
+ * escape is a common thing to find in a generated password, and every other malformed address here
+ * is answered with a sentence saying what to fix.
  */
+function decodePart(value: string, part: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    throw new TypeError(
+      `DATABASE_URL has a ${part} that is not percent-encoded. A literal "%" must be written "%25".`,
+    );
+  }
+}
+
 /**
  * The address, taken apart, because Bun will not take it whole on every platform.
  *
@@ -35,7 +49,7 @@ function addressOf(databaseUrl: string) {
       "DATABASE_URL names no host. Expected postgres://user:password@host:port/database.",
     );
   }
-  const database = decodeURIComponent(url.pathname.replace(/^\//, ""));
+  const database = decodePart(url.pathname.replace(/^\//, ""), "database name");
   if (database === "") {
     throw new TypeError(
       "DATABASE_URL names no database. Expected postgres://user:password@host:port/database.",
@@ -55,13 +69,19 @@ function addressOf(databaseUrl: string) {
     adapter: "postgres" as const,
     hostname: url.hostname,
     port: url.port === "" ? 5432 : Number(url.port),
-    username: decodeURIComponent(url.username),
-    password: decodeURIComponent(url.password),
+    username: decodePart(url.username, "username"),
+    password: decodePart(url.password, "password"),
     database,
     ...(Object.keys(connection).length > 0 ? { connection } : {}),
   };
 }
 
+/**
+ * `max` is exposed so tests can pin the pool to a single connection. Code that opens a transaction
+ * and then reads on a second connection deadlocks once every pooled connection is inside such a
+ * transaction; a pool of one turns that from a load-dependent production hang into an immediate,
+ * reproducible failure.
+ */
 export function createDatabase(
   databaseUrl: string,
   options: { max?: number } = {},

--- a/server/tests/db-client-address.test.ts
+++ b/server/tests/db-client-address.test.ts
@@ -46,6 +46,37 @@ describe("the database address", () => {
     ).toThrow(/names no database/);
   });
 
+  test("refuses a password holding a percent that starts no escape, naming the part", () => {
+    /*
+     * `new URL` accepts this and `decodeURIComponent` does not, so the refusal used to be a bare
+     * `URIError: URI error` naming neither DATABASE_URL nor the password -- out of the one function
+     * whose job is to make a connection failure legible. A generated password is a common place to
+     * find a literal `%`.
+     */
+    expect(() =>
+      createDatabase("postgres://openbot:100%pure@127.0.0.1:5432/openbot"),
+    ).toThrow(/DATABASE_URL has a password that is not percent-encoded/);
+  });
+
+  test("refuses a username holding one too", () => {
+    expect(() =>
+      createDatabase("postgres://open%bot:openbot@127.0.0.1:5432/openbot"),
+    ).toThrow(/DATABASE_URL has a username that is not percent-encoded/);
+  });
+
+  test("refuses a database name holding one too", () => {
+    expect(() =>
+      createDatabase("postgres://openbot:openbot@127.0.0.1:5432/open%bot"),
+    ).toThrow(/DATABASE_URL has a database name that is not percent-encoded/);
+  });
+
+  test("still accepts a password that IS percent-encoded, decoding it", () => {
+    // The escape a correctly written password uses: `%40` is `@`, which cannot be written raw.
+    expect(() =>
+      createDatabase("postgres://openbot:p%40ss@127.0.0.1:5432/openbot"),
+    ).not.toThrow();
+  });
+
   test("still refuses pool options where the address belongs", () => {
     // @ts-expect-error the wrong-way-round call this guard exists for
     expect(() => createDatabase({ max: 1 })).toThrow(/connection string/);


### PR DESCRIPTION
## What this changes

A `DATABASE_URL` whose password holds a `%` that starts no escape stops the server with

```
URIError: URI error
```

which names neither the variable nor which part of it was wrong. It comes out of `addressOf`, the
one function whose entire job is to make a connection failure legible, and which answers every other
malformed address with a sentence saying what to fix:

```
DATABASE_URL is not a URL: "://openbot@/openbot"
DATABASE_URL names no host. Expected postgres://user:password@host:port/database.
DATABASE_URL names no database. Expected postgres://user:password@host:port/database.
```

`new URL` accepts the string, so the failure lands two lines later on `decodeURIComponent`, which
was added in #384 alongside taking the address apart. Measured, on Bun 1.3.14:

```
postgres://openbot:100%pure@127.0.0.1:5432/openbot   URIError: URI error
postgres://openbot:pa%ss@127.0.0.1:5432/openbot      URIError: URI error
postgres://open%bot:openbot@127.0.0.1:5432/openbot   URIError: URI error
postgres://openbot:openbot@127.0.0.1:5432/open%bot   URIError: URI error
postgres://openbot:p%40ss@127.0.0.1:5432/openbot     connects, password is p@ss
```

A generated password is a common place to find a literal `%`, and this is a startup failure with no
retry and nothing in the message to search for.

`decodePart` wraps the three decodes and refuses with the same shape as its neighbours: which part,
and that a literal `%` must be written `%25`. A correctly encoded password decodes exactly as it did.

I also moved the `max` doc comment down onto `createDatabase`, where it belongs. It was already
detached — it sat above `addressOf`'s own doc block — and adding a function there would have made it
read as documentation for the new one.

## Where it runs

- [x] **New state that outlives a request?** None. A pure function over a string, called once at
      startup.
- [x] **What happens on the second replica?** The same as on the first: it refuses the same address
      with the same sentence. Every replica reads the same `DATABASE_URL`, so this is a change of
      message, not of behaviour that can differ per process.
- [x] **Anything serialised?** No.
- [x] **Anything fanned out to a browser?** No. This is reached before the server listens.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: no request path is touched.
- [x] New refusals and new failures each write a row: not applicable. This refusal happens before
      the database exists, so there is nowhere to write a row to and nothing has yet acted.
- [x] Nothing new is trusted from the client: the input is an operator's environment variable.

## Changelog

- [x] A line in `CHANGELOG.md` under `Unreleased`.

## Tests

Four in `server/tests/db-client-address.test.ts`, alongside the refusals already enumerated there:

- a password holding a bare `%` is refused, naming the password
- a username holding one is refused, naming the username
- a database name holding one is refused, naming the database name
- `p%40ss` still decodes to `p@ss`, so a correctly written password is untouched

Against `main` the first three fail; the fourth passes before and after and is there as the
regression guard.

## How I tested

Windows 11, Bun 1.3.14. `bun test server/tests/db-client-address.test.ts` is 9 passed, 1 failed —
the failure is `connection parameters on the URL > survive…`, which opens a real socket to Postgres
and fails identically on `main` on this machine, where no database is running.
`bun run --filter server typecheck` and `bunx biome check` are clean.
