### PR TITLE
Recognise a running stack on the other loopback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### The desktop app recognises its own running stack whichever loopback it answers on
+
+Opening the window a second time asks whether the deployment it manages is already up, so that
+somebody is shown OpenBot rather than offered a setup screen for a stack that is running. That
+question was asked at `127.0.0.1` alone, while every other check on the same port — the readiness
+wait, the navigation to the app, and the refusal to start on a port something else holds — accepts
+an answer at either loopback, because a process binds whichever one its runtime resolved `localhost`
+to. A server on `::1` therefore read as nothing running: the window offered to set up a deployment
+that was already up, and Start then refused, reporting OpenBot's own server as somebody else's
+process holding port 3001, with nothing on screen able to stop it. Both addresses are asked now.
+
 ### A deployment directory pasted with a stray space goes where it says
 
 The desktop setup screen asks where OpenBot should live, enables Start once that box is not blank

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -395,23 +395,10 @@ fn show_setup(app: tauri::AppHandle) -> Result<(), String> {
 /// an answer on the port says one is running now.
 #[tauri::command]
 fn already_running(root: String) -> bool {
-    let root = stack::root_from(&root);
-    if deployment::installed(&root).is_none() {
-        return false;
-    }
-    let port = openbot_env::Ports::default().server;
-    reqwest::blocking::Client::builder()
-        .timeout(std::time::Duration::from_secs(2))
-        .build()
-        .ok()
-        .and_then(|client| {
-            client
-                .get(format!("http://127.0.0.1:{port}/api/capabilities"))
-                .send()
-                .ok()
-        })
-        .map(|response| response.status().is_success())
-        .unwrap_or(false)
+    stack::already_running(
+        &stack::root_from(&root),
+        openbot_env::Ports::default().server,
+    )
 }
 
 /// What stopped the stack, if anything did, and forget it once it has been read.

--- a/desktop/src-tauri/src/stack.rs
+++ b/desktop/src-tauri/src/stack.rs
@@ -450,6 +450,25 @@ pub fn app_url(port: u16) -> Option<String> {
     answering_at(port, "/")
 }
 
+/// Whether a deployment this app installed is up right now.
+///
+/// Two questions, because either alone answers something else. A stamp says a deployment was laid
+/// down here once; only an answer on the port says one is running, and only a deployment we
+/// installed is ours to recognise.
+///
+/// Asked through [`answering_at`], which is the whole point of this living beside it. The API was
+/// asked at `127.0.0.1` alone, and a bun server is usually there, so this looked right on the
+/// machine it was written on. It is not a fact: `LOOPBACKS` above records why, and everything else
+/// that asks the same question of the same port -- the readiness wait, the window's own navigation,
+/// the guard that refuses a start on a held port -- accepts either address. So a stack answering on
+/// `[::1]` was reported to the window as nothing running: it offered to set up a deployment that
+/// was already up, and Start then refused on a port held by OpenBot itself, naming it as somebody
+/// else's process.
+pub fn already_running(root: &Path, port: u16) -> bool {
+    crate::deployment::installed(root).is_some()
+        && answering_at(port, "/api/capabilities").is_some()
+}
+
 /// Wait until the stack is genuinely usable, or say which part is not.
 ///
 /// Watches the children as well as the ports, because three processes that died leave a port
@@ -776,6 +795,97 @@ mod tests {
             LOOPBACKS.contains(&"[::1]"),
             "an IPv6-only bind still counts as answering"
         );
+    }
+
+    /// A deployment, laid down and stamped, with nothing running from it.
+    fn stamped(name: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("openbot-running-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        crate::deployment::record(&dir, "v0.0.8").expect("the stamp is written");
+        dir
+    }
+
+    /// A listener that answers every request with 200, on the one address it is given.
+    ///
+    /// The request is read before the answer is written: a socket dropped with unread bytes still
+    /// in it resets the connection instead of delivering anything, so a responder that only writes
+    /// looks like a port nobody holds.
+    fn answering_on(host: &str) -> (std::net::TcpListener, u16) {
+        let listener =
+            std::net::TcpListener::bind((host, 0)).expect("a loopback listener is bound");
+        let port = listener.local_addr().expect("it has an address").port();
+        let accepting = listener.try_clone().expect("the listener is shared");
+        std::thread::spawn(move || {
+            for stream in accepting.incoming() {
+                let Ok(mut stream) = stream else { break };
+                use std::io::{BufRead as _, Write as _};
+                let Ok(peer) = stream.try_clone() else { break };
+                let mut reader = std::io::BufReader::new(peer);
+                loop {
+                    let mut line = String::new();
+                    match reader.read_line(&mut line) {
+                        Ok(0) => break,
+                        Ok(_) if line == "\r\n" || line == "\n" => break,
+                        Ok(_) => {}
+                        Err(_) => break,
+                    }
+                }
+                let _ = stream.write_all(
+                    b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                );
+                let _ = stream.flush();
+            }
+        });
+        (listener, port)
+    }
+
+    #[test]
+    fn a_stack_answering_on_the_other_loopback_is_still_running() {
+        // The question a second window asks before it offers to set anything up, and it was asked
+        // at `127.0.0.1` alone while every other check on the same port accepts either address. A
+        // server on `[::1]` therefore read as nothing running, and the port guard then refused the
+        // start it offered, naming OpenBot's own server as somebody else's process.
+        let root = stamped("v6");
+        let (_listener, port) = answering_on("::1");
+
+        let seen = already_running(&root, port);
+        let _ = std::fs::remove_dir_all(&root);
+        assert!(
+            seen,
+            "the API is answering on [::1]:{port} and the window was told nothing is running"
+        );
+    }
+
+    #[test]
+    fn a_stack_answering_on_the_usual_loopback_is_running() {
+        // The case that already worked, kept so the fix above is a widening rather than a swap.
+        let root = stamped("v4");
+        let (_listener, port) = answering_on("127.0.0.1");
+
+        let seen = already_running(&root, port);
+        let _ = std::fs::remove_dir_all(&root);
+        assert!(seen, "nothing was reported running on 127.0.0.1:{port}");
+    }
+
+    #[test]
+    fn a_stamped_deployment_that_is_not_answering_is_not_running() {
+        // A stamp says a deployment was installed here, not that one is up. Port 1 needs privilege
+        // to bind, so this asks about a port that cannot quietly be somebody else's server.
+        let root = stamped("quiet");
+        let seen = already_running(&root, 1);
+        let _ = std::fs::remove_dir_all(&root);
+        assert!(!seen, "a stamp is not a running deployment");
+    }
+
+    #[test]
+    fn a_directory_this_app_never_installed_into_is_not_running() {
+        // Somebody else's server on the port is not this deployment. Without the stamp check the
+        // window would show OpenBot and navigate to whatever was listening.
+        let (_listener, port) = answering_on("127.0.0.1");
+        let empty = std::env::temp_dir().join(format!("openbot-unstamped-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&empty);
+        assert!(!already_running(&empty, port));
     }
 
     #[test]


### PR DESCRIPTION
Open the desktop app, set OpenBot up, and leave it running. Close the window and open it again. The
window says "Set up OpenBot" for a stack that is already up, and pressing Start answers:

    Something is already listening on port 3001, which OpenBot uses for the API server. Stop it, or
    change the port, and start again.

That is OpenBot's own server. There is nothing on screen that can stop it, because the window does
not believe it is running.

## Why

A second window has no handles on a stack an earlier one raised, so `already_running` asks the
deployment itself: is there a stamp here, and does the API answer? The second half asked one address:

```rust
client.get(format!("http://127.0.0.1:{port}/api/capabilities"))
```

Everything else in the shell that asks about that same port accepts either loopback. `answering_at`
walks `LOOPBACKS = ["127.0.0.1", "[::1]"]`, and its comment says why: "A process that binds one and
not the other is normal rather than broken: Node resolves `localhost` to `::1` and bun to
`127.0.0.1`, so which one a service ends up on depends on what started it." The readiness wait uses
it, `app_url` uses it to point the window at the app, and #453 brought `port_already_taken` in line
with it last night.

`already_running` is the one that was left behind, and it is the one that decides which screen a
person sees. So the two disagree in exactly the worst way: the screen says nothing is running, and
the guard in front of Start says the port is taken.

## The fix

The decision moves into `stack.rs`, beside the function that already asks both addresses, and takes
the port as an argument so a test can use one nothing else on the machine holds. `main.rs` keeps the
`#[tauri::command]` and nothing else — 21 lines out, 4 in — which also removes the last hand-rolled
`reqwest` client from that file.

One behaviour change worth naming: `answering_at`'s client has a 3s timeout where the deleted one
had 2s, and it can now make two attempts. The check runs once, in the background of the setup
screen's first render, and a refused connection comes back immediately, so this is only visible on a
machine where a firewall drops rather than refuses.

## Reproduction

**Against `1c7bd92` (`origin/main`), unmodified.** A stamped deployment directory and a listener
answering 200 on `[::1]:3001` and nowhere else, handed straight to the shipped `already_running`:

```
running 1 test
test repro::a_deployment_answering_on_the_other_loopback_is_seen_as_running ... FAILED

---- repro::a_deployment_answering_on_the_other_loopback_is_seen_as_running stdout ----
thread '...' panicked at src\main.rs:813:9:
the stack is answering on [::1]:3001 and the window was told nothing is running

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.01s
```

The same probe with the listener on `127.0.0.1` instead passes on `main`, so it is the address that
decides it and not the harness.

**The four tests this PR ships**, against `stack::already_running`. Put the one-address client back
into the new function and 1 of the 4 fails:

```
test stack::tests::a_stack_answering_on_the_other_loopback_is_still_running ... FAILED
thread '...' panicked at src\stack.rs:866:9:
the API is answering on [::1]:51083 and the window was told nothing is running

test result: FAILED. 91 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

The other three are the guard against over-correcting, and pass before and after: an answer on
`127.0.0.1` is still running, a stamp with nothing answering is not, and a directory this app never
installed into is not — that last one is what stops the window navigating to a stranger's server.

With the fix:

```
test result: ok. 92 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.06s
```

`main` is 88; the four above are the difference.

## Verification

```
cargo fmt --check                                     # clean
cargo clippy --all-targets -- -D warnings             # clean
cargo test --lib                                      # 92 passed, 0 failed
```

Run from `desktop/src-tauri` on Windows with Rust 1.98.0. `cargo test --lib` is what `desktop.yml`
runs, so these are covered there.

## Note on the changelog

The entry goes at the top of `## Unreleased`, which is the same line every open PR touching the
changelog inserts at. Say the word if this needs rebasing onto whatever lands first.
