### PR TITLE
Publish a component under the name the guard approved, not the padded one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A component whose name has a stray space is the same component
+
+The catalogue announcement asked whether each component's `name`, `title`, `kind` and `description`
+were more than whitespace, and then published the untrimmed strings. A `name` is a component's
+identity -- it is what `syncCatalogue` compares against what is already published, what `decide` and
+`listForAgent` look up, and what a grant names -- so a build shipping `" weatherPanel "` added a
+second catalogue row beside `weatherPanel`: published, ungranted by anybody, and impossible to hold
+a Bot back from under the name people use. The four fields are now stored as the strings the guard
+approved.
+
 ### The server connects to Postgres on Windows, and `localhost` is no longer a coin toss
 
 Two separate faults, both of which stop a deployment reaching its own database and neither of which

--- a/server/src/components/routes.ts
+++ b/server/src/components/routes.ts
@@ -105,7 +105,19 @@ export function createComponentRoutes(
       ) {
         return [];
       }
-      return [{ name, title, kind, description }];
+      // Trimmed, because that is the string the guard above just approved. A component's `name` is
+      // its identity -- `syncCatalogue` compares it against what is already published, `decide` and
+      // `listForAgent` look it up by it, and a grant names it -- so publishing " weatherPanel "
+      // adds a second component beside `weatherPanel` that nobody has granted and no Bot can be
+      // held back from by the name people use.
+      return [
+        {
+          name: name.trim(),
+          title: title.trim(),
+          kind: kind.trim(),
+          description: description.trim(),
+        },
+      ];
     });
 
     const { added } = await store.syncCatalogue(valid);

--- a/server/tests/component-catalogue.test.ts
+++ b/server/tests/component-catalogue.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import type { MiddlewareHandler } from "hono";
+import { Hono } from "hono";
+import type { AppVariables } from "../src/auth/guards";
+import { createComponentRoutes } from "../src/components/routes";
+import type { CatalogueEntry, ComponentStore } from "../src/components/store";
+
+/**
+ * What a build's announcement is allowed to put in the catalogue.
+ *
+ * A component's `name` is its identity: `syncCatalogue` compares it against the names already
+ * published, `decide` and `listForAgent` look it up by it, and a grant names it. A name that
+ * differs from another only by the spaces around it is therefore a second, separate component that
+ * nobody granted and no Bot can be held back from by the name people actually use.
+ */
+
+const asSignedIn: MiddlewareHandler<{ Variables: AppVariables }> = async (
+  context,
+  next,
+) => {
+  context.set("actor", { id: "u1", email: "someone@openbot.test" });
+  return next();
+};
+
+function harness() {
+  const published: CatalogueEntry[] = [];
+  const store = {
+    syncCatalogue: async (entries: CatalogueEntry[]) => {
+      published.push(...entries);
+      return { added: entries.map((entry) => entry.name) };
+    },
+  } as unknown as ComponentStore;
+
+  const app = new Hono().route(
+    "/components",
+    createComponentRoutes(store, asSignedIn, undefined, async () => true),
+  );
+
+  return {
+    published,
+    announce: (components: unknown[]) =>
+      app.request("http://openbot.local/components/catalogue", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ components }),
+      }),
+  };
+}
+
+function entry(over: Record<string, unknown> = {}) {
+  return {
+    name: "weatherPanel",
+    title: "Weather",
+    kind: "panel",
+    description: "The forecast where the reader is.",
+    ...over,
+  };
+}
+
+describe("a build announcing what it can draw", () => {
+  test("publishes an ordinary component unchanged", async () => {
+    const { published, announce } = harness();
+    await announce([entry()]);
+    expect(published).toEqual([
+      {
+        name: "weatherPanel",
+        title: "Weather",
+        kind: "panel",
+        description: "The forecast where the reader is.",
+      },
+    ]);
+  });
+
+  test("publishes a padded name as the name, not as a second component", async () => {
+    // The guard already asks whether the name is more than whitespace; it asks that of the trimmed
+    // string and then publishes the untrimmed one, so " weatherPanel " and "weatherPanel" are two
+    // catalogue rows and only one of them is the component anybody grants.
+    const { published, announce } = harness();
+    await announce([entry({ name: " weatherPanel " })]);
+    expect(published[0]?.name).toBe("weatherPanel");
+  });
+
+  test("publishes a padded title and description as the reader will see them", async () => {
+    const { published, announce } = harness();
+    await announce([
+      entry({ title: "  Weather\t", description: "\n The forecast. " }),
+    ]);
+    expect(published[0]?.title).toBe("Weather");
+    expect(published[0]?.description).toBe("The forecast.");
+  });
+
+  test("publishes a padded kind as the kind", async () => {
+    const { published, announce } = harness();
+    await announce([entry({ kind: " panel " })]);
+    expect(published[0]?.kind).toBe("panel");
+  });
+
+  test("still refuses an entry that is only whitespace", async () => {
+    const { published, announce } = harness();
+    await announce([entry({ name: "   " })]);
+    expect(published).toEqual([]);
+  });
+
+  test("still refuses a list that is not a list", async () => {
+    const { announce } = harness();
+    const response = await announce(undefined as unknown as unknown[]);
+    expect(response.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## What this changes

`PUT /components/catalogue` asks whether each announced component is more than whitespace, and then
publishes the string it did not ask about:

```ts
if (
  typeof name !== "string" || !name.trim() ||
  typeof title !== "string" || !title.trim() ||
  ...
) {
  return [];
}
return [{ name, title, kind, description }];
```

For `title`, `kind` and `description` that is cosmetic. For `name` it is not, because a component's
name is its identity:

- `syncCatalogue` compares it against a `Set` of names already published, so `" weatherPanel "` is
  not `weatherPanel` and a new row is added
- `decide(name, agentId)` and `listForAgent` look a component up by it
- a grant and a revoke each name it, and the audit row for the arrival carries it

So a build that ships a name with a stray space publishes a *second* component beside the real one.
It is published and ungranted by anyone, it appears in the catalogue, and an administrator holding a
Bot back from `weatherPanel` does not hold it back from the other one, because as far as every one
of those lookups is concerned they are different components. Nothing reports this; the announcement
returns `added: [" weatherPanel "]` and the trail records that name as an arrival.

The four fields are now stored as the strings the guard approved.

This is the same shape as #376 and #377 — validate the trimmed string, store the raw one — and the
fourth place it appears. #393 is the third and is still open; the two are independent files and
neither depends on the other.

## Where it runs

- [x] **New state that outlives a request?** None. The catalogue row already existed; this changes
      which string is written into it.
- [x] **What happens on the second replica?** The same announcement produces the same name on every
      replica, which is the point: today two replicas served by builds that differ by a space
      publish two components. `syncCatalogue` is additive and compares against what is in Postgres,
      so the row is shared and this makes the comparison agree across processes rather than depend
      on which build's string arrived.
- [x] **Anything serialised?** No new serialisation. `syncCatalogue` is unchanged: it still reads
      the published names and inserts only what is missing.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: this route is behind `requireUser` as
      before and its decision path is untouched.
- [x] New refusals and new failures each write a row: no new refusal. The existing
      `component.published` row now carries the trimmed name, which is the name every other part of
      the system uses for it.
- [x] Nothing new is trusted from the client: strictly less. The name is now the server's own
      normalisation of what the build sent.

## Changelog

- [x] A line in `CHANGELOG.md` under `Unreleased`.

## Tests

`server/tests/component-catalogue.test.ts`, new, against a stub store that records what was
published:

- an ordinary component is published unchanged
- a padded `name` is published as the name, not as a second component
- a padded `title` and `description` are published as the reader will see them
- a padded `kind` is published as the kind
- an entry that is only whitespace is still refused
- a body that is not a list is still a 400

Against `main`, three of the six fail:

```
expect(received).toBe(expected)
Expected: "weatherPanel"
Received: " weatherPanel "
```

## How I tested

Windows 11, Bun 1.3.14. `bun test server/tests/component-catalogue.test.ts
server/tests/component-decision.test.ts` is 11 passed, 0 failed.
`bun run --filter server typecheck` and `bunx biome check` are clean.
