### PR TITLE
Read the opening of an agent's answer, not all of it, when testing a connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### Test connection stops reading once it has seen the agent answer
+
+The button that checks an agent before it is registered sends it a real run and reads what comes
+back, needing only the opening of the stream to tell an AG-UI agent from a web server that happens to
+be reachable. It was reading the whole reply first and applying that limit afterwards, so the check
+took as long as the agent's run did. An agent that streams for more than fifteen seconds — a Bot
+working through a document, a model answering slowly — was given up on mid-answer and reported as
+`The agent started answering and the connection broke`, about a connection that had not broken and an
+agent that had answered correctly in its first two events. It now reads the opening it needs, closes
+the connection, and answers in the time the agent took to start rather than the time it took to
+finish.
 ### A deployment directory pasted with a stray space goes where it says
 
 The desktop setup screen asks where OpenBot should live, enables Start once that box is not blank

--- a/server/src/agents/connection-test.ts
+++ b/server/src/agents/connection-test.ts
@@ -20,6 +20,41 @@ const TEST_TIMEOUT_MS = 15_000;
 /** Enough of the stream to prove it is an agent. Reading it all could mean reading a whole reply. */
 const MAX_BYTES = 8_000;
 
+/**
+ * The opening of the answer, and then stop reading.
+ *
+ * The cap above was applied to a string this process had already taken in full, because
+ * `response.text()` reads a body to its end. An agent that streams — which is what an agent does —
+ * therefore held the form open for as long as its run took, and if that outlasted the timeout the
+ * abort came back through `text()` as a rejected read: `ok: false`, status 200, "The agent started
+ * answering and the connection broke." Nothing broke. The agent had answered correctly, in the first
+ * two events, and the person registering it was told to go and look at their own service.
+ *
+ * Counted in bytes, which is what the cap is named in and what a chunk off the wire is measured in.
+ * The chunk that crosses the cap is kept whole rather than cut at it: it is one read past the cap at
+ * most, and a cut through a multi-byte character would put a replacement character in the middle of
+ * a line the scan is about to read.
+ */
+async function readOpening(body: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  let bytes = 0;
+  try {
+    while (bytes < MAX_BYTES) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      text += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    // The agent is very likely still writing. Nothing is going to read the rest, and leaving it open
+    // holds a socket into somebody's agent for as long as that run cares to go on.
+    void reader.cancel().catch(() => undefined);
+  }
+  return text;
+}
+
 export type ConnectionTestResult =
   | {
       ok: true;
@@ -152,7 +187,7 @@ export async function testAgentConnection(
 
   let body: string;
   try {
-    body = (await response.text()).slice(0, MAX_BYTES);
+    body = response.body ? await readOpening(response.body) : "";
   } catch {
     return {
       ok: false,

--- a/server/tests/agent-connection-live.test.ts
+++ b/server/tests/agent-connection-live.test.ts
@@ -248,3 +248,71 @@ describe("registering an agent that answers badly", () => {
     expect(result.reason.length).toBeGreaterThan(0);
   });
 });
+
+/**
+ * An agent that keeps talking.
+ *
+ * The check needs the opening of the stream and says so: the cap beside it is named for how much of
+ * the answer is enough to prove the far end is an agent. What decides whether that cap means
+ * anything is whether the read stops there, and the person registering an agent that streams for a
+ * while is the one who finds out.
+ */
+describe("registering an agent that streams a long answer", () => {
+  /** The events, and then a run that goes on writing: a Bot working through a long document. */
+  function talkativeAgent() {
+    return Bun.serve({
+      port: 0,
+      fetch: () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            async start(controller) {
+              const encoder = new TextEncoder();
+              controller.enqueue(
+                encoder.encode(
+                  'event: RUN_STARTED\ndata: {"type":"RUN_STARTED"}\n\n' +
+                    'event: TEXT_MESSAGE_START\ndata: {"type":"TEXT_MESSAGE_START"}\n\n',
+                ),
+              );
+              // A kilobyte at a time, slowly, the way a model streams. Nothing here closes: the run
+              // is still going, which is the whole point.
+              for (let chunk = 0; chunk < 4_000; chunk += 1) {
+                controller.enqueue(
+                  encoder.encode(
+                    `event: TEXT_MESSAGE_CONTENT\ndata: {"type":"TEXT_MESSAGE_CONTENT","delta":"${"x".repeat(960)}"}\n\n`,
+                  ),
+                );
+                await Bun.sleep(20);
+              }
+              controller.close();
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+    });
+  }
+
+  test("is reported as working, without waiting for it to finish", async () => {
+    const agent = talkativeAgent();
+
+    try {
+      const started = Date.now();
+      const result = await testAgentConnection(
+        `http://127.0.0.1:${agent.port}/ag-ui`,
+        { allowPrivateHosts: true, timeoutMs: 3_000 },
+      );
+      const took = Date.now() - started;
+
+      // It answered, immediately and correctly, with events this check can read. Anything else is
+      // this deployment describing a working agent as one that may not be reachable.
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.events).toContain("RUN_STARTED");
+      // Well inside the timeout. The check has what it needs after the opening of the stream, and
+      // an answer that arrives only when the agent stops talking is an answer that depends on the
+      // agent stopping.
+      expect(took).toBeLessThan(2_000);
+    } finally {
+      agent.stop(true);
+    }
+  });
+});


### PR DESCRIPTION
Register an agent that streams its answer — a Bot working through a document, a model writing slowly
— and press **Test connection**. The form sits there for the full fifteen seconds and then says:

> The agent started answering and the connection broke.

Nothing broke. The agent had already answered correctly: `RUN_STARTED` was the first thing it wrote.
The person registering it is now looking at their own service, which is fine.

Measured, against a real `Bun.serve` agent on loopback that writes its events and then keeps
streaming (a kilobyte every 20ms, the way a model streams), with the timeout cut to 3s so the probe
is quick:

```
before: took 3016ms  { "ok": false, "status": 200,
                       "reason": "The agent started answering and the connection broke." }
after:  took  237ms  { "ok": true, "events": [ "RUN_STARTED" ], "status": 200 }
```

## Why

`server/src/agents/connection-test.ts` has the right idea written down beside the constant:

```ts
/** Enough of the stream to prove it is an agent. Reading it all could mean reading a whole reply. */
const MAX_BYTES = 8_000;
```

and then reads it all:

```ts
body = (await response.text()).slice(0, MAX_BYTES);
```

`response.text()` reads a body to its end, so the cap was applied to a string this process had
already taken in full. The check therefore took as long as the agent's *run*, not as long as its
*answer* — and when that outlasted `AbortSignal.timeout`, the abort came back through `text()` as a
rejected read, into the catch written for a connection that really did drop.

That catch is why the sentence is the one above rather than the timeout one: the request itself had
succeeded, so it is the body read that aborts, and 200 is already on the result.

## The fix

Read from `response.body` until `MAX_BYTES` is reached, then cancel the rest. Counted in bytes, which
is what the constant is named in and what a chunk off the wire is measured in. The chunk that crosses
the cap is kept whole rather than cut at it — one read past the cap at most, and a cut through a
multi-byte character would put a replacement character in the middle of a line the scan is about to
read.

The cancel is in a `finally`, because the agent is very likely still writing and nothing is going to
read the rest: leaving it open holds a socket into somebody's agent for as long as that run cares to
go on.

## Measured

`bun test server/tests/agent-connection-live.test.ts`

- Against `origin/main` with only the new test applied: **10 pass, 1 fail**. The new case
  (`is reported as working, without waiting for it to finish`) takes 3008ms and returns
  `ok: false`. Whole file: 3.28s.
- With the change: **11 pass, 0 fail**. Whole file: 345ms.

The ten cases that were already in that file are the pin, and they pass before and after. They are
the ones that would catch an over-correction, because they are all about reading the body correctly:
a real `@copilotkit/aimock` agent reporting `RUN_STARTED`/`RUN_FINISHED`, a run that starts and never
finishes, an agent answering `RUN_ERROR`, a stream carrying a tool call, a redirect that is followed,
a redirect that is refused, a redirect loop, and three unreachable addresses.

Also run, all green:

- `bun test server/tests/agent-endpoint.test.ts server/tests/agent-test-connection-headers.test.ts server/tests/agent-routes.test.ts` — 111 pass, 0 fail
- `bun run --filter server typecheck` — exit 0
- `bunx biome check` on both changed files — clean

## Note on the CHANGELOG

A deployment behaves differently afterwards, so there is an entry. It goes at the top of
`## Unreleased`, the same one line every entry goes at, so it will conflict with any other PR open
against that anchor. Happy to rebase whenever it suits you.
