### PR TITLE
Refuse a malformed DATABASE_URL without printing the password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A malformed `DATABASE_URL` is refused without printing the password
+
+`DATABASE_URL` is taken apart before it reaches Bun, and the string most likely to fail that parse is
+one with a stray character in the password. The refusal for an unparseable value quoted the whole
+string back to name the fault, which wrote the database password into the log line that reported it.
+It now names the variable and the shape it expects, the way the other refusals beside it already do,
+and never echoes the value.
+
 ### Wiping a computer is recorded even if clearing its stored state fails
 
 Resetting a computer destroys the profile first and wrote the audit row last, after two Postgres

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -40,8 +40,12 @@ function addressOf(databaseUrl: string) {
   try {
     url = new URL(databaseUrl);
   } catch {
+    // The value is not echoed back. DATABASE_URL holds the database password, and the one string
+    // most likely to fail `new URL` is one with a stray character in that password, so printing it
+    // to name the fault would put the credential in the log line that reports it. Name the variable
+    // and the shape it expects, the way every other refusal in this function does.
     throw new TypeError(
-      `DATABASE_URL is not a URL: ${JSON.stringify(databaseUrl)}`,
+      "DATABASE_URL is not a valid URL. Expected postgres://user:password@host:port/database.",
     );
   }
   if (url.hostname === "") {

--- a/server/tests/db-client-address.test.ts
+++ b/server/tests/db-client-address.test.ts
@@ -27,10 +27,26 @@ describe("the database address", () => {
     expect(process.env.DATABASE_URL).toBeUndefined();
   });
 
-  test("refuses a connection string that is not a URL, naming what it got", () => {
+  test("refuses a connection string that is not a URL", () => {
     expect(() => createDatabase("://openbot@/openbot")).toThrow(
-      /DATABASE_URL is not a URL/,
+      /DATABASE_URL is not a valid URL/,
     );
+  });
+
+  test("does not put the password in the message when the URL will not parse", () => {
+    // A stray character in a generated password is the likeliest reason `new URL` throws here, so
+    // the refusal must not echo the string it was given: DATABASE_URL carries the credential, and a
+    // message quoting it would write the password into the log line that reports the fault. The
+    // invalid port makes `new URL` throw with the secret still present in the input.
+    const secret = "s3cr3t-p4ssw0rd";
+    let message = "";
+    try {
+      createDatabase(`postgres://openbot:${secret}@127.0.0.1:notaport/openbot`);
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toMatch(/DATABASE_URL is not a valid URL/);
+    expect(message).not.toContain(secret);
   });
 
   test("refuses a URL with no host, which would otherwise parse and connect nowhere", () => {


### PR DESCRIPTION
## What this changes

`addressOf` in `server/src/db/client.ts` takes `DATABASE_URL` apart before it reaches Bun. When `new URL` rejected the value, the refusal quoted the whole string back — `DATABASE_URL is not a URL: "..."` — and `DATABASE_URL` holds the database password. The string most likely to fail that parse is one with a stray character in the password, so the one line that reported the fault wrote the credential into the log.

It now names the variable and the shape it expects, the way every other refusal in the same function already does (`names no host`, `names no database`, `... is not percent-encoded`), and never echoes the value.

Pre-existing; surfaced while reviewing #400 (which was careful not to leak, and contrasted with this sibling line).

## Where it runs
- **New state that outlives a request?** None. Boot-time parse of the environment.
- **Second replica?** Every replica parses its own env the same way.
- **Serialised / fanned out / new listener?** No.

## Boundary and audit
- Gateway path unchanged. No new refusals on acting calls. Nothing new trusted from the client.

## Proof
`server/tests/db-client-address.test.ts` gains a test that a URL with a secret password and an invalid port is refused with a message that does **not** contain the password; the existing not-a-URL test is updated to the new wording. `bun test server/tests/db-client-address.test.ts` → 11 pass, 0 fail.