### PR TITLE
Fetch the deployment at v0.0.8

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -13,7 +13,7 @@ use openbot_desktop_lib::{
 /// Pinned rather than "latest": the images a release runs are pinned per release, so the tree that
 /// names them has to be too, and an app that fetches whatever shipped this morning is not a version
 /// anybody can be given. Moved deliberately, with the app.
-const DEPLOYMENT_VERSION: &str = "v0.0.7";
+const DEPLOYMENT_VERSION: &str = "v0.0.8";
 use serde::Serialize;
 use tauri::{Emitter, Manager};
 


### PR DESCRIPTION
The shell pinned `v0.0.7`, which it cannot start: that release's app has no `serve` script, so the shell refuses it by name, and its compose file mounts `/var/run/docker.sock` literally, which does not exist under rootless Podman.

v0.0.8 carries the four deployment-side fixes: the `serve` and `dev` scripts that hand Vite to Bun, the Vite listen on `::`, `${ENGINE_SOCKET}` in compose, and the database URL parsing. This is the first tag a clean install can complete against on Linux and Windows.