### PR TITLE
Record an identity provider being registered, not only removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ and is safe to rerun. It kills a port holder only once that process has identifi
 OpenBot, so an unrelated process on 3010 is named and left alone rather than killed. Nothing is
 deleted: the database, the Bots' files and their browser profiles are volumes. `--keep-computers`
 leaves the browsers signed in.
+### The trail says when an identity provider was added, not only when one was taken away
+
+Whoever holds an identity provider decides who can sign in at all, and the audit trail recorded only
+half of that. Removing one through the administration screen was written down; registering one was
+not, because registration is the sign-in library's own endpoint and nothing this deployment owns ran
+on the way through. The event type for it had been declared and never written. Removing a provider
+through the library's endpoint rather than the screen was unrecorded for the same reason. Both are
+now written where the deployment already stands in front of those routes to check that the person
+asking is an administrator, so a provider appearing or disappearing names itself and whoever did it.
+
 ### Two workers on one machine can no longer fire the same routine twice
 
 Every process that claims work from the shared queue named itself after its hostname, and the queue

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -6,6 +6,7 @@ import type { BotAccessCheck } from "./agents/profile-policy";
 import type { AgentProfileStore } from "./agents/profile-store";
 import { createAgentRoutes } from "./agents/routes";
 import {
+  type AuditEventType,
   type AuditReader,
   type AuditStore,
   AuditQueryError,
@@ -276,6 +277,11 @@ export function createApp(
     "/api/auth/sso/delete-provider",
   ]);
 
+  const AUTH_ROUTE_EVENTS: Record<string, AuditEventType | undefined> = {
+    "/api/auth/sso/register": "identity_provider.registered",
+    "/api/auth/sso/delete-provider": "identity_provider.removed",
+  };
+
   app.on(["GET", "POST"], "/api/auth/*", async (context) => {
     if (!auth) {
       return context.json(
@@ -301,7 +307,43 @@ export function createApp(
       }
     }
 
-    return auth.handler(context.req.raw);
+    const eventType =
+      AUTH_ROUTE_EVENTS[new URL(context.req.url).pathname] ?? undefined;
+
+    // Read before the handler runs, because it consumes the stream: a clone taken afterwards is of
+    // a request whose body is already gone, and the row would name no provider.
+    const named =
+      auditStore && eventType
+        ? ((await context.req.raw
+            .clone()
+            .json()
+            .catch(() => null)) as { providerId?: unknown } | null)
+        : null;
+
+    const answer = await auth.handler(context.req.raw);
+
+    if (auditStore && eventType && answer.ok) {
+      const session = await auth.api.getSession({
+        headers: context.req.raw.headers,
+        query: { disableCookieCache: true },
+      });
+      await recordAuditEvent(auditStore, {
+        eventType,
+        targetType: "identity_provider",
+        ...(typeof named?.providerId === "string"
+          ? { targetId: named.providerId }
+          : {}),
+        ...(session?.user ? { actorUserId: session.user.id } : {}),
+        payload: {
+          ...(typeof named?.providerId === "string"
+            ? { providerId: named.providerId }
+            : {}),
+          ...(session?.user?.email ? { by: session.user.email } : {}),
+        },
+      });
+    }
+
+    return answer;
   });
 
   const authenticationUnavailable: MiddlewareHandler<{

--- a/server/tests/identity-provider-audit.test.ts
+++ b/server/tests/identity-provider-audit.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { createApp } from "../src/app";
+import type { AuditEventInput, AuditStore } from "../src/audit";
+import { loadConfig } from "../src/config";
+import { testEnvironment } from "./support/environment";
+
+const ADMIN = { id: "admin", email: "admin@openbot.test" };
+
+function app(role = "admin") {
+  const rows: AuditEventInput[] = [];
+  const auditStore: AuditStore = {
+    insert: async (event) => void rows.push(event),
+  };
+  const hono = createApp(
+    loadConfig(testEnvironment()),
+    {
+      /*
+       * Reads the body, as the real sign-in library does. A handler that leaves the stream
+       * untouched hides the ordering this depends on: a clone taken after the handler has run is of
+       * a consumed request, and the row would name no provider.
+       */
+      handler: async (request: Request) => {
+        await request.json().catch(() => null);
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+      api: { getSession: async () => ({ user: ADMIN }) },
+    } as never,
+    { rolesForUser: async () => [role] },
+    // Positions 4-12 are the other stores; auditStore is 13.
+    ...(Array.from({ length: 9 }) as never[]),
+    auditStore as never,
+  );
+  return { rows, hono };
+}
+
+const REGISTER_BODY = {
+  providerId: "acme",
+  issuer: "https://login.acme.test",
+  domain: "acme.test",
+};
+
+describe("the trail says how an identity provider came to exist", () => {
+  test("records the registration of an identity provider", async () => {
+    const { rows, hono } = app();
+    const response = await hono.request("/api/auth/sso/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(REGISTER_BODY),
+    });
+    expect(response.status).toBe(200);
+    expect(rows.map((row) => row.eventType)).toContain(
+      "identity_provider.registered",
+    );
+  });
+
+  test("names who registered it and which provider", async () => {
+    const { rows, hono } = app();
+    await hono.request("/api/auth/sso/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(REGISTER_BODY),
+    });
+    const row = rows.find(
+      (candidate) => candidate.eventType === "identity_provider.registered",
+    );
+    expect(row?.targetId).toBe("acme");
+    expect(row?.actorUserId).toBe("admin");
+  });
+
+  test("records a removal made through the library's own endpoint", async () => {
+    const { rows, hono } = app();
+    await hono.request("/api/auth/sso/delete-provider", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ providerId: "acme" }),
+    });
+    expect(rows.map((row) => row.eventType)).toContain(
+      "identity_provider.removed",
+    );
+  });
+
+  test("writes nothing when the library refuses the change", async () => {
+    const rows: AuditEventInput[] = [];
+    const hono = createApp(
+      loadConfig(testEnvironment()),
+      {
+        handler: async (request: Request) => {
+          await request.json().catch(() => null);
+          return new Response("no", { status: 400 });
+        },
+        api: { getSession: async () => ({ user: ADMIN }) },
+      } as never,
+      { rolesForUser: async () => ["admin"] },
+      ...(Array.from({ length: 9 }) as never[]),
+      { insert: async (event) => void rows.push(event) } as never,
+    );
+    await hono.request("/api/auth/sso/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(REGISTER_BODY),
+    });
+    expect(rows).toEqual([]);
+  });
+
+  test("writes nothing when a non-administrator is refused", async () => {
+    const { rows, hono } = app("user");
+    const response = await hono.request("/api/auth/sso/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(REGISTER_BODY),
+    });
+    expect(response.status).toBe(403);
+    expect(rows).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What this changes

Registering an identity provider now leaves an audit row, the way removing one already did. Both are
written in the catch-all that forwards `/api/auth/*` to the sign-in library, at the point where this
deployment already checks the caller is an administrator (`server/src/app.ts:280-283`).

- `identity_provider.registered` and `identity_provider.removed` for `POST /api/auth/sso/register`
  and `POST /api/auth/sso/delete-provider`. The first was declared in the vocabulary with no writer
  behind it (`server/src/audit.ts:325`).
- The body is read from a clone **before** `auth.handler` runs. The handler consumes the stream, so a
  clone taken afterwards is of a request whose body is gone and the row would name no provider.
- The row is written only when the library answered ok, so a refused registration is not recorded as
  one.
- The actor comes from `auth.api.getSession`, the same call the role check on those routes makes.

The admin screen's own removal keeps its existing row (`server/src/app.ts:735-742`); this adds the
path that went around it.

### Two things worth a reviewer's eye

**Payload key.** The existing removal row uses `{ removedBy: <email> }`. These use
`{ providerId, by: <email> }`, because one writer serves both events and `removedBy` reads wrongly on
a registration. That leaves two shapes for one target type; happy to split into per-event keys if
uniformity is preferred.

**`update-provider` is untouched.** It has no event type declared, so recording it means adding
vocabulary rather than adding a writer. Left out deliberately.

## Where it runs

- [x] **New state that outlives a request?** None — existing `audit_events` table, existing store.
- [x] **What happens on the second replica?** Whichever process answers writes the row from that
      request's session. Nothing here claims shared work, so no coordination is needed.
- [x] **Anything serialised?** Nothing new. `audit_events` is append-only and rows are independent.
- [x] **Anything fanned out to a browser?** No. The Audit screen reads the table on its own query.
- [x] **New listener, port, or schedule?** None.

## Boundary and audit

- [x] Every acting call still goes through the gateway. This is the audit step for two acting calls
      that had none.
- [x] New refusals and failures each write a row — with one deliberate exception: a refused
      registration writes nothing, because the library's refusal is not something this deployment
      did, and recording it as a registration would be worse than the gap being fixed.
- [x] Nothing new is trusted from the client. The actor comes from the session; the only
      request-supplied value is `providerId`, which is what the library itself acts on.

Cost: one `getSession` on two administrator-only routes that already make one, and one insert per
accepted call.

## Changelog

- [x] Under `Unreleased`: "The trail says when an identity provider was added, not only when one was
      taken away".

## Proof

Run against the bug first. On `main` three of the five new tests fail with real assertions — the
registration row missing, the actor and provider missing from it, and a removal through the library's
endpoint missing. The two that pass are the ones asserting those routes stay administrator-only. All
five pass here.

The tests stand a stub in for the sign-in library, so the two things that stub could get wrong were
checked against the installed package rather than assumed. `@better-auth/sso@1.7.1` declares
`/sso/register` and `/sso/delete-provider` — what the two keys name once mounted under `/api/auth` —
and both are `POST` with `providerId` in a JSON body (`delete-provider` as
`z.object({ providerId: z.string() })`), which is what the clone-and-read depends on.

**Not covered:** no registration was driven through the real library end to end. `/api/auth/*`
answers 503 unless an identity provider is configured (`server/src/app.ts:286-288`), and configuring
one needs credentials from a real directory. Driving the admin screen on a live local deployment
confirms exactly that boundary: the form answers "No identity provider is configured", the request is
`POST /api/auth/sso/register → 503`, and no audit row and no `sso_providers` row appear. Wiring,
ordering and refusal behaviour are covered by tests; the library's 200 path is not.

Gates: typecheck clean across app, server and worker; lint 596 files, format 592, no diff.
`drizzle-kit generate` reports no schema changes — no migration in this PR.

Suite against `06633a4`, with the two `agent-handoff-*.integration` files excluded because they fail
4-5 of their 5 tests on bare `main` and make any comparison meaningless: **branch 2538 pass / 2 fail,
`main` 2533 / 2, each identical across three consecutive runs.** Same two failures on both sides,
neither belonging to this change. The delta is exactly this PR's one new file — 2560 tests across 212
files on `main`, 2565 across 213 here.


Closes #461
