### PR TITLE
Trim the deployment directory pasted into the desktop setup screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A deployment directory pasted with a stray space goes where it says
+
+The desktop setup screen asks where OpenBot should live, enables Start once that box is not blank
+after trimming, and then sent the untrimmed string — the same trap the API URL, the gateway URL, the
+intelligence key and the model key were taken out of, and this is the one of the five that is a
+place on disk rather than a credential. A path copied with the space the selection picked up, or
+with the newline a copied line carries, was used whole. A trailing space made a second directory
+beside the one everything else means: the tray's Stop and the next launch both ask for the default
+path, which has no space in it, so a person was left with a deployment nothing on screen could
+reach. A leading space was worse, because a path starting with a space does not start with a
+separator — it stopped being absolute, and the deployment was laid out relative to wherever the
+window happened to be running from. The path is trimmed at both ends now. Spaces inside it are part
+of a directory's name and are left alone.
+
 ### One command to stop what `start.sh` started
 
 Stopping the local stack meant four commands read off the end of a successful start, and the one

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -120,7 +120,7 @@ async fn start_stack(
     api_key: String,
     openai_api_key: String,
 ) -> Result<(), String> {
-    let root = PathBuf::from(root);
+    let root = stack::root_from(&root);
 
     // The installer does not carry the deployment; it fetches one. Skipped when the recorded
     // version already matches, so a restart is not a download.
@@ -285,7 +285,7 @@ async fn start_stack(
 /// of everything their Bot had logged into.
 #[tauri::command]
 fn stop_stack(app: tauri::AppHandle, root: String) -> Result<(), String> {
-    stop_everything(&app, &PathBuf::from(&root))
+    stop_everything(&app, &stack::root_from(&root))
 }
 
 /// Take the whole stack down: the host processes, anything left over, and the containers.
@@ -395,7 +395,7 @@ fn show_setup(app: tauri::AppHandle) -> Result<(), String> {
 /// an answer on the port says one is running now.
 #[tauri::command]
 fn already_running(root: String) -> bool {
-    let root = PathBuf::from(&root);
+    let root = stack::root_from(&root);
     if deployment::installed(&root).is_none() {
         return false;
     }

--- a/desktop/src-tauri/src/stack.rs
+++ b/desktop/src-tauri/src/stack.rs
@@ -563,6 +563,24 @@ pub fn default_root() -> PathBuf {
     dirs_home().join("OpenBot")
 }
 
+/// The deployment directory somebody typed, as a path.
+///
+/// Trimmed, the way the four settings entered beside it on the same screen already are. That screen
+/// enables Start on `root.trim() !== ""` and then sends the untrimmed string, so a path pasted with
+/// the space the selection picked up, or with the newline a copied line carries, arrives here whole
+/// -- and this is the one of the five values that is not a credential but a place on disk.
+///
+/// A trailing space makes a second directory beside the one everything else means: the tray's Stop
+/// and the next launch both ask `default_root`, which has no space in it, so a person is left with
+/// a deployment nothing on screen can reach. A leading one is worse, because a path that begins
+/// with a space does not begin with a separator: it stops being absolute, and the whole deployment
+/// is laid out relative to wherever the window happens to be running from.
+///
+/// Only the ends. A space inside a path is part of a directory's name and stays where it is.
+pub fn root_from(typed: &str) -> PathBuf {
+    PathBuf::from(typed.trim())
+}
+
 fn dirs_home() -> PathBuf {
     std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
@@ -632,6 +650,50 @@ mod tests {
         .unwrap();
         assert!(deployment_problem(&dir).is_none());
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_deployment_directory_pasted_with_a_stray_space_is_the_one_it_names() {
+        // The fifth value on the setup screen that trimming missed. The screen enables Start on
+        // `root.trim() !== ""` and then sends the untrimmed string, which is exactly what the API
+        // URL, the gateway URL, the intelligence key and the model key were rescued from.
+        //
+        // A trailing space is a second directory beside the one everything else means: the tray's
+        // Stop and the next launch both ask `default_root`, which has no space in it. A leading one
+        // is worse, because a path that begins with a space does not begin with a separator: the
+        // whole deployment stops being absolute and lands under wherever the window is running
+        // from.
+        assert_eq!(
+            root_from("  /home/me/OpenBot  "),
+            PathBuf::from("/home/me/OpenBot")
+        );
+        assert_eq!(
+            root_from("/home/me/OpenBot\n"),
+            PathBuf::from("/home/me/OpenBot")
+        );
+        assert!(
+            root_from(" /home/me/OpenBot").has_root(),
+            "a leading space turned an absolute path into a relative one"
+        );
+    }
+
+    #[test]
+    fn a_space_inside_the_path_is_part_of_the_path() {
+        // Only the ends. "Documents and Settings" is a directory, and a person whose home has a
+        // space in it must still be able to say where OpenBot lives.
+        assert_eq!(
+            root_from("/home/me/My Files/OpenBot"),
+            PathBuf::from("/home/me/My Files/OpenBot")
+        );
+        assert_eq!(
+            root_from(r"C:\Users\me\Open Bot"),
+            PathBuf::from(r"C:\Users\me\Open Bot")
+        );
+        // And an ordinary path is handed back exactly as it was.
+        assert_eq!(
+            root_from("/home/me/OpenBot"),
+            PathBuf::from("/home/me/OpenBot")
+        );
     }
 
     #[test]


### PR DESCRIPTION
#417 trimmed four of the values entered on the desktop setup screen. There is a fifth on the same
screen — **Where OpenBot lives** — and it is still sent untrimmed, gated by the same `trim()` that
prompted that fix.

## The gap

`desktop/src/App.tsx` enables Start on the trimmed value and sends the raw one:

```tsx
disabled={busy || apiKey.trim() === "" || modelKey.trim() === "" || root.trim() === ""}
```

```tsx
await invoke("start_stack", { root, apiUrl, gatewayWsUrl: wsUrl, apiKey, openaiApiKey: modelKey });
```

Three commands take that string and make a path of it verbatim:

```rust
// start_stack
let root = PathBuf::from(root);
// stop_stack
stop_everything(&app, &PathBuf::from(&root))
// already_running
let root = PathBuf::from(&root);
```

This one is not a credential, it is a place on disk, so the two ways it goes wrong are different
from the credential case:

- **A trailing space** makes a second directory beside the one everything else means. The tray's
  Stop calls `default_root()` and the next launch is offered `default_root()` again, and neither has
  the space in it — so the deployment that was laid down is one nothing on screen reaches: Stop runs
  `compose down` in the wrong tree, and starting again re-fetches the whole release into the other
  directory.
- **A leading space** is worse. A path that begins with a space does not begin with a separator, so
  `" /home/me/OpenBot"` is not absolute — `Path::components` reads it as `" "`, `"Users"`, … and the
  deployment is laid out relative to wherever the window is running from.

A path picks these up the same way a key does: copied out of a document, or dragged in with the
newline at the end of the line.

## The change

One trim, at the point the typed string becomes a path, named so all three commands share it. Both
ends only — a space inside a path is part of a directory's name.

## Failing first

`main` has no such function, so the fail-before run implements `root_from` as `main`'s own rule,
which is `PathBuf::from(typed)` at each of the three call sites, and nothing else:

```rust
pub fn root_from(typed: &str) -> PathBuf {
    PathBuf::from(typed)
}
```

```
$ RUSTUP_TOOLCHAIN=1.98.0-x86_64-pc-windows-msvc cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib stack::
running 15 tests
test stack::tests::a_space_inside_the_path_is_part_of_the_path ... ok
...
test stack::tests::a_deployment_directory_pasted_with_a_stray_space_is_the_one_it_names ... FAILED

---- stack::tests::a_deployment_directory_pasted_with_a_stray_space_is_the_one_it_names stdout ----

thread 'stack::tests::a_deployment_directory_pasted_with_a_stray_space_is_the_one_it_names' (34928) panicked at src\stack.rs:655:9:
assertion `left == right` failed
  left: "  /home/me/OpenBot  "
 right: "/home/me/OpenBot"

failures:
    stack::tests::a_deployment_directory_pasted_with_a_stray_space_is_the_one_it_names

test result: FAILED. 14 passed; 1 failed; 0 ignored; 0 measured; 72 filtered out; finished in 4.04s
```

With `typed.trim()`:

```
$ RUSTUP_TOOLCHAIN=1.98.0-x86_64-pc-windows-msvc cargo test --manifest-path desktop/src-tauri/Cargo.toml
test result: ok. 87 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.08s
```

85 of those 87 are the suite as it stands on `main`, all still passing.

## Against over-correcting

`a_space_inside_the_path_is_part_of_the_path` pins what must still come through untouched, and it
**passed in the failing run above as well as after the change** — the trim must not reach inside the
path:

- `/home/me/My Files/OpenBot` — a home directory with a space in it.
- `C:\Users\me\Open Bot` — the same on Windows.
- `/home/me/OpenBot` — an ordinary path, handed back exactly as it was.

The trade this does make is that a directory whose *name* genuinely ends in a space can no longer be
named from this box. That is the same trade #417 made for the credentials, for the same reason: the
screen's own enable check already treats the trimmed value as the value, so a person who typed one
was going to be told the button was available and then given something else.

## Verified with

```
RUSTUP_TOOLCHAIN=1.98.0-x86_64-pc-windows-msvc cargo test   --manifest-path desktop/src-tauri/Cargo.toml
RUSTUP_TOOLCHAIN=1.98.0-x86_64-pc-windows-msvc cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --all-targets
RUSTUP_TOOLCHAIN=1.98.0-x86_64-pc-windows-msvc cargo fmt    --manifest-path desktop/src-tauri/Cargo.toml -- --check
```

clippy finished with no warnings on the crate; `fmt --check` is clean.

## Note on the changelog

A deployment behaves differently afterwards — the directory a person names is the directory that is
used — so there is a `## Unreleased` entry. It shares that anchor with other open pull requests and
may need a one-line rebase.
