### PR TITLE
Keep the secrets the first start minted, so a second start can still read the vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### Starting the desktop app again keeps the secrets the first start generated
+
+The shell generated a fresh set of secrets every time Start was pressed, including the
+`KEY_ENCRYPTION_KEY` that encrypts the credential vault. The database survives a stop, so the second
+session of an installed OpenBot met a vault it could no longer read: every stored credential failed
+to decrypt, with an error that named an operation rather than a cause. It also handed the server a
+`COMPUTER_TOKEN` that no computer created before the restart holds. The secrets an existing `.env`
+already carries are now kept, and only generated when there is nothing usable to keep — a value
+published in this repository does not count, and neither does a `KEY_ENCRYPTION_KEY` the server would
+refuse to start on.
+
 ## 0.0.8
 
 ### A desktop shell that installs OpenBot and then becomes it

--- a/desktop/src-tauri/src/env.rs
+++ b/desktop/src-tauri/src/env.rs
@@ -207,13 +207,58 @@ pub struct Model {
     pub openai_api_key: String,
 }
 
-/// Write the file, replacing only what this owns.
+const MINTED: [&str; 6] = [
+    "AGENT_TOOL_TOKEN",
+    "COMPUTER_TOKEN",
+    "KEY_ENCRYPTION_KEY",
+    "MANAGED_AGENT_TOKEN",
+    "SUPERVISOR_TOKEN",
+    "WORKER_SHARED_SECRET",
+];
+
+const PUBLISHED: [&str; 4] = [
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+    "openbot-dev-supervisor-token",
+    "openbot-dev-computer-token",
+    "openbot-dev-worker-secret",
+];
+
+fn usable(key: &str, value: &str) -> bool {
+    if value.is_empty() || PUBLISHED.contains(&value) {
+        return false;
+    }
+    if key == "KEY_ENCRYPTION_KEY" {
+        return matches!(BASE64.decode(value), Ok(bytes) if bytes.len() == 32);
+    }
+    true
+}
+
+fn carried(existing: &str) -> BTreeMap<String, String> {
+    let mut found = BTreeMap::new();
+    for line in existing.lines() {
+        if line.trim_start().starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = value.trim();
+        if MINTED.contains(&key) && usable(key, value) {
+            found.insert(key.to_string(), value.to_string());
+        }
+    }
+    found
+}
+
+/// Write the file, replacing only what this owns and keeping the secrets it has already minted.
 ///
 /// Lines the shell did not write are kept: somebody who added `OPENAI_API_KEY` by hand, or a
 /// setting a later version of this app does not know about, should not lose it because the stack
 /// was restarted.
 pub fn write(path: &Path, owned: &BTreeMap<String, String>) -> std::io::Result<()> {
     let existing = std::fs::read_to_string(path).unwrap_or_default();
+    let carried = carried(&existing);
     let mut out = String::new();
 
     for line in existing.lines() {
@@ -229,6 +274,7 @@ pub fn write(path: &Path, owned: &BTreeMap<String, String>) -> std::io::Result<(
     }
     out.push_str("\n# Written by OpenBot Desktop. Anything else in this file is left alone.\n");
     for (key, value) in owned {
+        let value = carried.get(key).unwrap_or(value);
         out.push_str(&format!("{key}={value}\n"));
     }
 
@@ -489,6 +535,200 @@ mod tests {
             "the key was written twice"
         );
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    fn env_at(dir: &std::path::Path) -> std::path::PathBuf {
+        std::fs::create_dir_all(dir).unwrap();
+        dir.join(".env")
+    }
+
+    fn tmp(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("openbot-env-{name}-{}", std::process::id()))
+    }
+
+    fn fresh() -> BTreeMap<String, String> {
+        compose(
+            &intelligence(),
+            &Model::default(),
+            &engine_status(None),
+            &Ports::default(),
+            &pinned(),
+        )
+    }
+
+    fn value_of(text: &str, key: &str) -> String {
+        text.lines()
+            .find(|line| line.starts_with(&format!("{key}=")))
+            .map(|line| line.split_once('=').unwrap().1.to_string())
+            .unwrap_or_else(|| panic!("{key} is not in the file"))
+    }
+
+    #[test]
+    fn restarting_keeps_every_secret_the_first_start_minted() {
+        let dir = tmp("restart");
+        let path = env_at(&dir);
+
+        write(&path, &fresh()).unwrap();
+        let after_install = std::fs::read_to_string(&path).unwrap();
+        write(&path, &fresh()).unwrap();
+        let after_restart = std::fs::read_to_string(&path).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
+
+        for key in MINTED {
+            assert_eq!(
+                value_of(&after_install, key),
+                value_of(&after_restart, key),
+                "{key} was re-minted by a restart"
+            );
+        }
+    }
+
+    #[test]
+    fn a_restart_that_re_mints_the_key_would_leave_the_vault_unreadable() {
+        let dir = tmp("vault");
+        let path = env_at(&dir);
+
+        write(&path, &fresh()).unwrap();
+        let installed = value_of(
+            &std::fs::read_to_string(&path).unwrap(),
+            "KEY_ENCRYPTION_KEY",
+        );
+        write(&path, &fresh()).unwrap();
+        let restarted = value_of(
+            &std::fs::read_to_string(&path).unwrap(),
+            "KEY_ENCRYPTION_KEY",
+        );
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(
+            installed, restarted,
+            "every credential encrypted under the first key can no longer be decrypted"
+        );
+    }
+
+    #[test]
+    fn a_first_install_mints_rather_than_finding_nothing_to_carry() {
+        let dir = tmp("first");
+        let path = env_at(&dir);
+        write(&path, &fresh()).unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
+
+        for key in MINTED {
+            let value = value_of(&written, key);
+            assert!(!value.is_empty(), "{key} was written empty");
+            assert!(
+                !PUBLISHED.contains(&value.as_str()),
+                "{key} kept a published value"
+            );
+        }
+    }
+
+    #[test]
+    fn a_published_value_is_replaced_rather_than_carried_forward() {
+        let dir = tmp("published");
+        let path = env_at(&dir);
+        std::fs::write(
+            &path,
+            "KEY_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n\
+             SUPERVISOR_TOKEN=openbot-dev-supervisor-token\n\
+             COMPUTER_TOKEN=openbot-dev-computer-token\n\
+             WORKER_SHARED_SECRET=openbot-dev-worker-secret\n",
+        )
+        .unwrap();
+
+        write(&path, &fresh()).unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
+
+        for published in PUBLISHED {
+            assert!(
+                !written.contains(published),
+                "a .env copied from a developer kept {published}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_key_the_server_would_refuse_is_replaced_rather_than_carried_forward() {
+        for refused in ["", "not base64 at all", "c2hvcnQ="] {
+            let dir = tmp("refused");
+            let path = env_at(&dir);
+            std::fs::write(&path, format!("KEY_ENCRYPTION_KEY={refused}\n")).unwrap();
+
+            write(&path, &fresh()).unwrap();
+            let written = std::fs::read_to_string(&path).unwrap();
+            std::fs::remove_dir_all(&dir).ok();
+
+            let value = value_of(&written, "KEY_ENCRYPTION_KEY");
+            assert_ne!(
+                value, refused,
+                "carried a key the server refuses to start on"
+            );
+            assert_eq!(
+                BASE64.decode(&value).map(|bytes| bytes.len()).unwrap_or(0),
+                32,
+                "wrote a key that is not 32 bytes"
+            );
+        }
+    }
+
+    #[test]
+    fn a_commented_out_secret_is_not_read_as_one() {
+        let dir = tmp("commented");
+        let path = env_at(&dir);
+        std::fs::write(&path, "# KEY_ENCRYPTION_KEY=commented-out-and-not-a-key\n").unwrap();
+
+        write(&path, &fresh()).unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_ne!(
+            value_of(&written, "KEY_ENCRYPTION_KEY"),
+            "commented-out-and-not-a-key"
+        );
+    }
+
+    #[test]
+    fn a_secret_somebody_set_by_hand_is_the_one_that_is_kept() {
+        let dir = tmp("byhand");
+        let path = env_at(&dir);
+        let theirs = BASE64.encode([7u8; 32]);
+        std::fs::write(&path, format!("KEY_ENCRYPTION_KEY={theirs}\n")).unwrap();
+
+        write(&path, &fresh()).unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(value_of(&written, "KEY_ENCRYPTION_KEY"), theirs);
+    }
+
+    #[test]
+    fn everything_that_is_not_a_secret_still_takes_this_run_s_value() {
+        let dir = tmp("notsecret");
+        let path = env_at(&dir);
+        write(&path, &fresh()).unwrap();
+
+        let moved = compose(
+            &intelligence(),
+            &Model::default(),
+            &engine_status(None),
+            &Ports {
+                server: 3999,
+                ..Ports::default()
+            },
+            &pinned(),
+        );
+        write(&path, &moved).unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(value_of(&written, "SERVER_PORT"), "3999");
+        assert_eq!(
+            value_of(&written, "SERVER_INTERNAL_URL"),
+            "http://127.0.0.1:3999",
+            "a setting that is not a secret was carried forward and is now stale"
+        );
     }
 }
 


### PR DESCRIPTION
## What this changes

The desktop shell generated all six of its deployment secrets on every press of Start. Five of them
can be rotated harmlessly, because the processes that share them restart together from the same
file. `KEY_ENCRYPTION_KEY` cannot: it encrypts the credential vault, `stack::down` runs `compose
down` without `-v`, and the volume holding the vault outlives the key that opened it. The second
session of an installed OpenBot therefore met credentials it could no longer decrypt, and the error
that came back was `OperationError: The operation failed for an operation-specific reason` — AES-GCM
refusing a tag, naming neither the key, nor the credential, nor the restart.

`COMPUTER_TOKEN` is the second one that matters, for a different reason. The supervisor bakes it into
a Bot's computer container as an environment variable at create time (`supervisor/src/index.ts:96`),
Stop leaves those containers stopped rather than removed so the Bot keeps its volumes
(`stack.rs:154`), and `ensure` starts an existing owned container and otherwise leaves it "exactly as
it is" (`supervisor/src/docker.ts:422`). Those containers are not Compose services, so `stack::up`
naming every service does not recreate them. After a restart the server held a token no earlier
computer had.

`write` now keeps the secrets an existing `.env` already carries and generates only what is not
already there. Two values are deliberately not carried: anything published in this repository — the
`.env.example` key and `start.sh`'s three `openbot-dev-*` fallbacks — and a `KEY_ENCRYPTION_KEY` that
is not a base64 32-byte value, which `server/src/config.ts` refuses to start on. Carrying either
would keep an install broken in a way nothing on screen could undo.

`scripts/start.sh` already works this way for the two secrets it generates: `MANAGED_AGENT_TOKEN` and
`AGENT_TOOL_TOKEN` are generated once, written back to `.env`, and reused on later runs. This is that
rule applied to the shell, and to all six.

The guard lives in `write` rather than in `compose` because `write` is already the function that
reads the existing file and decides, per line, what to keep.

Fixes #414.

## Where it runs

This runs on one laptop, in a Tauri shell, before any server process exists. It is a desktop
installer writing a file, not a request path.

- [x] **New state that outlives a request?** None. The state involved is a file on disk, `.env`,
      which is the thing being made to outlive a restart rather than new state being introduced.
- [x] **What happens on the second replica?** Nothing. This code is not deployed; it is the desktop
      shell that raises a single-machine deployment, and `OPENBOT_SINGLE_USER=true` is written two
      lines away. A hosted OpenBot never runs it. The failure it fixes is the desktop analogue of a
      replica bug — one process regenerating a secret another process's data depends on — but the
      second process here is the next launch of the same one.
- [x] **Anything serialised?** Nothing new. Two copies of the shell cannot run: `main.rs` hands the
      window over to the instance that already exists.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** None. Ports are unchanged, and the test
      `everything_that_is_not_a_secret_still_takes_this_run_s_value` pins that a port moved between
      versions is still written fresh rather than carried.

## Boundary and audit

- [x] Every acting call still goes through the gateway: unchanged, and not reached by this. No
      server code is touched.
- [x] New refusals and new failures each write a row: no new refusal or failure exists. The shell
      has no audit trail and predates the server it starts.
- [x] Nothing new is trusted from the client that the server can resolve itself: nothing new is
      trusted at all. The one new input is the deployment's own `.env`, and the two ways it can lie —
      a published value, or a key the server would refuse — are both rejected rather than carried.

## Changelog

- [x] A line in `CHANGELOG.md` under `Unreleased`.

## Proof

Every command `.github/workflows/desktop.yml` runs on this tree, on this machine:

```
cargo fmt --check                      clean
cargo clippy --all-targets -- -D warnings   clean
cargo test --lib                       78 passed; 0 failed
```

The bug reproduces, and the tests catch it. With the carry-forward line removed and everything else
in this branch left in place, three of the new tests fail and the rest still pass:

```
test env::tests::restarting_keeps_every_secret_the_first_start_minted ... FAILED
test env::tests::a_restart_that_re_mints_the_key_would_leave_the_vault_unreadable ... FAILED
test env::tests::a_secret_somebody_set_by_hand_is_the_one_that_is_kept ... FAILED
test result: FAILED. 19 passed; 3 failed
```

Restored: `22 passed; 0 failed` for `env::`, `78 passed; 0 failed` for the crate.

The consequence was checked against the real code rather than argued. Encrypting under the key the
first Start wrote and decrypting under the key the second Start wrote, through
`server/src/credentials.ts` unmodified:

```
with the key it was stored under: sk-a-stored-credential
with the re-minted key: OperationError | The operation failed for an operation-specific reason
```

Nothing outside `desktop/` changed, and the repository is unaffected: `bunx biome lint
--error-on-warnings .` clean over 573 files, `bun run typecheck` clean in `app`, `server` and
`worker`. `bun test` gives `2443 pass, 23 skip, 3 fail` on this branch and the identical
`2443 pass, 23 skip, 3 fail` on `main` — the three are the handoff-queue lease tests, which fail on a
clean checkout and are not touched here.

Not covered: the shell was not installed and driven end to end for this, because reproducing the
original failure that way means installing a container engine, letting the first Start pull five
images, storing a credential through the UI, quitting and starting again. The two halves were each
run instead — the file the shell writes, in Rust, and the decryption the server does, in TypeScript —
and they meet at the value of `KEY_ENCRYPTION_KEY`. `desktop.yml` says the `core` job is "the only
job that runs the assertions about what the shell writes into `.env`", which is the level this is
tested at.
