### PR TITLE
Record a computer reset as soon as the profile is gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### Wiping a computer is recorded even if clearing its stored state fails
+
+Resetting a computer destroys the profile first and wrote the audit row last, after two Postgres
+deletes. A connection reset, a failover or a statement timeout in either delete threw before the row
+was written, so the most destructive button in the product could leave a wiped computer -- every
+login gone, no undo -- with nothing on the trail to say who wiped it or when. The row is now written
+as soon as the profile is gone, which is the point after which nothing can be put back. A failure in
+either delete is still reported to the caller.
+
 ### The server connects to Postgres on Windows, and `localhost` is no longer a coin toss
 
 Two separate faults, both of which stop a deployment reaching its own database and neither of which

--- a/server/src/computer/gateway.ts
+++ b/server/src/computer/gateway.ts
@@ -713,6 +713,22 @@ export function createComputerGateway(
      */
     async resetComputer(botId: string, actor: ActionActor) {
       const result = await provider.reset(botId);
+      /*
+       * The row goes in HERE, before the two deletes below, because this line is the point of no
+       * return: the profile is already gone and nothing after it can put the logins back.
+       *
+       * Both clears are Postgres deletes, and a connection reset, a failover or a statement timeout
+       * in either used to throw before the row was written -- leaving a computer wiped with nothing
+       * on the trail to say who wiped it, which is the one outcome the note above rules out. The
+       * failure still propagates, so the caller is told the clears did not finish.
+       */
+      await writeControlEvent(auditStore, "computer.reset", {
+        botId,
+        actor,
+        reason: result.cleared
+          ? "the computer and its saved state were deleted"
+          : "no saved state was present to delete",
+      });
       // The refs the last snapshot handed out describe a page that no longer exists, and a fresh
       // computer counts generations from one again, so the row has to go with the profile.
       await snapshots.clear(botId);
@@ -725,13 +741,6 @@ export function createComputerGateway(
        * anything a person would recognise as private.
        */
       await pageFrames?.clear(botId);
-      await writeControlEvent(auditStore, "computer.reset", {
-        botId,
-        actor,
-        reason: result.cleared
-          ? "the computer and its saved state were deleted"
-          : "no saved state was present to delete",
-      });
       return result;
     },
 

--- a/server/tests/computer-gateway.test.ts
+++ b/server/tests/computer-gateway.test.ts
@@ -687,6 +687,67 @@ describe("the computer gateway", () => {
     expect(rows[0]?.targetId).toBe("bot-2");
   });
 
+  /*
+   * "The most destructive button we have. Every login the Bot had is gone and no undo exists, so the
+   * row is written whatever happens next."
+   *
+   * The profile is destroyed by `provider.reset` before either of the two Postgres deletes runs, so
+   * a delete that fails cannot put it back -- it can only take the row with it, which is the one
+   * thing that note rules out.
+   */
+  test("resetComputer records the reset even when clearing the stored page fails", async () => {
+    const { provider, fetchImpl } = fakeComputer({
+      resetResult: { cleared: true },
+    });
+    const { store, rows } = fakeAudit();
+    const snapshots: SnapshotStore = {
+      ...createInMemorySnapshotStore(),
+      clear: async () => {
+        throw new Error("connection reset by peer");
+      },
+    };
+    const gateway = createComputerGateway({
+      provider,
+      fetchImpl,
+      auditStore: store,
+      policy: () => PERMISSIVE,
+      snapshots,
+    });
+
+    await expect(gateway.resetComputer("bot-1", ACTOR)).rejects.toThrow(
+      "connection reset by peer",
+    );
+
+    expect(rows.map((row) => row.eventType)).toContain("computer.reset");
+    expect(rows[0]?.targetId).toBe("bot-1");
+  });
+
+  test("resetComputer records the reset even when clearing the screenshots fails", async () => {
+    const { provider, fetchImpl } = fakeComputer({
+      resetResult: { cleared: true },
+    });
+    const { store, rows } = fakeAudit();
+    const gateway = createComputerGateway({
+      provider,
+      fetchImpl,
+      auditStore: store,
+      policy: () => PERMISSIVE,
+      pageFrames: {
+        clear: async () => {
+          throw new Error("statement timeout");
+        },
+      } as unknown as NonNullable<
+        Parameters<typeof createComputerGateway>[0]["pageFrames"]
+      >,
+    });
+
+    await expect(gateway.resetComputer("bot-1", ACTOR)).rejects.toThrow(
+      "statement timeout",
+    );
+
+    expect(rows.map((row) => row.eventType)).toContain("computer.reset");
+  });
+
   test("computers maps provider status 'running' and 'stopped' directly and preserves egress distinctions", async () => {
     const locations: ComputerLocation[] = [
       {


### PR DESCRIPTION
## What this changes

`resetComputer` says of itself:

> The most destructive button we have. Every login the Bot had is gone and no undo exists, so the
> row is written whatever happens next.

The row is written last:

```ts
const result = await provider.reset(botId);   // the profile is gone HERE
await snapshots.clear(botId);                 // Postgres delete
await pageFrames?.clear(botId);               // Postgres delete
await writeControlEvent(auditStore, "computer.reset", { … });
```

Both clears are database deletes. A connection reset, a failover or a statement timeout in either
throws before the row is reached, and the throw propagates. The profile is already destroyed by
then — `provider.reset` ran first and there is no undo — so the outcome is a computer with every
login wiped and nothing on the trail saying who did it or when. That is precisely what the note
above rules out, and it is the one action where the trail is the only record that survives.

Measured, with a snapshot store whose `clear` rejects:

```
Expected to contain: "computer.reset"
Received: []
```

and the same for the screenshot store.

## Fix

The row is written as soon as `provider.reset` returns, which is the point of no return, and the two
clears follow. Nothing else moves: the reason string still comes from `result.cleared`, both clears
still run in the same order, and a failure in either still propagates, so the caller is still told
the clears did not finish.

Writing it before the deletes rather than wrapping them is deliberate. Swallowing the delete failure
would make the row a claim the deployment cannot back — the screenshots are the part the comment
below `snapshots.clear` says made "every login is gone" untrue in the first place — so the honest
record is a reset that happened, with the failure surfaced to whoever pressed the button.

## Where it runs

- [x] **New state that outlives a request?** None. The same row, written earlier in the same call.
- [x] **What happens on the second replica?** No change. The audit row goes to Postgres as before,
      and both clears are keyed by `botId`, so a second replica sees the same reset with the same
      row whichever process served it.
- [x] **Anything serialised?** Nothing new. `provider.reset` remains the single destructive step and
      the deletes are unconditional by `botId`, so two resets racing converge on the same end state.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: this is the gateway, and the order of its
      own steps is what changed.
- [x] New refusals and new failures each write a row: this is the point. A reset followed by a
      failed delete used to write no row at all; now it writes one and still reports the failure.
- [x] Nothing new is trusted from the client: nothing new is read.

## Changelog

- [x] A line in `CHANGELOG.md` under `Unreleased`.

## Tests

Two in `server/tests/computer-gateway.test.ts`, beside the existing reset tests:

- a snapshot store whose `clear` rejects: the reset still records `computer.reset` against the bot,
  and the failure still reaches the caller
- a screenshot store whose `clear` rejects: same

Against `main` both fail with `Received: []`.

## How I tested

Windows 11, Bun 1.3.14. `bun test server/tests/computer-gateway.test.ts` is 59 passed, 0 failed, up
from 57 by the two new tests. Neighbours unchanged: `computer-client` 18, `computer-sandbox` 8,
`computer-provider` 12, `computer-session-guard` 5, `audit` 7, all passing.
`bun run --filter server typecheck` and `bunx biome check` are clean.
