### PR TITLE
Validate timeoutMs on POST /computers/:botId/exec

### DIFF
--- a/server/src/computer/routes.ts
+++ b/server/src/computer/routes.ts
@@ -537,13 +537,27 @@ export function createComputerRoutes(
    * A command on the Bot's computer.
    *
    * Same shape as every other acting route: the gateway decides and records, this only shapes the
-   * request. `timeoutMs` is passed through and capped by the computer rather than here, so one place
-   * owns the limit.
+   * request. `timeoutMs` is validated here against the shell's own bounds (1s floor, 600s ceiling),
+   * so a NaN, an Infinity, a negative, or a ten-hour value answers 400 instead of travelling to the
+   * computer as a RangeError 500 or a run that outlasts the transport backstop.
    */
   routes.post("/:botId/exec", (context) =>
     act(context, (botId, actor, body, signal) => {
       if (typeof body?.command !== "string" || !body.command.trim()) {
         return { error: "A command is required." };
+      }
+      if (body.timeoutMs !== undefined) {
+        if (
+          typeof body.timeoutMs !== "number" ||
+          !Number.isInteger(body.timeoutMs) ||
+          body.timeoutMs < 1_000 ||
+          body.timeoutMs > 600_000
+        ) {
+          return {
+            error:
+              "timeoutMs must be a whole number of milliseconds between 1000 and 600000.",
+          };
+        }
       }
       // The fourth argument, like every other acting route. Without it the plumbing through
       // gateway.runCommand and into the shell's own abort listener was dead code, and Stop ended the

--- a/server/tests/computer-exec-timeout.test.ts
+++ b/server/tests/computer-exec-timeout.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import type { MiddlewareHandler } from "hono";
+import type { AppVariables } from "../src/auth/guards";
+import type { ComputerGateway } from "../src/computer/gateway";
+import type { PolicyStore } from "../src/computer/policy-store";
+import { createComputerRoutes } from "../src/computer/routes";
+
+function appWith(calls: { timeoutMs?: number }[]) {
+  const gateway = {
+    runCommand: async (
+      _botId: string,
+      _actor: unknown,
+      input: { command: string; timeoutMs?: number },
+    ) => {
+      calls.push({
+        ...(input.timeoutMs !== undefined
+          ? { timeoutMs: input.timeoutMs }
+          : {}),
+      });
+      return { output: "hi", timedOut: false, elapsedMs: 1 };
+    },
+  } as unknown as ComputerGateway;
+  const requireUser: MiddlewareHandler<{ Variables: AppVariables }> = async (
+    context,
+    next,
+  ) => {
+    context.set("actor", {
+      id: "user-1",
+      email: "user@openbot.test",
+      role: "admin",
+    });
+    await next();
+  };
+  return createComputerRoutes(
+    gateway,
+    {} as PolicyStore,
+    requireUser,
+    async () => true,
+  );
+}
+
+async function postExec(
+  app: ReturnType<typeof createComputerRoutes>,
+  body: unknown,
+) {
+  return app.request("http://openbot.test/bot-1/exec", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /:botId/exec timeoutMs", () => {
+  test("a valid timeout reaches the gateway", async () => {
+    const calls: { timeoutMs?: number }[] = [];
+    const response = await postExec(appWith(calls), {
+      command: "echo hi",
+      timeoutMs: 5000,
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual([{ timeoutMs: 5000 }]);
+  });
+
+  test("an absent timeout still runs with the computer default", async () => {
+    const calls: { timeoutMs?: number }[] = [];
+    const response = await postExec(appWith(calls), { command: "echo hi" });
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual([{}]);
+  });
+
+  test.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["a negative", -1],
+    ["zero", 0],
+    ["below the shell floor", 999],
+    ["above the shell ceiling", 600_001],
+    ["a ten-hour value", 36_000_000],
+    ["a fraction", 1500.5],
+    ["a string", "3000"],
+    ["null", null],
+  ])(
+    "rejects %s with 400 and never reaches the gateway",
+    async (_name, timeoutMs) => {
+      const calls: { timeoutMs?: number }[] = [];
+      const response = await postExec(appWith(calls), {
+        command: "echo hi",
+        timeoutMs,
+      });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error:
+          "timeoutMs must be a whole number of milliseconds between 1000 and 600000.",
+      });
+      expect(calls).toEqual([]);
+    },
+  );
+});


### PR DESCRIPTION
## What

`POST /:botId/exec` in `server/src/computer/routes.ts` passed any numeric `timeoutMs` straight to `gateway.runCommand`, whose 615s transport backstop exists to outlast the shell rather than enforce the limit. A NaN, Infinity, negative, fractional, or ten-hour value travelled to the computer, where `AbortSignal.timeout` threw a RangeError 500 or the run outlasted the backstop the gateway documents.

This validates `timeoutMs` against the shell's own bounds (whole milliseconds, 1000..600000) and answers `400 { error }` before the gateway decides and records — so the refusal is a caller error, not a failed action on the audit trail. Omitted timeouts still run with the computer default.

## Why it matters

Reliability and cost: unbounded shell runs are the most expensive thing a Bot can start, and a malformed timeout previously surfaced as a 500 or a run that outlived its transport. Twelve route-level cases now pin the contract.

## Verification

- New suite `server/tests/computer-exec-timeout.test.ts`: valid 5000 reaches the gateway; absent timeout runs with default; NaN, Infinity, negatives, zero, 999, 600001, 36M, fractions, strings, and null each answer 400 without reaching the gateway.
- `bun test server/tests/computer-exec-timeout.test.ts` — 12 pass.
- `bun run --filter server typecheck` — clean. Biome format + lint — clean.