### PR TITLE
Replace the desktop .env banner instead of stacking another one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### The desktop app stops adding a banner to `.env` on every start
+
+`env::write` keeps the lines it did not write, and its own header comment is one of them, so each
+start preserved the previous banner and appended another. A deployment started fifty times had fifty
+copies of "Written by OpenBot Desktop" and fifty blank lines stacked above its settings. The banner
+is now recognised and replaced rather than kept, and comments somebody else put in the file are left
+alone exactly as before.
+
 ## 0.0.8
 
 ### A desktop shell that installs OpenBot and then becomes it

--- a/desktop/src-tauri/src/env.rs
+++ b/desktop/src-tauri/src/env.rs
@@ -207,6 +207,12 @@ pub struct Model {
     pub openai_api_key: String,
 }
 
+/// The line that separates what the shell owns from what it found.
+///
+/// Named rather than written inline, because `write` has to recognise its own from a previous start
+/// as well as put one down.
+const BANNER: &str = "# Written by OpenBot Desktop. Anything else in this file is left alone.";
+
 /// Write the file, replacing only what this owns.
 ///
 /// Lines the shell did not write are kept: somebody who added `OPENAI_API_KEY` by hand, or a
@@ -217,6 +223,15 @@ pub fn write(path: &Path, owned: &BTreeMap<String, String>) -> std::io::Result<(
     let mut out = String::new();
 
     for line in existing.lines() {
+        // The shell's own banner is not one of the lines it did not write. Keeping it and then
+        // writing another one added a banner and a blank line to the file on every start, so a
+        // deployment restarted fifty times had fifty of them above its settings.
+        // The shell's own banner is not one of the lines it did not write. Keeping it and then
+        // writing another one added a banner and a blank line to the file on every start, so a
+        // deployment restarted fifty times had fifty of them above its settings.
+        if line.trim() == BANNER {
+            continue;
+        }
         let key = line.split('=').next().unwrap_or("").trim();
         if key.is_empty() || line.trim_start().starts_with('#') || !owned.contains_key(key) {
             out.push_str(line);
@@ -224,10 +239,15 @@ pub fn write(path: &Path, owned: &BTreeMap<String, String>) -> std::io::Result<(
         }
     }
 
-    if !out.is_empty() && !out.ends_with('\n') {
-        out.push('\n');
-    }
-    out.push_str("\n# Written by OpenBot Desktop. Anything else in this file is left alone.\n");
+    // The blank lines the removed banners left behind go with them, so the separator below is one
+    // blank line rather than one more on every start.
+    let kept = out.trim_end_matches('\n');
+    let mut out = if kept.is_empty() {
+        String::new()
+    } else {
+        format!("{kept}\n")
+    };
+    out.push_str(&format!("\n{BANNER}\n"));
     for (key, value) in owned {
         out.push_str(&format!("{key}={value}\n"));
     }
@@ -268,6 +288,59 @@ mod tests {
             engine_socket: socket.map(str::to_string),
             detail: String::new(),
         }
+    }
+
+    #[test]
+    fn restarting_does_not_add_a_banner_to_the_file_every_time() {
+        // The banner is a comment, and the preserve pass keeps comments, so the file grew by one
+        // banner and one blank line on every start: fifty restarts, fifty banners.
+        let dir = std::env::temp_dir().join(format!("openbot-env-banner-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".env");
+
+        let mut owned = BTreeMap::new();
+        owned.insert("SERVER_PORT".to_string(), "3000".to_string());
+        owned.insert("KEY_ENCRYPTION_KEY".to_string(), "abc=".to_string());
+
+        for _ in 0..5 {
+            write(&path, &owned).unwrap();
+        }
+        let text = std::fs::read_to_string(&path).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_eq!(text.matches(BANNER).count(), 1);
+        // And the file is the same size on the fifth start as on the first.
+        assert_eq!(text.lines().count(), 4);
+    }
+
+    #[test]
+    fn a_comment_somebody_else_wrote_is_still_kept() {
+        // Only the shell's own banner is dropped; the rule about leaving other lines alone stands.
+        let dir = std::env::temp_dir().join(format!("openbot-env-keep-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".env");
+        std::fs::write(
+            &path,
+            "# our proxy needs this
+HTTPS_PROXY=http://proxy:8080
+",
+        )
+        .unwrap();
+
+        let mut owned = BTreeMap::new();
+        owned.insert("SERVER_PORT".to_string(), "3000".to_string());
+        write(&path, &owned).unwrap();
+        write(&path, &owned).unwrap();
+
+        let text = std::fs::read_to_string(&path).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(text.contains("# our proxy needs this"));
+        assert!(text.contains("HTTPS_PROXY=http://proxy:8080"));
+        assert_eq!(text.matches("# our proxy needs this").count(), 1);
+        assert_eq!(text.matches(BANNER).count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## What this changes

The desktop shell's `.env` grows by two lines on every start, forever.

`write` keeps the lines it did not write — which is the right rule, and its own header comment
matches it:

```rust
if key.is_empty() || line.trim_start().starts_with('#') || !owned.contains_key(key) {
    out.push_str(line);   // the previous banner is a comment, so it is kept
}
…
out.push_str("\n# Written by OpenBot Desktop. Anything else in this file is left alone.\n");
```

So the old banner is preserved and a new one is appended beside it.

## Measured

Five starts, same settings:

```
start 1: 4 lines, 1 banners, 1 blank lines
start 2: 6 lines, 2 banners, 2 blank lines
start 3: 8 lines, 3 banners, 3 blank lines
start 4: 10 lines, 4 banners, 4 blank lines
start 5: 12 lines, 5 banners, 5 blank lines
```

and the file itself:

```
# Written by OpenBot Desktop. Anything else in this file is left alone.

# Written by OpenBot Desktop. Anything else in this file is left alone.

# Written by OpenBot Desktop. Anything else in this file is left alone.

# Written by OpenBot Desktop. Anything else in this file is left alone.

# Written by OpenBot Desktop. Anything else in this file is left alone.
KEY_ENCRYPTION_KEY=abc=
SERVER_PORT=3000
```

Nothing breaks — Compose reads the settings fine. It is the file a person opens when they want to
add `HTTPS_PROXY` or check which port the server is on, and after a few weeks of use the thing they
came to read is under a wall of repeated banners. The existing test
`rewriting_replaces_its_own_settings_rather_than_appending_them_twice` covers the settings, which is
why this was not caught: it is the banner that repeats, not the settings.

## Fix

The banner is a constant, and the preserve pass recognises it as the shell's own rather than as a
line somebody else wrote. The blank lines the removed banners leave behind go with them, so the
separator stays one blank line rather than one per start.

Comments somebody else put in the file are untouched — that is the point of the rule and it is what
the second test pins.

## Where it runs

- [x] **New state that outlives a request?** None. This is the desktop shell writing a file on one
      machine.
- [x] **What happens on the second replica?** Not applicable: the shell runs on a person's own
      computer. The `.env` it writes is what the replicas later read, and it now says the same thing
      on the fiftieth start as on the first.
- [x] **Anything serialised?** No. Same single `std::fs::write` as before.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: no server path is touched.
- [x] New refusals and new failures each write a row: not applicable — this runs before a deployment
      exists.
- [x] Nothing new is trusted from the client: nothing new is read at all.

## Changelog

- [x] A line in `CHANGELOG.md` under `Unreleased`.

## Tests

Two in `desktop/src-tauri/src/env.rs`:

- five starts leave one banner and a file the same length as after the first
- a comment somebody else wrote is still kept across two starts, and kept once

Against `main` the first fails with `left: 5, right: 1`.

## How I tested

Windows 11. `cargo test --lib` in `desktop/src-tauri` is 72 passed, 0 failed, up from 70 by the two
new tests. `cargo fmt --all -- --check` and `cargo clippy --lib` are clean. The crate has no
`rust-toolchain.toml`, so I built it with the 1.98.0 toolchain installed here.
