### PR TITLE
Block credential fields spelled with the `x-` header prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### An MCP call carrying `x-api-key` is stopped the same as one carrying `api-key`
+
+The check that keeps credentials out of MCP tool arguments compared each argument name against a
+list, and `api-key` was on it while `x-api-key` was not -- so the spelling that is more obviously a
+credential header was the one that went out. `x-` is the conventional prefix for a non-standard
+header and says nothing about the value, so it is now dropped before the comparison. The same pass
+adds the spellings of names already on the list that were missing from it: `passwd` and `pwd` for
+`password`, `auth_token` and `bearer_token` and `session_token` for `token`, `api_secret` and
+`secret_key` and `signing_key` for `secret`, and `ssh_key` for `private_key`. Nothing new counts as
+a credential: an argument named `x_axis`, `token_count`, `max_tokens` or `secretary` is passed as
+before.
+
 ### One command to stop what `start.sh` started
 
 Stopping the local stack meant four commands read off the end of a successful start, and the one

--- a/server/src/plugins/content-governance.ts
+++ b/server/src/plugins/content-governance.ts
@@ -26,24 +26,43 @@ export type ToolArgumentInspection =
       findings: SensitiveArgumentFinding[];
     };
 
+// Each entry is a spelling of a field already named here, not a widening of what counts as a
+// credential: `passwd` is `password`, `api_secret` is `secret`, `ssh_key` is `private_key`. A tool
+// argument carrying one of these carries the same thing under a different name.
 const sensitiveFieldNames = new Set([
   "access_token",
   "accesstoken",
   "api_key",
+  "api_secret",
   "apikey",
+  "apisecret",
+  "auth_token",
   "authorization",
+  "authtoken",
+  "bearer_token",
+  "bearertoken",
   "client_secret",
   "clientsecret",
   "credential",
   "credentials",
   "id_token",
   "idtoken",
+  "passwd",
   "password",
   "private_key",
   "privatekey",
+  "pwd",
   "refresh_token",
   "refreshtoken",
   "secret",
+  "secret_key",
+  "secretkey",
+  "session_token",
+  "sessiontoken",
+  "signing_key",
+  "signingkey",
+  "ssh_key",
+  "sshkey",
   "token",
 ]);
 
@@ -61,7 +80,12 @@ const MAX_FINDINGS = 20;
 const MAX_STRING_LENGTH = 64 * 1024;
 
 function normalizedFieldName(value: string): string {
-  return value.toLowerCase().replace(/[-.\s]/g, "_");
+  const normalized = value.toLowerCase().replace(/[-.\s]/g, "_");
+  // `x_` is the conventional prefix for a non-standard header and says nothing about the value, so
+  // `x-api-key` is the same field as `api-key`. Without this the list caught `api-key` -- which
+  // normalises exactly onto `api_key` -- and let through the spelling that is more obviously a
+  // credential, not less.
+  return normalized.startsWith("x_") ? normalized.slice(2) : normalized;
 }
 
 function categoryForValue(value: string): SensitiveArgumentCategory | null {

--- a/server/tests/content-governance.test.ts
+++ b/server/tests/content-governance.test.ts
@@ -110,4 +110,57 @@ describe("MCP tool argument content governance", () => {
       findings: [],
     });
   });
+
+  test("blocks a credential field carrying the conventional non-standard header prefix", () => {
+    const secret = "do-not-copy-this-value";
+    const result = inspectToolArguments({
+      headers: { "x-api-key": secret },
+    });
+
+    expect(result).toEqual({
+      safe: false,
+      reason: "sensitive_content",
+      findings: [{ category: "credential_field", path: "$.headers.x-api-key" }],
+    });
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  test.each([
+    "X-API-Key",
+    "x-auth-token",
+    "authToken",
+    "auth_token",
+    "api_secret",
+    "bearer_token",
+    "passwd",
+    "pwd",
+    "secret_key",
+    "session_token",
+    "signing_key",
+    "ssh_key",
+  ])("blocks %s as a spelling of a name already listed", (field) => {
+    const result = inspectToolArguments({ [field]: "do-not-copy-this-value" });
+
+    expect(result).toMatchObject({ safe: false, reason: "sensitive_content" });
+    expect(result).toMatchObject({
+      findings: [{ category: "credential_field" }],
+    });
+  });
+
+  test.each([
+    "query",
+    "url",
+    "path",
+    "token_count",
+    "max_tokens",
+    "tokenizer",
+    "x_axis",
+    "x_offset",
+    "xml",
+    "secretary",
+  ])("allows %s, which only resembles a credential name", (field) => {
+    expect(inspectToolArguments({ [field]: "ordinary value" })).toEqual({
+      safe: true,
+    });
+  });
 });


### PR DESCRIPTION
## What is wrong

`inspectToolArguments` (added in #436, whose job is to keep credential material out of MCP tool
arguments) normalises each argument name -- lowercase, then `-`, `.` and whitespace folded to `_` --
and compares the result against `sensitiveFieldNames`. `api-key` normalises exactly onto `api_key`
and is caught. `x-api-key` normalises onto `x_api_key`, which is not on the list, and goes out.

The spelling that most obviously names a credential is the one that is not blocked.

Measured on `main` before the change, via `inspectToolArguments({ [name]: "value" })`:

| argument name | `main` | with this change |
| --- | --- | --- |
| `api-key` | blocked | blocked |
| `x-api-key` | **passes** | blocked |
| `X-API-Key` | **passes** | blocked |
| `x-auth-token` | **passes** | blocked |
| `auth_token`, `authToken` | **passes** | blocked |
| `bearer_token`, `session_token` | **passes** | blocked |
| `passwd`, `pwd` | **passes** | blocked |
| `api_secret`, `secret_key`, `signing_key` | **passes** | blocked |
| `ssh_key` | **passes** | blocked |

## The change

Two parts, both narrow.

1. `normalizedFieldName` drops a leading `x_`. `x-` is the conventional prefix for a non-standard
   header; it says nothing about the value, so `x-api-key` is the same field as `api-key`.
2. `sensitiveFieldNames` gains the spellings of names it already carries: `passwd` and `pwd` for
   `password`, `auth_token` / `authtoken` / `bearer_token` / `bearertoken` / `session_token` /
   `sessiontoken` for `token`, `api_secret` / `apisecret` / `secret_key` / `secretkey` /
   `signing_key` / `signingkey` for `secret`, and `ssh_key` / `sshkey` for `private_key`.

Neither part widens what counts as a credential. Every added entry is another name for something
already on the list, and the prefix rule strips only a prefix that carries no meaning of its own.

## Verification

`bun test server/tests/content-governance.test.ts`

- With `server/src/plugins/content-governance.ts` reverted to `main` and only the tests applied:
  **13 fail, 18 pass**.
- With the change: **31 pass, 0 fail**.

Ten names that merely resemble credential names are pinned as still allowed -- `query`, `url`,
`path`, `token_count`, `max_tokens`, `tokenizer`, `x_axis`, `x_offset`, `xml`, `secretary` -- and
pass both before and after, so the guard against over-blocking is a real one rather than a
restatement of the new behaviour.

`bun run --filter server typecheck` and `bunx biome check` on both touched files are clean.
