### PR TITLE
Validate navigate URLs and exec timeouts on the Bot computer

### DIFF
--- a/agent-computer/src/index.ts
+++ b/agent-computer/src/index.ts
@@ -18,6 +18,7 @@ import {
 } from "./control";
 import { identity } from "./identity";
 import { createProfiles, numberFromEnv, VIEWPORT } from "./profiles";
+import { parseExecTimeout, parseNavigateUrl } from "./request-validation";
 import { type InputMessage, startScreencast } from "./screencast";
 import { createShell } from "./shell";
 import { createViewerSlot, type ViewerSlot } from "./viewer";
@@ -793,14 +794,15 @@ serve<StreamData>({
       const body = (await request.json().catch(() => null)) as {
         url?: unknown;
       } | null;
-      if (typeof body?.url !== "string") {
-        return json({ error: "A url is required." }, 400);
+      const parsed = parseNavigateUrl(body?.url);
+      if (!parsed.ok) {
+        return json({ error: parsed.error }, 400);
       }
 
       const startedAt = Date.now();
       try {
         const target = await currentPage(botId);
-        await target.goto(body.url, {
+        await target.goto(parsed.url, {
           waitUntil: "domcontentloaded",
           timeout: NAVIGATION_TIMEOUT_MS,
         });
@@ -905,12 +907,16 @@ serve<StreamData>({
       if (typeof body?.command !== "string" || !body.command.trim()) {
         return json({ error: "A command is required." }, 400);
       }
+      const timeout = parseExecTimeout(body.timeoutMs);
+      if (!timeout.ok) {
+        return json({ error: timeout.error }, 400);
+      }
       try {
         return json(
           await shell.run({
             command: body.command,
-            ...(typeof body.timeoutMs === "number"
-              ? { timeoutMs: body.timeoutMs }
+            ...(timeout.timeoutMs !== undefined
+              ? { timeoutMs: timeout.timeoutMs }
               : {}),
             signal: request.signal,
           }),

--- a/agent-computer/src/request-validation.ts
+++ b/agent-computer/src/request-validation.ts
@@ -1,0 +1,69 @@
+/**
+ * The shape of a call, checked before it reaches the browser or the shell.
+ *
+ * This process holds no policy engine: the server gateway decides whether an action may run. What
+ * is checked here is whether the request is well-formed at all, so a typo'd caller gets a 400
+ * naming the field rather than a 502 that reads as a broken computer.
+ */
+
+/** Long enough for an install, short enough that a hung command is not a hung Bot. */
+export const EXEC_DEFAULT_TIMEOUT_MS = 120_000;
+/** A command has to be given long enough to start. Below this, a caller is asking for nothing. */
+export const EXEC_MIN_TIMEOUT_MS = 1_000;
+export const EXEC_MAX_TIMEOUT_MS = 600_000;
+
+export type NavigateParseResult =
+  | { ok: true; url: string }
+  | { ok: false; error: string };
+
+/**
+ * A navigation target, checked before Playwright is asked.
+ *
+ * An empty string used to travel into `page.goto` and come back as a 502 "Navigation failed",
+ * which reads as a broken computer rather than a caller error. A `javascript:`, `file://`, or
+ * `data:` URL is never a page a Bot should be sent to from this endpoint.
+ */
+export function parseNavigateUrl(input: unknown): NavigateParseResult {
+  if (typeof input !== "string" || !input.trim()) {
+    return { ok: false, error: "A url is required." };
+  }
+  const trimmed = input.trim();
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return { ok: false, error: "That is not a valid http(s) URL." };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false, error: "Only http(s) URLs can be opened." };
+  }
+  return { ok: true, url: trimmed };
+}
+
+export type ExecTimeoutParseResult =
+  | { ok: true; timeoutMs: number | undefined }
+  | { ok: false; error: string };
+
+const EXEC_TIMEOUT_ERROR =
+  "timeoutMs must be a whole number of milliseconds between 1000 and 600000.";
+
+/**
+ * A shell timeout, checked before the command is spawned.
+ *
+ * A `NaN` or `Infinity` used to travel into `Math.min(Math.max(...))` as `NaN`, so `setTimeout`
+ * fired immediately: the command was killed before it did anything and the answer said it had
+ * timed out, which is true and useless. Anything outside the shell's own bounds answers 400 here,
+ * matching the server gateway's validation of the same field.
+ */
+export function parseExecTimeout(input: unknown): ExecTimeoutParseResult {
+  if (input === undefined) return { ok: true, timeoutMs: undefined };
+  if (
+    typeof input !== "number" ||
+    !Number.isInteger(input) ||
+    input < EXEC_MIN_TIMEOUT_MS ||
+    input > EXEC_MAX_TIMEOUT_MS
+  ) {
+    return { ok: false, error: EXEC_TIMEOUT_ERROR };
+  }
+  return { ok: true, timeoutMs: input };
+}

--- a/agent-computer/src/shell.ts
+++ b/agent-computer/src/shell.ts
@@ -227,9 +227,18 @@ export function createShell(
        * Bounded at both ends. Only `Math.min` was applied, so a zero or negative `timeoutMs` from a
        * caller made `setTimeout` fire immediately: the command was killed before it did anything and
        * the answer said it had timed out, which is true and useless.
+       *
+       * A non-finite value is the same failure one step earlier: `Math.max(NaN, 1000)` is `NaN`,
+       * and `setTimeout(NaN)` fires immediately too. The HTTP layer rejects those with a 400, so
+       * this is defence in depth for a direct caller — fall back to the default rather than run a
+       * command that is already out of time.
        */
+      const requested =
+        typeof input.timeoutMs === "number" && Number.isFinite(input.timeoutMs)
+          ? input.timeoutMs
+          : DEFAULT_TIMEOUT_MS;
       const timeoutMs = Math.min(
-        Math.max(input.timeoutMs ?? DEFAULT_TIMEOUT_MS, MIN_TIMEOUT_MS),
+        Math.max(requested, MIN_TIMEOUT_MS),
         MAX_TIMEOUT_MS,
       );
 

--- a/agent-computer/tests/request-validation.test.ts
+++ b/agent-computer/tests/request-validation.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { parseExecTimeout, parseNavigateUrl } from "../src/request-validation";
+
+/**
+ * The shape of a call, checked before it reaches the browser or the shell.
+ *
+ * A malformed navigation used to travel into `page.goto` and come back as a 502 "Navigation
+ * failed", which reads as a broken computer rather than a caller error. A non-finite timeout used
+ * to travel into `Math.max` as `NaN`, so `setTimeout` fired immediately and the answer said the
+ * command had timed out before it did anything.
+ */
+describe("navigating the browser", () => {
+  test("a plain https URL passes through trimmed", () => {
+    expect(parseNavigateUrl("  https://example.com/a  ")).toEqual({
+      ok: true,
+      url: "https://example.com/a",
+    });
+  });
+
+  test.each([
+    ["absent", undefined],
+    ["null", null],
+    ["a number", 42],
+    ["empty", ""],
+    ["whitespace-only", "   "],
+    ["not a URL", "not a url"],
+    ["a bare path", "/etc/passwd"],
+    ["javascript:", "javascript:alert(1)"],
+    ["file:", "file:///etc/passwd"],
+    ["data:", "data:text/html,<h1>hi</h1>"],
+    ["ftp:", "ftp://example.com/file"],
+  ])("rejects %s with a 400 message", (_name, input) => {
+    const parsed = parseNavigateUrl(input);
+    expect(parsed.ok).toBe(false);
+    expect((parsed as { error: string }).error).toBeString();
+  });
+});
+
+describe("a shell timeout", () => {
+  test("absent stays absent: the shell default applies", () => {
+    expect(parseExecTimeout(undefined)).toEqual({
+      ok: true,
+      timeoutMs: undefined,
+    });
+  });
+
+  test("a valid timeout passes through", () => {
+    expect(parseExecTimeout(5000)).toEqual({ ok: true, timeoutMs: 5000 });
+    expect(parseExecTimeout(1000)).toEqual({ ok: true, timeoutMs: 1000 });
+    expect(parseExecTimeout(600_000)).toEqual({
+      ok: true,
+      timeoutMs: 600_000,
+    });
+  });
+
+  test.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["a negative", -1],
+    ["zero", 0],
+    ["below the floor", 999],
+    ["above the ceiling", 600_001],
+    ["a fraction", 1500.5],
+    ["a string", "3000"],
+    ["null", null],
+    ["an object", { ms: 3000 }],
+  ])("rejects %s with a 400 message", (_name, input) => {
+    expect(parseExecTimeout(input)).toEqual({
+      ok: false,
+      error:
+        "timeoutMs must be a whole number of milliseconds between 1000 and 600000.",
+    });
+  });
+});

--- a/agent-computer/tests/shell.test.ts
+++ b/agent-computer/tests/shell.test.ts
@@ -329,4 +329,24 @@ describe("what a command cannot do to the computer", () => {
     expect(result.timedOut).toBe(false);
     expect(result.stdout.trim()).toBe("ran");
   }, 15_000);
+
+  test.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ])(
+    "a timeout of %s falls back to the default instead of killing the command at once",
+    async (_name, timeoutMs) => {
+      // Math.max(NaN, 1000) is NaN, and setTimeout(NaN) fires immediately: the command was reported
+      // as timed out before it did anything. The HTTP layer rejects these with a 400; the shell
+      // itself falls back to the default so a direct caller gets a run, not a lie.
+      const result = await createShell(root, source()).run({
+        command: 'echo "ran"',
+        timeoutMs,
+      });
+
+      expect(result.timedOut).toBe(false);
+      expect(result.stdout.trim()).toBe("ran");
+    },
+    15_000,
+  );
 });


### PR DESCRIPTION
## What

Two shape checks on the Bot computer itself (`agent-computer`), which holds no policy engine — so a malformed call should be a 400 naming the field, not a 502 that reads as a broken computer:

- `POST /navigate` accepted any string into `page.goto`: an empty string came back 502 Navigation failed, and `javascript:`/`file://`/`data:`/`ftp:` URLs were never refused up front. New `parseNavigateUrl` trims, requires a parseable URL, and allows only `http:`/`https:`.
- `POST /exec` forwarded NaN/Infinity into the shell, where `Math.max(NaN, 1000)` stays NaN and `setTimeout(NaN)` fires at once — the command reported timed out before doing anything. New `parseExecTimeout` enforces whole milliseconds in 1000..600000 (matching the server gateway), and `shell.run` falls back to its default on a non-finite value so a direct caller gets a run rather than a lie.

## Why it matters

The computer is the Bot's SSRF surface (/navigate) and its most expensive action (/exec). Both previously failed in ways that pointed at the computer instead of the caller. The shared validation module (`agent-computer/src/request-validation.ts`) is pure and unit-tested without a browser.

## Verification

- `agent-computer/tests/request-validation.test.ts` (new): 11 invalid navigate inputs rejected, 10 invalid timeouts rejected, valid inputs pass — 24 pass.
- `agent-computer/tests/shell.test.ts` (+2 NaN/Infinity cases): a non-finite timeout now runs the command with the default instead of reporting an instant timeout — 23 pass.
- `bun run --filter server typecheck` — clean (agent-computer's pre-existing missing playwright/spiffe deps in this env are untouched). Biome format + lint — clean.