### PR TITLE
Report a Stop that lands mid-action as a stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### Pressing Stop is recorded as a stop, not as a computer that is not running
+
+The computer transport answered a Stop correctly only when it arrived before the request left. The
+caller's signal is handed to `fetch` precisely so a Stop can also land mid-action, and a fetch
+aborted that way rejects with an `AbortError`, which fell through to the message for a computer that
+cannot be reached. The person was told their own click had failed because the assistant's computer
+was not running, and the gateway wrote that sentence into the action's audit row as its failure --
+so a deliberate stop read back as an outage. A genuinely unreachable computer and a timeout still
+say what they said.
+
 ### The server connects to Postgres on Windows, and `localhost` is no longer a coin toss
 
 Two separate faults, both of which stop a deployment reaching its own database and neither of which

--- a/server/src/computer/client.ts
+++ b/server/src/computer/client.ts
@@ -155,6 +155,18 @@ export function createComputerTransport(
           : AbortSignal.timeout(timeoutMs),
       });
     } catch (error) {
+      /*
+       * The caller's own abort is answered first, and says what the check above the fetch says.
+       *
+       * The signal is handed to fetch precisely so a Stop can land mid-flight, and a fetch aborted
+       * that way rejects with an AbortError, which is neither a TimeoutError nor a computer that is
+       * not running. Both of the other answers are statements about the infrastructure, and this
+       * message is not only read by the model: the gateway writes it into the action's audit row as
+       * `failure`, so a person pressing Stop was recorded as an outage.
+       */
+      if (caller?.aborted) {
+        throw new ComputerUnavailableError("The action was stopped.");
+      }
       throw new ComputerUnavailableError(
         error instanceof Error && error.name === "TimeoutError"
           ? "The assistant's computer did not respond in time."

--- a/server/tests/computer-client.test.ts
+++ b/server/tests/computer-client.test.ts
@@ -395,3 +395,69 @@ describe("the deadline a call is given", () => {
     ).resolves.toBeDefined();
   });
 });
+
+describe("a person's Stop", () => {
+  /*
+   * Stop is the person saying "not that". The transport already answers it that way when the signal
+   * is already aborted before the request leaves; the signal is handed to fetch precisely so Stop can
+   * also land mid-flight, and that half was reported as a dead computer. The message is not only what
+   * the model reads: the gateway writes it into the action's audit row as `failure`, so a person's
+   * Stop was recorded as an outage.
+   */
+  test("a Stop that lands mid-action is reported as a stop, not as a dead computer", async () => {
+    const controller = new AbortController();
+    const aborting = ((_url: string, init?: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          // What fetch does when the signal it was given aborts.
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+        controller.abort();
+      })) as unknown as typeof fetch;
+
+    const transport = createComputerTransport({ fetchImpl: aborting });
+
+    await expect(
+      transport.post(
+        "http://computer",
+        "bot-1",
+        "/click",
+        {},
+        controller.signal,
+      ),
+    ).rejects.toThrow("The action was stopped.");
+  });
+
+  test("a Stop pressed before the request leaves still says the same thing", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const transport = createComputerTransport({
+      fetchImpl: (() => {
+        throw new Error("the request should never have been sent");
+      }) as unknown as typeof fetch,
+    });
+
+    await expect(
+      transport.post(
+        "http://computer",
+        "bot-1",
+        "/click",
+        {},
+        controller.signal,
+      ),
+    ).rejects.toThrow("The action was stopped.");
+  });
+
+  test("a computer that is really unreachable still says so", async () => {
+    const transport = createComputerTransport({
+      fetchImpl: (() =>
+        Promise.reject(
+          new Error("connect ECONNREFUSED"),
+        )) as unknown as typeof fetch,
+    });
+
+    await expect(
+      transport.post("http://computer", "bot-1", "/click", {}),
+    ).rejects.toThrow("The assistant's computer is not running.");
+  });
+});


### PR DESCRIPTION
## What this changes

A person presses Stop on a click, a keystroke or a long shell command, and is told:

> The assistant's computer is not running.

It is running. They stopped it.

The transport already knows how to say that, and says it only for a Stop that arrives before the
request leaves:

```ts
if (caller?.aborted) {
  throw new ComputerUnavailableError("The action was stopped.");
}
```

The caller's signal is then handed to `fetch` precisely so a Stop can land mid-flight:

```ts
signal: caller
  ? AbortSignal.any([caller, AbortSignal.timeout(timeoutMs)])
  : AbortSignal.timeout(timeoutMs),
```

and a fetch aborted that way rejects with an `AbortError`. The catch sorts errors into exactly two
kinds, and `AbortError` is neither:

```ts
error instanceof Error && error.name === "TimeoutError"
  ? "The assistant's computer did not respond in time."
  : "The assistant's computer is not running."
```

Both of those are statements about the infrastructure, and the mid-flight window is the whole point
of passing the signal at all — a Stop pressed while a 600-second shell command runs is exactly the
case the abort plumbing exists for.

## Why the message matters beyond the model

It is not only what the Bot reads. The gateway writes it into the action's audit row:

```ts
await write(auditStore, {
  toolName, botId, actor, element, ref, …
  failure: error instanceof Error ? error.message : "The action failed.",
});
```

So a person deliberately stopping an action is recorded on the audit page as the computer being
down. That is the same class of thing as #302 and #351: a row that names something other than what
happened. It also fires whenever the browser tab closes mid-request, since Bun aborts
`context.req.raw.signal` then, so a closed tab is filed as an outage too.

## Fix

The caller's own abort is answered first, with the sentence the pre-flight check already uses.
Anything else reaches the existing two branches untouched.

```ts
if (caller?.aborted) {
  throw new ComputerUnavailableError("The action was stopped.");
}
```

Reading `caller.aborted` rather than the thrown error's name is deliberate: it asks the question
that actually matters — did the person stop this — instead of inferring it from a DOMException name
that varies between runtimes.

## Where it runs

- [x] **New state that outlives a request?** None. The signal belongs to the request being served.
- [x] **What happens on the second replica?** Unchanged. The Stop arrives on the same connection as
      the action it stops, so the process that is serving it is the one that sees the abort; nothing
      here is shared between processes.
- [x] **Anything serialised?** No.
- [x] **Anything fanned out to a browser?** No new fan-out. The corrected message travels back on
      the same response and into the same audit row as before.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: untouched. This is the transport underneath
      it, and only the wording of one failure changes.
- [x] New refusals and new failures each write a row: the row was already written. It now says the
      action was stopped instead of naming an outage that did not happen.
- [x] Nothing new is trusted from the client: the abort is the server's own signal for the request
      it is serving, not a claim in a body.

## Changelog

- [x] A line in `CHANGELOG.md` under `Unreleased`.

## Tests

Three in `server/tests/computer-client.test.ts`, under a new `a person's Stop` group:

- a Stop that lands mid-action is reported as a stop. The stub aborts the signal it was handed and
  rejects with the `AbortError` a real fetch rejects with.
- a Stop pressed before the request leaves still says the same thing, and the fetch is never sent.
- a computer that is really unreachable still says it is not running, which is the check that the
  other branch did not move.

Against `main` the first fails:

```
Expected substring: "The action was stopped."
Received message: "The assistant's computer is not running."
```

## How I tested

Windows 11, Bun 1.3.14. `bun test server/tests/computer-client.test.ts` is 21 passed, 0 failed, up
from 18 by the three new tests. The neighbouring suites are unchanged: `computer-gateway` 57 passed,
`computer-sandbox` 8, `computer-provider` 12, `computer-session-guard` 5, all with no failures.
`bun run --filter server typecheck` and `bunx biome check` are clean.
