### PR TITLE
Refuse a header value that cannot be sent, instead of reporting an unreachable agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A key pasted with a line break in it is now refused, instead of reported as an unreachable agent
+
+The box that holds an agent's key takes whatever is pasted into it, and what comes off a clipboard is
+not always what was on the screen: a long key copied out of a wrapped terminal line brings the wrap
+with it, and a hyphen copied out of a document has often been turned into an en dash on the way.
+Neither can be sent as an HTTP header — the runtime refuses the value outright — and neither was
+being looked at. On Test connection that refusal surfaced as "This server could not reach that
+address", with a suggestion about tunnels and firewalls, about an agent that was running perfectly
+well and had never been dialled. Stored on the Bot it was quieter and worse: the form said saved, and
+every turn that Bot took afterwards failed on a value nothing on screen said anything about. Both
+places now check the value before accepting it and say which kind of character is in the way. The
+character is named; the key never is.
 ### A deployment directory pasted with a stray space goes where it says
 
 The desktop setup screen asks where OpenBot should live, enables Start once that box is not blank

--- a/server/src/agents/routes.ts
+++ b/server/src/agents/routes.ts
@@ -106,6 +106,16 @@ export function parseAgentInput(
       if (!/^[A-Za-z0-9-]+$/.test(header)) {
         return { ok: false, error: "That is not a valid header name." };
       }
+      // Refused here rather than discovered on the first run. This value is encrypted and stored,
+      // and then sent as a header on every turn the Bot takes; one that cannot be a header value
+      // throws inside `fetch` every one of those times, long after the form said it was saved.
+      const unsendable = unsendableHeaderValue(value);
+      if (unsendable) {
+        return {
+          ok: false,
+          error: `That key contains ${unsendable}, so it cannot be sent as a header.`,
+        };
+      }
       auth = { header, value };
     }
   }
@@ -118,6 +128,31 @@ export function parseAgentInput(
 
 function isAgentInputObject(input: unknown): input is AgentInputObject {
   return typeof input === "object" && input !== null && !Array.isArray(input);
+}
+
+/**
+ * What in this value stops it being a header, or null when nothing does.
+ *
+ * `new Headers()` refuses a line break, a NUL, and any code point above U+00FF, and it refuses them
+ * by throwing a TypeError from inside `fetch` — which is not a decision this deployment gets to
+ * take part in. Both surfaces below take a header value from the same box on the same form and
+ * neither looked, so the throw arrived somewhere that reads as something else entirely: on the
+ * connection test it lands in the catch written for a dead host, and the person is told "this server
+ * could not reach that address", which sends them to their tunnel and their firewall over a key
+ * they had just pasted with a wrapped line in it. A hyphen a document turned into an en dash does
+ * the same thing, and looks like nothing at all in a password box.
+ *
+ * The description never contains the value. This is asked of a credential on one of the two paths,
+ * and one character of a secret in an error message is one character too many.
+ */
+function unsendableHeaderValue(value: string): string | null {
+  for (const character of value) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code === 0x0a || code === 0x0d) return "a line break";
+    if (code === 0) return "a null character";
+    if (code > 0xff) return "a character that cannot go in a header value";
+  }
+  return null;
 }
 
 /**
@@ -175,6 +210,13 @@ export function parseConnectionHeaders(
       return {
         ok: false,
         error: `Header "${name}" must be at most 4096 characters.`,
+      };
+    }
+    const unsendable = unsendableHeaderValue(value);
+    if (unsendable) {
+      return {
+        ok: false,
+        error: `Header "${name}" contains ${unsendable}, so it cannot be sent.`,
       };
     }
     headers[name] = value;

--- a/server/tests/agent-test-connection-headers.test.ts
+++ b/server/tests/agent-test-connection-headers.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import type { MiddlewareHandler } from "hono";
-import type { AppVariables } from "../src/auth/guards";
 import {
   createAgentRoutes,
+  parseAgentInput,
   parseConnectionHeaders,
 } from "../src/agents/routes";
+import type { AppVariables } from "../src/auth/guards";
 
 describe("parseConnectionHeaders", () => {
   test("absent headers stay absent", () => {
@@ -38,6 +39,75 @@ describe("parseConnectionHeaders", () => {
   ])("rejects %s", (_name, input) => {
     const parsed = parseConnectionHeaders(input);
     expect(parsed.ok).toBe(false);
+  });
+
+  /*
+   * A value the runtime will not put on the wire.
+   *
+   * `new Headers()` throws a TypeError for a line break, a NUL, and any code point above U+00FF,
+   * measured on Bun 1.3.14. That throw comes out of the probe `fetch`, lands in the catch that is
+   * there for a dead host, and is reported as an address this server could not reach — so a pasted
+   * key with a wrapped line in it, or one carrying the en dash a document turned a hyphen into,
+   * sends somebody looking at their tunnel and their firewall.
+   */
+  test.each([
+    ["a newline in the value", "Bearer abc\ndef"],
+    ["a carriage return in the value", "Bearer abc\rdef"],
+    ["a NUL in the value", `Bearer abc${String.fromCharCode(0)}def`],
+    ["a character above Latin-1", "Bearer — abc"],
+  ])("rejects %s", (_name, value) => {
+    const parsed = parseConnectionHeaders({ Authorization: value });
+    expect(parsed.ok).toBe(false);
+  });
+
+  /*
+   * The guard against over-correcting. Everything here is a value `new Headers()` accepts, so
+   * refusing any of it would be taking away a header somebody's agent really wants.
+   */
+  test.each([
+    ["a tab", "Bearer\tabc"],
+    ["an inner space", "Bearer abc def"],
+    ["a Latin-1 accent", "Bearer café"],
+    ["punctuation", "Bearer abc-_.~+/=:;,@!$%^&*()[]{}"],
+  ])("keeps %s", (_name, value) => {
+    expect(parseConnectionHeaders({ Authorization: value })).toEqual({
+      ok: true,
+      value: { Authorization: value },
+    });
+  });
+});
+
+/*
+ * The other half of the same form.
+ *
+ * The key stored on a Bot is typed into the same box as the one a connection test carries, and it is
+ * sent as a header on every run rather than once. Accepted here, it is encrypted, stored, and then
+ * throws inside `fetch` on every turn that Bot takes.
+ */
+describe("the key stored on a Bot", () => {
+  const agent = (value: string) => ({
+    name: "Helper",
+    title: "Helper",
+    roleDescription: "Helps.",
+    visibility: "private",
+    endpoint: "https://agent.example/ag-ui",
+    auth: { header: "Authorization", value },
+  });
+
+  test("a key that cannot be sent as a header is refused", () => {
+    const parsed = parseAgentInput(agent("Bearer abc\ndef"));
+    expect(parsed.ok).toBe(false);
+  });
+
+  test("an ordinary key is still stored", () => {
+    const parsed = parseAgentInput(agent("Bearer abc"));
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect(parsed.value.auth).toEqual({
+        header: "Authorization",
+        value: "Bearer abc",
+      });
+    }
   });
 });
 
@@ -87,5 +157,64 @@ describe("POST /test-connection header validation", () => {
     });
 
     expect(response.status).toBe(400);
+  });
+});
+
+/*
+ * The failure as the person registering an agent meets it: a real server on the other end, a real
+ * `fetch`, and a header value with a line break in it.
+ */
+describe("a header value that cannot be sent", () => {
+  test("is refused before anything is dialled", async () => {
+    let dialled = 0;
+    const agent = Bun.serve({
+      port: 0,
+      fetch: () => {
+        dialled += 1;
+        return new Response(
+          'event: RUN_STARTED\ndata: {"type":"RUN_STARTED"}\n\n',
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      },
+    });
+
+    try {
+      const requireUser: MiddlewareHandler<{
+        Variables: AppVariables;
+      }> = async (context, next) => {
+        context.set("actor", {
+          id: "user-1",
+          email: "user@openbot.test",
+          role: "user",
+        });
+        await next();
+      };
+      const app = createAgentRoutes({} as never, requireUser, true);
+
+      const response = await app.request(
+        "http://openbot.test/test-connection",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            endpoint: `http://127.0.0.1:${agent.port}/ag-ui`,
+            headers: { Authorization: "Bearer abc\ndef" },
+          }),
+        },
+      );
+
+      expect(response.status).toBe(400);
+      // The agent is fine and was never asked. What is wrong is the value in the box, and that is
+      // what the answer has to be about.
+      expect(dialled).toBe(0);
+      const body = (await response.json()) as {
+        error?: string;
+        reason?: string;
+      };
+      expect(body.reason).toBeUndefined();
+      expect(body.error).toMatch(/line break|cannot be sent/i);
+    } finally {
+      agent.stop(true);
+    }
   });
 });


### PR DESCRIPTION
Paste a key into an agent's key box with a line break somewhere in the middle — which is what a long
key copied out of a wrapped terminal line brings with it — and press **Test connection** against an
agent that is running perfectly well. What comes back is:

> This server could not reach that address. If your agent runs on your own machine, it needs to be
> reachable from here, a tunnel, or somewhere this server can dial.

Measured, against a real `Bun.serve` agent on loopback and a header value of `Bearer abc\ndef`: the
agent counted **zero** requests. It was never dialled. The person is now looking at their tunnel and
their firewall over a value in the box they had just filled in.

Save the same key instead of testing it and it is quieter and worse. The form says saved, the value
is encrypted and stored, and every turn that Bot takes afterwards fails on it.

## Why

`new Headers()` refuses a line break, a NUL, and any code point above U+00FF, and it refuses them by
throwing a `TypeError` from inside `fetch` — not by anything this deployment decides. Measured on Bun
1.3.14, the same probe that produced the numbers below:

```
newline: THREW TypeError        tab: OK
cr:      THREW TypeError        inner space: OK
nul:     THREW TypeError        latin1 e-acute: OK
cjk:     THREW TypeError        0x80: OK
emoji:   THREW TypeError        del 0x7f: OK
```

Neither of the two places that take a header value looked at one:

- `parseConnectionHeaders` (`server/src/agents/routes.ts`) checks the **name** against
  `/^[A-Za-z0-9-]+$/`, refuses `__proto__`, caps the map at 32 entries and the value at 4096
  characters — and then accepts any string. Its own docstring says it exists because "an array
  value, a nested object, or a `__proto__` key travelled into the network call and threw a
  TypeError 500". A value that throws the same TypeError was the case it did not cover.
- `parseAgentInput`, a few lines above it, checks the header **name** the same way and stores the
  value as it arrives.

On the connection test the throw travels out of `createAgentFetch`, into `testAgentConnection`'s
catch — which exists for a dead host and a typo'd address — and is answered 200 with the sentence
above. On the stored key nothing catches it at all until the next run.

The other spelling that does this is not a line break: a hyphen copied out of a document has often
been turned into an en dash, which is U+2013, and in a password box it looks like a hyphen.

## The fix

One helper, used by both. It returns *what kind* of character is in the way and never the value —
this is asked of a credential on one of the two paths, and one character of a secret in an error
message is one character too many.

Refused rather than stripped. A key with a line break in it is not a key with a line break removed,
and silently sending a different value than was pasted is how somebody spends an afternoon on a 401.

## Measured

`bun test server/tests/agent-test-connection-headers.test.ts`

- Against `origin/main` with only the new tests applied: **20 pass, 6 fail**.
  - `rejects a newline in the value`, `rejects a carriage return in the value`,
    `rejects a NUL in the value`, `rejects a character above Latin-1` — all four return `ok: true`.
  - `a key that cannot be sent as a header is refused` — `parseAgentInput` returns `ok: true`.
  - `is refused before anything is dialled` — the route answers **200**, not 400, carrying the
    "could not reach that address" reason.
- With the change: **26 pass, 0 fail**.

Four of the new cases are the guard against over-correcting, and pass before and after: a tab, an
inner space, a Latin-1 accent, and a value made of punctuation are all things `new Headers()`
accepts, so refusing any of them would be taking away a header somebody's agent really wants. So are
the eleven cases that were already there.

Also run, all green:

- `bun test server/tests/agent-routes.test.ts server/tests/agent-endpoint.test.ts server/tests/agent-connection-live.test.ts` — 106 pass, 0 fail
- `bun run --filter server typecheck` — exit 0
- `bunx biome check` on both changed files — clean

## Note on the CHANGELOG

A deployment behaves differently afterwards, so there is an entry. It is inserted at the top of
`## Unreleased`, which is where every entry goes, so it will conflict on that one line with any other
PR open against the same anchor. Happy to rebase whenever it suits you.
