### PR TITLE
Write the desktop .env readable only by its owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### The desktop app writes its `.env` readable only by its owner
+
+The desktop `.env` holds `KEY_ENCRYPTION_KEY` and every minted token, and those are now long-lived:
+the first start writes them and every later start reads them back. It was created at the default
+umask (`0644`), so on a shared macOS or Linux machine another local user could read the vault key off
+disk. The file is now narrowed to `0600` after it is written. Windows has no equivalent mode and its
+single-user desktop profile is already the boundary, so the change is Unix-only.
+
 ### The desktop app stops adding a banner to `.env` on every start
 
 `env::write` keeps the lines it did not write, and its own header comment is one of them, so each

--- a/desktop/src-tauri/src/env.rs
+++ b/desktop/src-tauri/src/env.rs
@@ -306,7 +306,20 @@ pub fn write(path: &Path, owned: &BTreeMap<String, String>) -> std::io::Result<(
         out.push_str(&format!("{key}={value}\n"));
     }
 
-    std::fs::write(path, out)
+    std::fs::write(path, &out)?;
+
+    // The file holds `KEY_ENCRYPTION_KEY` and every minted token, and those are now long-lived: the
+    // first start writes them and every later start reads them back. `fs::write` creates the file at
+    // the process umask, which is `0644` by default, so on a shared macOS or Linux box another local
+    // user could read the vault key. Narrow it to the owner. Windows has no equivalent mode, and its
+    // single-user desktop profile is already the boundary, so this is Unix-only.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -395,6 +408,26 @@ HTTPS_PROXY=http://proxy:8080
         assert!(text.contains("HTTPS_PROXY=http://proxy:8080"));
         assert_eq!(text.matches("# our proxy needs this").count(), 1);
         assert_eq!(text.matches(BANNER).count(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_written_file_is_readable_only_by_its_owner() {
+        // It holds KEY_ENCRYPTION_KEY and every minted token, so another local user must not be able
+        // to read it off a shared machine.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("openbot-env-perms-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".env");
+
+        let mut owned = BTreeMap::new();
+        owned.insert("KEY_ENCRYPTION_KEY".to_string(), "abc=".to_string());
+        write(&path, &owned).unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(mode, 0o600);
     }
 
     #[test]


### PR DESCRIPTION
## What this changes

The desktop `.env` (`desktop/src-tauri/src/env.rs`) holds `KEY_ENCRYPTION_KEY` and every minted token. Since #415 those secrets are long-lived — the first start writes them, every later start reads them back — which raises the stakes of how the file is written. `std::fs::write` creates it at the process umask (`0644` by default), so on a shared macOS/Linux machine another local user could read the vault key off disk.

After writing, the file is now narrowed to `0600` (owner read/write only). Windows has no equivalent mode and its single-user desktop profile is already the boundary, so the `set_permissions` call is `#[cfg(unix)]`.

Surfaced during the #415 review as a pre-existing weakness heightened by making the secrets persistent.

## Where it runs
- **New state that outlives a request?** None. It tightens the mode of a file the desktop shell already writes.
- **Second replica / serialised / fanned out / new listener?** N/A — desktop-only, local file.

## Boundary and audit
- No gateway path, no acting call, nothing from the client. A local filesystem permission only.

## Proof
- New `#[cfg(unix)]` test `the_written_file_is_readable_only_by_its_owner` asserts `mode & 0o777 == 0o600` after `write`.
- No local Rust toolchain here, so the Desktop CI build (Linux/macOS/Windows) is the compile+test gate.