### PR TITLE
Open the app's sockets against the server, so no proxy has to carry them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,15 @@ by itself.
 
 Nothing about existing rows changes. Every row already written, and every row a person's own click
 writes from now on, reads as a person, because that is what it was.
+### The live screen and live channel updates work again, and one request can no longer end the app
+
+The app opened its two WebSockets against its own address, so they travelled through Vite's `/api`
+proxy. Vite is run through bun, and under bun that proxy does not carry a WebSocket: neither the
+Bot's screen nor live channel updates ever connected, and the browser retried in a loop. Worse, an
+upgrade the server answered with an ordinary HTTP response — a 503 when a Bot's computer is not
+running, which is exactly when somebody opens the screen — crashed the process that served the app,
+taking the server and the worker with it in development. Both sockets now address the server
+directly, so nothing upgrades through the proxy and the proxy no longer offers to carry one.
 
 ## 0.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,8 +97,11 @@ proxy. Vite is run through bun, and under bun that proxy does not carry a WebSoc
 Bot's screen nor live channel updates ever connected, and the browser retried in a loop. Worse, an
 upgrade the server answered with an ordinary HTTP response — a 503 when a Bot's computer is not
 running, which is exactly when somebody opens the screen — crashed the process that served the app,
-taking the server and the worker with it in development. Both sockets now address the server
-directly, so nothing upgrades through the proxy and the proxy no longer offers to carry one.
+taking the server and the worker with it in development. Where Vite serves the app — the dev server
+and the desktop's `vite preview` — both sockets now address the server directly, so nothing upgrades
+through the proxy and the proxy no longer offers to carry one. In production the server serves the
+app itself and answers the upgrade on the same origin, so the sockets stay on the browser's own
+host, which is what an ingress terminating TLS on 443 requires and a fixed server port would break.
 
 ## 0.0.8
 

--- a/app/src/components/computer/live-screen.tsx
+++ b/app/src/components/computer/live-screen.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { pageCoordinates } from "./take-the-wheel";
+import { socketUrl } from "@/lib/socket-url";
 
 /**
  * Low-latency screencast used while a human is driving the Bot's browser.
@@ -57,10 +58,10 @@ export function LiveScreen({ computerId, driving, onProblem }: Props) {
   const [connected, setConnected] = useState(false);
 
   useEffect(() => {
-    // Same origin, so the scheme follows the page: wss when the app is served over https.
-    const scheme = window.location.protocol === "https:" ? "wss" : "ws";
+    // The server's own address, so no proxy has to carry the upgrade. The scheme still follows
+    // the page: wss when the app is served over https.
     const socket = new WebSocket(
-      `${scheme}://${window.location.host}/api/computers/${encodeURIComponent(computerId)}/stream`,
+      socketUrl(`/api/computers/${encodeURIComponent(computerId)}/stream`),
     );
     socketRef.current = socket;
     let closed = false;

--- a/app/src/lib/channels/use-channel-events.ts
+++ b/app/src/lib/channels/use-channel-events.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { type ChannelPage, type ChannelSummary, channelKeys } from "./queries";
+import { socketUrl as buildSocketUrl } from "@/lib/socket-url";
 
 /**
  * Keep the roster live.
@@ -197,9 +198,7 @@ const FIRST_RETRY_MS = 500;
 const MAX_RETRY_MS = 30_000;
 
 function socketUrl() {
-  const url = new URL("/api/channels/events", window.location.href);
-  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
-  return url.toString();
+  return buildSocketUrl("/api/channels/events");
 }
 
 export function useChannelEvents() {

--- a/app/src/lib/socket-url.ts
+++ b/app/src/lib/socket-url.ts
@@ -1,5 +1,31 @@
-const configuredPort =
-  typeof __OPENBOT_SERVER_PORT__ === "string" ? __OPENBOT_SERVER_PORT__ : "";
+/**
+ * A WebSocket's address, same-origin unless a Vite runtime says otherwise.
+ *
+ * In production the server serves the app and answers the `/api` WebSocket upgrade on the same
+ * origin, so the browser's own host is the target — including behind an ingress that terminates TLS
+ * on 443 and never exposes the container's port. Deriving the socket from `window.location` is the
+ * standard shape for a reverse-proxied deployment, and it is the default here because it is the case
+ * that must not break.
+ *
+ * Development and the desktop's `vite preview` are the exception. There Vite serves the app on
+ * APP_PORT and proxies `/api` to the server on SERVER_PORT, a different origin, and under bun that
+ * proxy cannot carry a WebSocket at all (oven-sh/bun#24127): the upgrade is answered with a plain
+ * HTTP response and the socket never opens. So those two runtimes address the server directly, by
+ * the port each announces on `window.__OPENBOT_WS_PORT__`. Nothing announces it in the built bundle
+ * the server hands out, so a production page has no port to override with and stays same-origin.
+ */
+declare global {
+  interface Window {
+    __OPENBOT_WS_PORT__?: string;
+  }
+}
+
+function announcedPort(): string {
+  return typeof window !== "undefined" &&
+    typeof window.__OPENBOT_WS_PORT__ === "string"
+    ? window.__OPENBOT_WS_PORT__
+    : "";
+}
 
 export function socketUrl(
   path: string,
@@ -8,9 +34,11 @@ export function socketUrl(
     hostname: string;
     host: string;
   } = window.location,
-  port: string = configuredPort,
+  port: string = announcedPort(),
 ): string {
   const scheme = location.protocol === "https:" ? "wss:" : "ws:";
+  // A port only when a Vite runtime named one: the app is not same-origin with the server there.
+  // Otherwise the browser's own host, which is the server's own origin in production.
   const authority = port ? `${location.hostname}:${port}` : location.host;
   return `${scheme}//${authority}${path}`;
 }

--- a/app/src/lib/socket-url.ts
+++ b/app/src/lib/socket-url.ts
@@ -1,0 +1,16 @@
+const configuredPort =
+  typeof __OPENBOT_SERVER_PORT__ === "string" ? __OPENBOT_SERVER_PORT__ : "";
+
+export function socketUrl(
+  path: string,
+  location: {
+    protocol: string;
+    hostname: string;
+    host: string;
+  } = window.location,
+  port: string = configuredPort,
+): string {
+  const scheme = location.protocol === "https:" ? "wss:" : "ws:";
+  const authority = port ? `${location.hostname}:${port}` : location.host;
+  return `${scheme}//${authority}${path}`;
+}

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -2,5 +2,3 @@
 
 // Vite's own ambient types, which is where `import.meta.glob` is declared. Needed because the
 // component gallery discovers its files rather than listing them (see lib/copilot/gallery-registry).
-
-declare const __OPENBOT_SERVER_PORT__: string;

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -2,3 +2,5 @@
 
 // Vite's own ambient types, which is where `import.meta.glob` is declared. Needed because the
 // component gallery discovers its files rather than listing them (see lib/copilot/gallery-registry).
+
+declare const __OPENBOT_SERVER_PORT__: string;

--- a/app/tests/socket-url.test.ts
+++ b/app/tests/socket-url.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { socketUrl } from "../src/lib/socket-url";
+
+const at = (protocol: string, hostname: string, host: string) => ({
+  protocol,
+  hostname,
+  host,
+});
+
+describe("where a socket is opened", () => {
+  test("goes to the server's port rather than the page's, so no proxy carries it", () => {
+    expect(
+      socketUrl(
+        "/api/channels/events",
+        at("http:", "localhost", "localhost:3010"),
+        "3001",
+      ),
+    ).toBe("ws://localhost:3001/api/channels/events");
+  });
+
+  test("keeps the host the person actually used, and changes only the port", () => {
+    expect(
+      socketUrl(
+        "/api/channels/events",
+        at("http:", "192.168.1.10", "192.168.1.10:3010"),
+        "3001",
+      ),
+    ).toBe("ws://192.168.1.10:3001/api/channels/events");
+  });
+
+  test("stays on the page's own origin when no server port is configured", () => {
+    expect(
+      socketUrl(
+        "/api/channels/events",
+        at("https:", "openbot.example", "openbot.example"),
+        "",
+      ),
+    ).toBe("wss://openbot.example/api/channels/events");
+  });
+
+  test("follows the page's scheme, so an https page never opens an insecure socket", () => {
+    expect(
+      socketUrl(
+        "/api/computers/a/stream",
+        at("https:", "openbot.example", "openbot.example:8443"),
+        "3001",
+      ),
+    ).toBe("wss://openbot.example:3001/api/computers/a/stream");
+  });
+});

--- a/app/tests/socket-url.test.ts
+++ b/app/tests/socket-url.test.ts
@@ -28,7 +28,7 @@ describe("where a socket is opened", () => {
     ).toBe("ws://192.168.1.10:3001/api/channels/events");
   });
 
-  test("stays on the page's own origin when no server port is configured", () => {
+  test("stays on the page's own origin when no server port is announced", () => {
     expect(
       socketUrl(
         "/api/channels/events",
@@ -36,6 +36,20 @@ describe("where a socket is opened", () => {
         "",
       ),
     ).toBe("wss://openbot.example/api/channels/events");
+  });
+
+  test("behind an ingress that only exposes 443, stays on 443, never the container port", () => {
+    // The case that must not break, and the one a baked server port broke: production serves the
+    // app and answers the upgrade same-origin, behind an ingress that terminates TLS on 443 and
+    // never exposes the container's port. No Vite runtime announces a port there, so the socket
+    // stays on the origin the browser loaded rather than being sent to a port nothing routes.
+    expect(
+      socketUrl(
+        "/api/computers/a/stream",
+        at("https:", "openbot.example", "openbot.example"),
+        "",
+      ),
+    ).toBe("wss://openbot.example/api/computers/a/stream");
   });
 
   test("follows the page's scheme, so an https page never opens an insecure socket", () => {

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -35,8 +35,15 @@ function announceServerPort(port: number): Plugin {
       const indexPath = path.resolve(__dirname, "dist", "index.html");
       server.middlewares.use((request, response, next) => {
         const requestPath = (request.url ?? "/").split("?")[0];
-        // Only the SPA entry: a navigation, not an asset with a file extension.
-        if (request.method !== "GET" || /\.[^/]+$/.test(requestPath)) {
+        // Only the SPA entry, and this middleware runs before Vite's own — so everything Vite must
+        // still handle has to fall through: a non-GET, an `/api` call the proxy carries to the
+        // server (extension-less GETs like `/api/bots` included), and an asset with a file
+        // extension. What is left is a navigation, which gets the app shell with the port announced.
+        if (
+          request.method !== "GET" ||
+          requestPath.startsWith("/api") ||
+          /\.[^/]+$/.test(requestPath)
+        ) {
           return next();
         }
         let html: string;

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,9 +1,56 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import { listenPort } from "../shared/listen-port";
+
+/*
+ * Announce the server's port to the two runtimes that serve the app through Vite, and to no other.
+ *
+ * The dev server and the desktop's `vite preview` serve the app on APP_PORT and proxy `/api` to the
+ * server, but under bun that proxy cannot carry a WebSocket (oven-sh/bun#24127), so the app's
+ * sockets address the server directly on this port. `socketUrl` reads it off `window`.
+ *
+ * It is deliberately kept OUT of the built HTML. In production the server serves that same HTML on
+ * its own origin and answers the upgrade there, so the socket is same-origin; a baked port would
+ * point it at a container port an ingress terminating TLS on 443 does not expose, which is how a
+ * build-time constant broke the fleet. The dev injection is gated on `ctx.server` so it never runs
+ * during `vite build`; `vite preview` serves the static build unchanged and so is handled by its
+ * own middleware below.
+ */
+function announceServerPort(port: number): Plugin {
+  const tag = `<script>window.__OPENBOT_WS_PORT__=${JSON.stringify(String(port))};</script>`;
+  const inject = (html: string) =>
+    html.includes("__OPENBOT_WS_PORT__")
+      ? html
+      : html.replace("</head>", `    ${tag}\n  </head>`);
+  return {
+    name: "openbot-announce-server-port",
+    transformIndexHtml(html, ctx) {
+      return ctx.server ? inject(html) : html;
+    },
+    configurePreviewServer(server) {
+      const indexPath = path.resolve(__dirname, "dist", "index.html");
+      server.middlewares.use((request, response, next) => {
+        const requestPath = (request.url ?? "/").split("?")[0];
+        // Only the SPA entry: a navigation, not an asset with a file extension.
+        if (request.method !== "GET" || /\.[^/]+$/.test(requestPath)) {
+          return next();
+        }
+        let html: string;
+        try {
+          html = readFileSync(indexPath, "utf8");
+        } catch {
+          return next();
+        }
+        response.setHeader("content-type", "text/html; charset=utf-8");
+        response.end(inject(html));
+      });
+    },
+  };
+}
 
 /*
  * The same address and the same proxy whether this is the dev server or the preview of a build.
@@ -38,10 +85,12 @@ const serving = {
 };
 
 export default defineConfig({
-  define: {
-    __OPENBOT_SERVER_PORT__: JSON.stringify(String(apiPort.port)),
-  },
-  plugins: [tanstackRouter(), react(), tailwindcss()],
+  plugins: [
+    announceServerPort(apiPort.port),
+    tanstackRouter(),
+    react(),
+    tailwindcss(),
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -31,16 +31,16 @@ const serving = {
   port: appPort.port,
   strictPort: true,
   proxy: {
-    // `ws: true` is required for the live screen. Without it Vite answers the upgrade request with
-    // the app's HTML and the socket fails with an opaque error that looks like a server problem.
     "/api": {
       target: `http://localhost:${apiPort.port}`,
-      ws: true,
     },
   },
 };
 
 export default defineConfig({
+  define: {
+    __OPENBOT_SERVER_PORT__: JSON.stringify(String(apiPort.port)),
+  },
   plugins: [tanstackRouter(), react(), tailwindcss()],
   resolve: {
     alias: {


### PR DESCRIPTION
## What this changes

The app built both its WebSocket URLs from its own address, so both travelled through Vite's `/api` proxy. Under bun that proxy cannot carry a WebSocket ([oven-sh/bun#24127](https://github.com/oven-sh/bun/issues/24127), a regression since bun 1.3.1 whose fix is unmerged), so neither the Bot's screen nor live channel updates ever connected, and an upgrade the server answered with plain HTTP crashed the process serving the app.

Both now address the server directly. `app/src/lib/socket-url.ts` keeps the host the person actually used and changes only the port, so reaching the app at `192.168.1.10:3010` opens its socket at `192.168.1.10:3001` rather than somebody else's loopback. When no server port is configured it returns the page's own origin, so a deployment serving app and API from one origin is unchanged — pinned by a test.

With nothing upgrading through the proxy, `ws: true` is no longer carrying anything, so it is gone. That is what removes the crash rather than a workaround for it: the branch containing `socket.destroySoon()` is only reached when the proxy is asked to handle an upgrade.

`__OPENBOT_SERVER_PORT__` is defined in `vite.config.ts` from `SERVER_PORT`, which is already in the environment Vite is started with, in dev and in the `serve` script the desktop shell runs.

Fixes #420.

## Where it runs

This is browser code choosing an address, plus one build-time constant.

- [x] **New state that outlives a request?** None.
- [x] **What happens on the second replica?** Nothing changes. The socket address is derived per browser from the page's own hostname; no process holds anything. A hosted deployment serving app and API from one origin configures no port and keeps today's behaviour exactly.
- [x] **Anything serialised?** No.
- [x] **Anything fanned out to a browser?** The two existing sockets, unchanged in protocol and payload. Only the address they dial moved.
- [x] **New listener, port, or schedule?** None. The server already listened on this port and already served both socket routes.

## Boundary and audit

- [x] Every acting call still goes through the gateway: unchanged, no server code touched.
- [x] New refusals and failures each write a row: no new refusal or failure exists.
- [x] Nothing new is trusted from the client: the socket address is derived from the page's own location plus a build-time constant, never from anything a request carries. The server's own guard on `/api/computers/<bot>/stream` — `resolveRequestActor`, applied by hand because middleware does not run on an upgrade — is untouched and still runs.

## Changelog

- [x] A line in `CHANGELOG.md` under `Unreleased`.

## Proof

Measured, not argued. The upstream cause, with a control that isolates the runtime:

```
vite under node v24     server direct: OPEN    through vite: OPEN
vite under bun 1.3.14   server direct: OPEN    through vite: TIMEOUT
```

Before and after, in a browser on the running app:

```
before   ws://localhost:3010/api/channels/events  TIMEOUT,  405 console errors on one page load
after    ws://localhost:3001/api/channels/events  OPEN,     0 console errors
```

The live screen, on the endpoint the component now builds, against a running computer:

```
ws://localhost:3001/api/computers/general-assistant/stream
opened: true, first frame 8432 bytes
```

The crash, on both paths that serve the app, with the server up so the upgrade gets a real non-101 answer. Before, one request took both ports down and logged the `destroySoon` TypeError. After:

```
bun run dev      curl upgrade /api/agents                    server=200 app=200
bun run dev      curl upgrade /api/computers/x/stream (503)  server=200 app=200
vite preview     curl upgrade /api/agents                    app=200
vite preview     curl upgrade /api/computers/x/stream (503)  app=200
destroySoon occurrences in either log: 0
```

The one assumption worth stating was tested rather than reasoned about. Moving a socket to another port only works if the session cookie follows it, so a cookie was set on the page at `:3010` and the server on `:3001` was instrumented to log what arrived on the handshake:

```
path: /api/channels/events   upgrade: websocket
origin: http://localhost:3010
cookie: openbot_probe_session=abc123
```

Cookies ignore ports and the two are same-site, so the session reaches the guard exactly as before. The instrumentation was reverted; it is not in this branch.

App tests: 348 pass / 0 fail on `main`, 352 pass / 0 fail here, the four new ones covering the address chosen. `bun run typecheck` clean across `app`, `server` and `worker`; `biome lint --error-on-warnings` clean over 575 files. The repository suite's handoff-queue lease tests fail on this branch and on a clean `main` alike, and their count moves between runs on `main` too — they are not touched here.

Not covered: this was verified on macOS with bun 1.3.14 and vite 7.3.6, and against a deployment with no identity provider configured, so the cookie above was a stand-in for a real session rather than one.
