### PR TITLE
Read an empty example Bot PORT as unset, so NaN never reaches Bun.serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### Example LangGraph and Mastra Bots no longer bind an ephemeral port on empty `PORT=`
+
+An empty `PORT=` in compose or `.env` used to become `NaN` for those two example processes, so they listened on a random port while docs still named 4300/4400. They now use the same `listenPort` helper as `agent-bot`: empty is the documented default, and a prefix typo refuses to start.
+
 ## 0.0.8
 
 ### A desktop shell that installs OpenBot and then becomes it

--- a/examples/langgraph-bot/src/index.ts
+++ b/examples/langgraph-bot/src/index.ts
@@ -10,6 +10,7 @@ import {
 import { Annotation, END, START, StateGraph } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
 import { serve } from "bun";
+import { listenPort } from "../../shared/listen-port";
 
 /**
  * A Bot written in LangGraph.
@@ -26,7 +27,12 @@ import { serve } from "bun";
  * `computer_navigate` and still drives a governed browser.
  */
 
-const PORT = Number.parseInt(process.env.PORT ?? "4300", 10);
+const resolvedPort = listenPort(process.env.PORT, 4300);
+if (!resolvedPort.ok) {
+  console.error(resolvedPort.reason);
+  process.exit(1);
+}
+const PORT = resolvedPort.port;
 const MODEL = process.env.BOT_MODEL ?? "gpt-5.5";
 /**
  * `gpt-5.6-*` rejects function tools on `/v1/chat/completions` and needs the Responses API, which

--- a/examples/langgraph-bot/src/index.ts
+++ b/examples/langgraph-bot/src/index.ts
@@ -10,7 +10,7 @@ import {
 import { Annotation, END, START, StateGraph } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
 import { serve } from "bun";
-import { listenPort } from "../../shared/listen-port";
+import { listenPort } from "../../../shared/listen-port";
 
 /**
  * A Bot written in LangGraph.

--- a/examples/mastra-bot/src/index.ts
+++ b/examples/mastra-bot/src/index.ts
@@ -3,6 +3,7 @@ import { EventEncoder } from "@ag-ui/encoder";
 import { openai } from "@ai-sdk/openai";
 import { Agent } from "@mastra/core/agent";
 import { serve } from "bun";
+import { listenPort } from "../../shared/listen-port";
 
 /**
  * A Bot written in Mastra.
@@ -16,7 +17,12 @@ import { serve } from "bun";
  * as `agent-bot` and the LangGraph example.
  */
 
-const PORT = Number.parseInt(process.env.PORT ?? "4400", 10);
+const resolvedPort = listenPort(process.env.PORT, 4400);
+if (!resolvedPort.ok) {
+  console.error(resolvedPort.reason);
+  process.exit(1);
+}
+const PORT = resolvedPort.port;
 const MODEL = process.env.BOT_MODEL ?? "gpt-5.5";
 /**
  * `gpt-5.6-*` rejects function tools on `/v1/chat/completions` and needs the Responses API, which

--- a/examples/mastra-bot/src/index.ts
+++ b/examples/mastra-bot/src/index.ts
@@ -3,7 +3,7 @@ import { EventEncoder } from "@ag-ui/encoder";
 import { openai } from "@ai-sdk/openai";
 import { Agent } from "@mastra/core/agent";
 import { serve } from "bun";
-import { listenPort } from "../../shared/listen-port";
+import { listenPort } from "../../../shared/listen-port";
 
 /**
  * A Bot written in Mastra.


### PR DESCRIPTION
## What this changes

The LangGraph and Mastra example Bots used `Number.parseInt(process.env.PORT ?? default)`. An empty `PORT=` is `""`, not unset, so they bound an ephemeral port while docs still named 4300/4400. They now share `listenPort` with `agent-bot` (#395).

## Where it runs

- [x] **New state that outlives a request?** None.
- [x] **What happens on the second replica?** Each process still reads its own `PORT` at boot. Empty → documented default; a prefix typo still refuses to start.
- [x] **Anything serialised?** No.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** No. Same listen, same documented ports.

## Boundary and audit

- [x] Gateway path unchanged.
- [x] No new refusals in the server audit trail (process exits at boot, same as agent-bot).
- [x] Nothing new trusted from the client.

## Changelog

- [x] Unreleased: example LangGraph/Mastra Bots no longer bind an ephemeral port on empty `PORT=`.

## Proof

`shared/listen-port.test.ts` already covers empty/prefix/range. Same helper, same defaults 4300/4400.