### PR TITLE
Trim the settings pasted into the desktop setup screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A credential pasted with a stray space into the desktop setup screen now works
+
+The setup screen enables its button on `value.trim() !== ""` and then sends the untrimmed string, so
+a key copied from a provider's dashboard with the space the selection picked up arrived intact. The
+model key was trimmed on the way into `.env`; the API URL, the gateway URL and the intelligence key
+entered on the same screen were not, so Compose passed the space through, the provider rejected the
+credential, and the failure the person saw named neither the space nor the field. All four are now
+trimmed the same way.
+
 ## 0.0.8
 
 ### A desktop shell that installs OpenBot and then becomes it

--- a/desktop/src-tauri/src/env.rs
+++ b/desktop/src-tauri/src/env.rs
@@ -80,12 +80,23 @@ pub fn compose(
         );
     }
 
-    env.insert("INTELLIGENCE_API_URL".into(), intelligence.api_url.clone());
+    // Trimmed, the way the model key beside it already is. All four values come from the same
+    // setup screen, which enables its button on `value.trim() !== ""` and then sends the untrimmed
+    // string, so a key copied from a provider's dashboard with the trailing space the selection
+    // picked up arrives here intact. Compose keeps it, the provider rejects the key, and the Bot
+    // reports that it cannot answer without ever naming the space.
+    env.insert(
+        "INTELLIGENCE_API_URL".into(),
+        intelligence.api_url.trim().to_string(),
+    );
     env.insert(
         "INTELLIGENCE_GATEWAY_WS_URL".into(),
-        intelligence.gateway_ws_url.clone(),
+        intelligence.gateway_ws_url.trim().to_string(),
     );
-    env.insert("INTELLIGENCE_API_KEY".into(), intelligence.api_key.clone());
+    env.insert(
+        "INTELLIGENCE_API_KEY".into(),
+        intelligence.api_key.trim().to_string(),
+    );
 
     env.insert("KEY_ENCRYPTION_KEY".into(), secret());
     env.insert("SUPERVISOR_TOKEN".into(), secret());
@@ -268,6 +279,49 @@ mod tests {
             engine_socket: socket.map(str::to_string),
             detail: String::new(),
         }
+    }
+
+    #[test]
+    fn a_pasted_value_is_trimmed_the_way_the_model_key_beside_it_is() {
+        // The setup screen enables its button on `value.trim() !== ""` and sends the untrimmed
+        // string. The model key was rescued here; the three values entered on the same screen were
+        // not, so a copied credential kept whatever whitespace the selection picked up.
+        let env = compose(
+            &Intelligence {
+                api_url: "  https://api.example  ".into(),
+                gateway_ws_url: "	wss://realtime.example
+"
+                .into(),
+                api_key: " key-with-a-trailing-space ".into(),
+            },
+            &Model {
+                openai_api_key: " sk-model ".into(),
+            },
+            &engine_status(None),
+            &Ports::default(),
+            &pinned(),
+        );
+
+        assert_eq!(env["INTELLIGENCE_API_URL"], "https://api.example");
+        assert_eq!(env["INTELLIGENCE_GATEWAY_WS_URL"], "wss://realtime.example");
+        assert_eq!(env["INTELLIGENCE_API_KEY"], "key-with-a-trailing-space");
+        // Unchanged, and the reason the other three now match it.
+        assert_eq!(env["OPENAI_API_KEY"], "sk-model");
+    }
+
+    #[test]
+    fn a_value_with_nothing_around_it_is_untouched() {
+        let env = compose(
+            &intelligence(),
+            &Model {
+                openai_api_key: "sk-model".into(),
+            },
+            &engine_status(None),
+            &Ports::default(),
+            &pinned(),
+        );
+        assert_eq!(env["INTELLIGENCE_API_URL"], "https://api.example");
+        assert_eq!(env["INTELLIGENCE_API_KEY"], "key");
     }
 
     #[test]


### PR DESCRIPTION
## What this changes

Four values are typed or pasted on the desktop setup screen. The screen decides whether to enable
its button on the trimmed string:

```tsx
disabled={busy || apiKey.trim() === "" || modelKey.trim() === "" || root.trim() === ""}
```

and then sends the untrimmed one:

```tsx
await invoke("start_stack", { root, apiUrl, gatewayWsUrl: wsUrl, apiKey, openaiApiKey: modelKey });
```

On the Rust side exactly one of them is rescued:

```rust
if !model.openai_api_key.trim().is_empty() {
    env.insert("OPENAI_API_KEY".into(), model.openai_api_key.trim().to_string());
}

env.insert("INTELLIGENCE_API_URL".into(), intelligence.api_url.clone());
env.insert("INTELLIGENCE_GATEWAY_WS_URL".into(), intelligence.gateway_ws_url.clone());
env.insert("INTELLIGENCE_API_KEY".into(), intelligence.api_key.clone());
```

So `OPENAI_API_KEY` survives a stray space and the other three carry it into `.env`.

## What that costs

Selecting a token in a provider's dashboard picks up a trailing space more often than not, and a
credential is the one kind of value nobody eyeballs after pasting — it is a wall of characters in a
password field.

The result is a deployment that starts cleanly and then fails at the first request, with the
provider rejecting a key that looks right in `.env` and a Bot saying it cannot answer. Nothing in
that chain names the space. The trimming already applied to the model key is there for exactly this
reason; this extends it to the three values entered beside it.

## Fix

`compose` trims the three intelligence values the way it already trims the model key. Nothing else
moves: a value with nothing around it is byte-identical, and the "blank means leave it out
entirely" rule for the model key is untouched.

Done here rather than in the screen deliberately. `start_stack` is a Tauri command and this is the
boundary where the string becomes a setting, so trimming here holds whatever called it.

## Where it runs

- [x] **New state that outlives a request?** None. A pure function over its arguments.
- [x] **What happens on the second replica?** Not applicable: the shell runs on one machine. The
      `.env` it writes is what every replica of the deployment then reads, so the fix reaches all of
      them by reaching the file.
- [x] **Anything serialised?** No.
- [x] **Anything fanned out to a browser?** No.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway: no server path is touched.
- [x] New refusals and new failures each write a row: not applicable — this runs before a deployment
      exists.
- [x] Nothing new is trusted from the client: strictly less. The value is normalised at the command
      boundary rather than taken as sent.

## Changelog

- [x] A line in `CHANGELOG.md` under `Unreleased`.

## Tests

Two in `desktop/src-tauri/src/env.rs`:

- the three intelligence values are trimmed, and the model key beside them still is — the assertion
  that pins them as consistent rather than each separately
- a value with nothing around it is untouched

Against `main` the first fails:

```
  left: "  https://api.example  "
 right: "https://api.example"
```

## How I tested

Windows 11. `cargo test --lib` in `desktop/src-tauri` is 72 passed, 0 failed, up from 70 by the two
new tests. `cargo fmt --all -- --check` and `cargo clippy --lib` are clean. The crate has no
`rust-toolchain.toml`, so I built it with the 1.98.0 toolchain installed here.

I left `root` alone: it is a directory chosen through a picker rather than pasted, and trimming a
path is a different question from trimming a credential. Happy to take it in this PR if you would
rather they moved together.
