### PR TITLE
Start the app and the server from `bun run dev`, and leave the routines worker to start.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### `bun run dev` no longer starts a routines worker that cannot start
+
+`bun run dev` fanned out across every workspace, and one of them is the routines worker. That worker
+is handed `DATABASE_URL`, `SERVER_INTERNAL_URL` and `WORKER_SHARED_SECRET` by `scripts/start.sh` and
+by nothing else, so the copy this command started read none of them and threw at boot on every run,
+printing a stack trace in between the app's output and the server's. It has never started
+successfully. The command now starts the app and the server, which is what `README.md` and
+`docs/development.md` already say it does. Routines are unaffected: `scripts/start.sh` starts the
+worker exactly as before, and on Kubernetes the CronJob does.
+
 ### A deployment directory pasted with a stray space goes where it says
 
 The desktop setup screen asks where OpenBot should live, enables Start once that box is not blank

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build": "bun run generate:app-config && bun run --filter '*' build",
-    "dev": "bun run generate:app-config && bun run --filter '*' --parallel dev",
+    "dev": "bun run generate:app-config && bun run --filter app --filter server --parallel dev",
     "generate:app-config": "bun --env-file=.env scripts/generate-app-config.ts",
     "format": "bunx biome format --write .",
     "format:check": "bunx biome format .",

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -12,17 +12,56 @@ function packageManifest(path: string) {
   };
 }
 
+function rootManifest() {
+  return JSON.parse(
+    readFileSync(join(repositoryRoot, "package.json"), "utf8"),
+  ) as { workspaces: string[]; scripts: Record<string, string> };
+}
+
+function packagesStartedBy(script: string, workspaces: string[]): string[] {
+  const filters = [
+    ...script.matchAll(/--filter\s+(?:'([^']*)'|"([^"]*)"|(\S+))/g),
+  ].map((match) => match[1] ?? match[2] ?? match[3]);
+  return workspaces.filter((workspace) =>
+    filters.some((filter) => filter === "*" || filter === workspace),
+  );
+}
+
 describe("OpenBot workspace", () => {
   test("defines the app, server, and worker packages", () => {
-    const rootManifest = JSON.parse(
-      readFileSync(join(repositoryRoot, "package.json"), "utf8"),
-    ) as { workspaces: string[] };
+    const manifest = rootManifest();
 
-    expect(rootManifest.workspaces).toEqual(["app", "server", "worker"]);
+    expect(manifest.workspaces).toEqual(["app", "server", "worker"]);
 
-    for (const packageName of rootManifest.workspaces) {
+    for (const packageName of manifest.workspaces) {
       expect(existsSync(join(repositoryRoot, packageName))).toBe(true);
       expect(packageManifest(packageName).name).toBe(packageName);
     }
+  });
+
+  test("dev starts the app and the server, and not the routines worker", () => {
+    const manifest = rootManifest();
+
+    expect(
+      packagesStartedBy(manifest.scripts.dev, manifest.workspaces),
+    ).toEqual(["app", "server"]);
+  });
+
+  test("build still covers every workspace, including the worker", () => {
+    const manifest = rootManifest();
+
+    expect(
+      packagesStartedBy(manifest.scripts.build, manifest.workspaces),
+    ).toEqual(manifest.workspaces);
+  });
+
+  test("scripts/start.sh is what starts the routines worker", () => {
+    const startScript = readFileSync(
+      join(repositoryRoot, "scripts", "start.sh"),
+      "utf8",
+    );
+
+    expect(startScript).toContain("bun worker/src/index.ts");
+    expect(startScript).toContain("WORKER_SHARED_SECRET=");
   });
 });


### PR DESCRIPTION
Fixes #467

## What this changes

`bun run dev` fanned out with `--filter '*'`, which selects all three workspaces, and the third of them is the routines worker. That worker is handed `DATABASE_URL`, `SERVER_INTERNAL_URL` and `WORKER_SHARED_SECRET` by `scripts/start.sh` and by nothing else, so the copy this command started read none of them and threw at boot on every run. It has never started successfully on any machine — `worker/package.json` has one commit in its history, and `.env.example` ships the secret empty by design, so even adding `--env-file=../.env` would leave a fresh clone throwing.

The command now names its two packages, which is what `README.md:339` and `docs/development.md:34` already say it does. `build` and `typecheck` still use `--filter '*'`, so the worker is compiled and typechecked exactly as before.

Making the worker start instead would have been the worse fix. `scripts/start.sh:329` records that its `pgrep` guard matches `bun worker/src/index.ts` specifically, because the `cd worker && bun src/index.ts` form also matches three Dockerfiles. A worker started by `bun run dev` runs under that second form, so `start.sh` would not see it and would start a second worker beside it.

One line in the repository does read the other way, and it is worth naming rather than leaving to be
found. `CHANGELOG.md:113` says "`scripts/start.sh` looks for a process it does not start the way
`bun run dev` does", so somebody was aware a worker process comes out of this command. It is written
as a hazard rather than as an endorsement, and the hazard is hypothetical, because that worker throws
before it can claim anything. Nothing else in the repository asks for a worker here: `git log -S`
shows the `--filter '*'` in this script has never been edited since the initial commit, and both
places that describe the command scope it to two processes. If the arrangement was deliberate, say so
and I will close this — the alternative fix, wiring `--env-file=../.env` into `worker/package.json`,
is one line, though `.env.example` shipping the secret empty means a fresh clone would still throw.

## Where it runs

- **New state that outlives a request?** None. The change is a package script.
- **What happens on the second replica?** Nothing differs. No deployment runs `bun run dev`; Kubernetes fires routines from the CronJob and a laptop from `scripts/start.sh`.
- **Anything serialised?** None added. One fewer process contends for the routine lease locally.
- **Anything fanned out to a browser?** No.
- **New listener, port, or schedule?** None. This removes a process that bound no port and never ran.

## Boundary and audit

- Unchanged. No acting call, refusal, or audit path is touched.

## Changelog

- Added under `Unreleased`.

## Proof

**Reproduced on `origin/main` `1c7bd92`.** `bun run --filter worker dev` — the exact command
`--filter '*'` issues for that workspace:

```
worker dev: error: WORKER_SHARED_SECRET is not set, so this worker cannot authenticate itself
worker dev:   to /internal/routines/run and no routine could be fired.
worker dev:       at loadWorkerEnv (worker/src/env.ts:32:15)
worker dev:       at worker/src/index.ts:52:3
```

**The new test fails against `main`'s script and passes against this one.** Same test file, only
`package.json` swapped for the one on `main`:

```
(fail) OpenBot workspace > dev starts the app and the server, and not the routines worker
  @@ -3,3 +3,3 @@
     "server",
  +   "worker",
```

**End to end.** `bun run dev` on this branch, on spare ports so it did not collide with a running
stack: `VITE ready`, app on 3910, `OpenBot server listening on http://localhost:3901`, and zero lines
in the whole run mentioning either the worker or `WORKER_SHARED_SECRET`.

**The worker still starts by its supported path.** Launched the way `scripts/start.sh:335` launches
it, from the repository root with the three settings it expects:

```
OpenBot worker status: idle
{"type":"routine-sweep","offered":[],"considered":0,"fired":[],"skipped":[]}
{"type":"routine-sweep-purge","purged":0}
```

**Gates.** Typecheck clean across all three workspaces — the worker is still compiled, because
`build` and `typecheck` keep `--filter '*'`. Lint 604 files, format 600 files, no diff.

**Suite**, run in one session against a same-session control, with the two
`agent-handoff-*.integration` files excluded because they fail most of their tests on bare `main` and
make any comparison meaningless:

| | pass | skip | fail | tests |
| --- | --- | --- | --- | --- |
| `origin/main` @ `1c7bd92` | 2609 | 25 | 8 | 2642 |
| this branch | 2612 | 25 | 8 | 2645 |

The failing test names are byte-identical on both sides, as is the `@langchain/core/messages`
resolution error, so none of them belong to this change. The difference is exactly the three tests
added here.
