### PR TITLE
Stop the local stack with one command, computers included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### One command to stop what `start.sh` started
+
+Stopping the local stack meant four commands read off the end of a successful start, and the one
+easiest to miss was the one that mattered: a Bot's computer is made by the supervisor rather than by
+compose, so `docker compose down` left a Chromium running per Bot. `bash scripts/stop.sh` stops the
+app, the routine worker, the API server, the compose services and every Bot computer, in that order,
+and is safe to rerun. It kills a port holder only once that process has identified itself as
+OpenBot, so an unrelated process on 3010 is named and left alone rather than killed. Nothing is
+deleted: the database, the Bots' files and their browser profiles are volumes. `--keep-computers`
+leaves the browsers signed in.
+
 ## 0.0.8
 
 ### A desktop shell that installs OpenBot and then becomes it

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ A Bot is any endpoint speaking [AG-UI](https://github.com/ag-ui-protocol/ag-ui),
 
 `scripts/start.sh` starts Docker services, applies migrations, starts the API server on port 3001, starts the app on port 3010, and checks that the services answer their own health routes before printing next steps.
 
+`scripts/stop.sh` takes the same things down, including each Bot's computer, which compose does not own. Nothing is deleted: the database, the Bots' files and their browser profiles are volumes.
+
 ## Deploy it
 
 One image carries the app, the API, the browser the Bots drive, and optionally PostgreSQL. Same
@@ -334,7 +336,7 @@ bun run --filter server db:generate
 bun run --filter server db:migrate
 ```
 
-Use `bash scripts/start.sh` for the whole stack. Use `bun run dev` only when you want the app and server without the Docker Bots and computers.
+Use `bash scripts/start.sh` for the whole stack and `bash scripts/stop.sh` to take it down. Use `bun run dev` only when you want the app and server without the Docker Bots and computers.
 
 ## Documentation
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -29,6 +29,8 @@ bash scripts/start.sh
 
 Use `bash scripts/start.sh` for the full local stack. It starts Docker services, applies migrations, starts the API server and app, and verifies health routes.
 
+Use `bash scripts/stop.sh` to take it down: the app, the routine worker, the API server, the Docker services, and each Bot's computer, which the supervisor makes rather than compose and which therefore outlives `docker compose down`. Pass `--keep-computers` to leave those browsers signed in. Nothing is deleted either way.
+
 Use `bun run dev` only when you want the app and API server without starting the Docker Bots and computers.
 
 | Service           | Port                       |

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -394,10 +394,9 @@ Try:
 
 Logs: $LOGS
   Routine sweep worker: $LOGS/worker.log
-Stop the routine worker: pkill -f 'bun worker/src/index.ts'
-Stop Docker services: docker compose down
-  A Bot's computer is made by the supervisor rather than by compose, so it keeps running:
-  docker rm -f \$(docker ps -q --filter label=openbot.supervisor=true)
-  Its files and its browser profile are volumes and survive either way.
-Stop host app/server: kill the processes using ports $APP_PORT and $SERVER_PORT
+
+Stop all of it: bash scripts/stop.sh
+  The app, the worker, the API server, the Docker services, and each Bot's computer, which compose
+  does not own because the supervisor makes it. Pass --keep-computers to leave the browsers signed
+  in. Nothing is deleted either way: the database, the files and the browser profiles are volumes.
 EOF

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# Stop everything `scripts/start.sh` started, in the reverse order it started them.
+# Safe to rerun: anything already stopped is reported and skipped.
+#
+# Four things run, and they are stopped in this order so nothing is left calling something that has
+# gone: the app, then the routine worker, then the API server, then Docker. The Bot computers come
+# last because they are made by the supervisor rather than by compose, so `docker compose down`
+# leaves them running and they are the heaviest thing here, one Chromium each.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+ROOT="$PWD"
+
+KEEP_COMPUTERS=false
+for arg in "$@"; do
+  case "$arg" in
+    --keep-computers) KEEP_COMPUTERS=true ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: bash scripts/stop.sh [--keep-computers]
+
+Stops the app, the routine worker, the API server, the Docker services, and each Bot's computer.
+
+  --keep-computers  Leave the Bot computers running, so their browsers stay signed in and warm.
+                    Their files and browser profiles are Docker volumes and survive either way.
+EOF
+      exit 0
+      ;;
+    *)
+      printf '\033[31m%s\033[0m\n' "Unknown argument: $arg. Try --help."
+      exit 1
+      ;;
+  esac
+done
+
+# The environment first, then .env, then the default: the same resolution order start.sh uses, so a
+# port configured there is the port stopped here. A missing .env is not an error for stopping —
+# the defaults still find whatever a previous run left behind.
+setting() {
+  local name="$1" fallback="$2" value="${!1:-}"
+  if [ -z "$value" ] && [ -f "$ROOT/.env" ]; then
+    value="$(grep -E "^$name=" "$ROOT/.env" | tail -1 | cut -d= -f2- | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/")"
+  fi
+  printf '%s' "${value:-$fallback}"
+}
+
+APP_PORT="$(setting APP_PORT 3010)"
+SERVER_PORT="$(setting SERVER_PORT 3001)"
+
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '\033[31m%s\033[0m\n' "$1"; }
+info()  { printf '\033[2m%s\033[0m\n' "$1"; }
+
+holder() {
+  lsof -nP -iTCP:"$1" -sTCP:LISTEN -Fcn 2>/dev/null | awk '/^c/{c=substr($0,2)} /^n/{print c" ("substr($0,2)")"; exit}' || true
+}
+
+# Does whatever holds this port answer as OpenBot, rather than merely answer?
+#
+# The same question start.sh asks before starting, asked here for the opposite reason. Starting on
+# an occupied port is a failed run; killing the occupant of a port is somebody else's editor server
+# gone. So a port holder is only killed once it has identified itself, and is otherwise named and
+# left alone.
+identifies_as_openbot() {
+  local port="$1" name="$2"
+  case "$name" in
+    server)
+      curl -fsS --max-time 3 "http://localhost:$port/api/copilotkit/info" 2>/dev/null \
+        | grep -q '"licenseStatus"'
+      ;;
+    app)
+      curl -fsS --max-time 3 "http://localhost:$port/" 2>/dev/null \
+        | grep -qi '<title>[^<]*OpenBot'
+      ;;
+  esac
+}
+
+# Stop the process listening on a port, once it has proved to be ours.
+#
+# SIGTERM first, then SIGKILL for anything still holding the port two seconds later: bun and vite
+# both exit on the first signal, but a process wedged mid-request would otherwise keep the port and
+# make the next start.sh refuse it.
+stop_port() {
+  local port="$1" name="$2" who pids
+  who="$(holder "$port")"
+  if [ -z "$who" ]; then
+    info "  $name: not running on $port"
+    return 0
+  fi
+  if ! identifies_as_openbot "$port" "$name"; then
+    red "  $name: port $port is held by something that is not OpenBot: $who"
+    red "  Left it alone. Stop it yourself if it is in the way."
+    return 0
+  fi
+  pids="$(lsof -t -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+  [ -z "$pids" ] && { info "  $name: not running on $port"; return 0; }
+  # shellcheck disable=SC2086
+  kill $pids 2>/dev/null || true
+  sleep 2
+  pids="$(lsof -t -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+  if [ -n "$pids" ]; then
+    # shellcheck disable=SC2086
+    kill -9 $pids 2>/dev/null || true
+  fi
+  green "  $name: stopped ($who)"
+}
+
+echo
+echo "OpenBot"
+echo "======="
+
+info "1/4  App"
+stop_port "$APP_PORT" app
+
+info "2/4  Routine worker"
+# The same pattern start.sh starts it with, and it has to stay that specific: a bare `bun
+# src/index.ts` matches the server, computer and supervisor containers on a Linux host too.
+if pgrep -f "bun worker/src/index.ts" >/dev/null 2>&1; then
+  pkill -f "bun worker/src/index.ts" || true
+  green "  worker: stopped"
+else
+  info "  worker: not running"
+fi
+
+info "3/4  API server"
+stop_port "$SERVER_PORT" server
+
+info "4/4  Docker"
+if docker compose ps --quiet 2>/dev/null | grep -q .; then
+  docker compose down >/dev/null 2>&1
+  green "  compose services: stopped"
+else
+  info "  compose services: not running"
+fi
+
+COMPUTERS="$(docker ps -q --filter label=openbot.supervisor=true 2>/dev/null || true)"
+if [ -z "$COMPUTERS" ]; then
+  info "  Bot computers: none running"
+elif [ "$KEEP_COMPUTERS" = "true" ]; then
+  info "  Bot computers: left running ($(printf '%s\n' "$COMPUTERS" | wc -l | tr -d ' ')), as asked"
+else
+  # shellcheck disable=SC2086
+  docker rm -f $COMPUTERS >/dev/null 2>&1 || true
+  green "  Bot computers: removed ($(printf '%s\n' "$COMPUTERS" | wc -l | tr -d ' '))"
+fi
+
+cat <<EOF
+
+$(green "Stopped.")
+
+Nothing was deleted. PostgreSQL, each Bot's files and each Bot's browser profile are Docker
+volumes, so channels, credentials and signed-in sessions are all still there next time.
+
+Start again: bash scripts/start.sh
+EOF


### PR DESCRIPTION
## What this changes

Adds `scripts/stop.sh`, the counterpart to `scripts/start.sh`.

Starting the stack is one command. Stopping it was four, printed at the end of a successful start,
and the one easiest to skip was the one that mattered: a Bot's computer is made by the supervisor
rather than by compose, so `docker compose down` returns and leaves a Chromium running per Bot. On a
laptop with other Docker work on it, that is the difference between a machine that has memory and
one that does not.

`bash scripts/stop.sh` stops the app, the routine worker, the API server, the compose services and
every Bot computer, in the reverse of the order `start.sh` brought them up so nothing is left calling
something that has gone. It is safe to rerun: anything already stopped is reported and skipped.
`--keep-computers` leaves those browsers running and signed in.

Two decisions worth naming:

- **A port holder is killed only once it has identified itself.** `stop.sh` reuses `start.sh`'s
  `identifies_as_openbot` check. Starting on an occupied port is a failed run; killing the occupant
  of a port is somebody else's editor server gone. Anything on 3010 or 3001 that does not answer as
  OpenBot is named and left alone.
- **SIGTERM, then SIGKILL after two seconds** for anything still holding the port. Bun and vite both
  exit on the first signal, but a process wedged mid-request would otherwise keep the port and make
  the next `start.sh` refuse it.

Nothing is deleted. PostgreSQL, each Bot's files and each Bot's browser profile are volumes, so
channels, credentials and signed-in sessions are all still there next time.

`start.sh`'s epilogue now points at the one command instead of listing the four, and README and
`docs/development.md` say the same in the places they already describe starting.

## Where it runs

This is a local development script. It runs on a laptop, against one machine's own stack, and is not
part of a deployment: nothing in the server, the app, the worker or any image changed.

- [ ] **New state that outlives a request?** None. No process reads or writes anything but its own
      signals.
- [ ] **What happens on the second replica?** Not applicable. The script stops processes on the
      machine it runs on, by port and by Docker label, and is never deployed. Behind a load balancer
      there is no `scripts/` to run.
- [ ] **Anything serialised?** Nothing. Two concurrent runs would both send signals to processes that
      are already going away, and the second reports "not running" rather than failing, which is the
      same path as the rerun case that is tested below.
- [ ] **Anything fanned out to a browser?** No.
- [ ] **New listener, port, or schedule?** None. It opens no port and schedules nothing. It reads
      `APP_PORT` and `SERVER_PORT` through the same environment-then-`.env`-then-default resolution
      `start.sh` uses, so a port moved in one place is the port stopped in the other.

## Boundary and audit

- [x] Every acting call still goes through the gateway: resolve, decide, audit, then act. No gateway
      path is touched. The script acts on host processes and containers from a terminal, which is
      outside the gateway's subject the same way `docker compose down` always was.
- [x] New refusals and new failures each write a row. No new refusals or failures exist in the
      product. Removing a Bot computer is what `/admin/computers` already offers and what the epilogue
      already told people to do by hand; the volumes it leaves behind are untouched.
- [x] Nothing new is trusted from the client that the server can resolve itself. No client, no server
      change.

## Changelog

- [x] A line in `CHANGELOG.md` under `Unreleased`.

## Proof

`shellcheck scripts/stop.sh scripts/start.sh` clean, `bash -n` clean on both, `bunx biome format .`
and `bunx biome lint --error-on-warnings .` clean, `bun test tests/compose.test.ts` 7 pass.

Run against a live stack — app, worker, server, five compose services and one Bot computer up:

```
OpenBot
=======
1/4  App
  app: stopped (node ([::1]:3010))
2/4  Routine worker
  worker: stopped
3/4  API server
  server: stopped (bun (*:3001))
4/4  Docker
  compose services: stopped
  Bot computers: removed (1)

Stopped.
```

After it, both ports free, `docker compose ps -q` empty, and
`docker ps -q --filter label=openbot.supervisor=true` empty. Rerun immediately after, which is the
idempotency path:

```
1/4  App
  app: not running on 3010
2/4  Routine worker
  worker: not running
3/4  API server
  server: not running on 3001
4/4  Docker
  compose services: not running
  Bot computers: none running
```

All seven volumes still present afterwards, including `openbot_postgres-data` and the
`openbot-profile-general-assistant` browser profile.

Not exercised: the branch that finds a non-OpenBot process on 3010 and leaves it alone. It is the
same `identifies_as_openbot` call `start.sh` has always made before refusing an occupied port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)