### PR TITLE
Stop the deployment that is running, not the default one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### Quitting the desktop app stops the deployment it was running
+
+Stop and Quit take the containers down by running `compose down` in the deployment's own directory,
+and the shell remembers which directory that is while a stack is up. It also ends the run before it
+takes anything down, so the restart policy watching the three host processes does not start one
+again into a stack that is going away — and ending the run is what clears the remembered path. The
+path was then read back, two lines later, and was always the empty one that had just been written.
+So every stop fell through to the path it had been handed instead, which from the menu bar and on
+quit is the default `~/OpenBot`. A deployment somebody had put anywhere else was left running:
+postgres, the supervisor, the computer and both Bots still up, with the application gone from the
+screen and nothing left to stop them from. The deployment is now named at the moment the run ends,
+in one step, so the two cannot come apart again. A window that raised nothing itself still stops the
+deployment it was told about, which is what makes Stop work in a second window.
+
 ### A deployment directory pasted with a stray space goes where it says
 
 The desktop setup screen asks where OpenBot should live, enables Start once that box is not blank

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -44,6 +44,29 @@ struct Shell {
     setup_url: Mutex<Option<String>>,
 }
 
+impl Shell {
+    /// Which deployment this run raised, taken rather than read.
+    ///
+    /// Both places that stop a stack do the same two things, and the order they have to happen in
+    /// is what this exists for. The run is ended first, because the watcher must stop before
+    /// anything is killed or it answers a death it caused by starting a process into a stack that
+    /// is going away -- and ending the run is what clears this. Then the deployment has to be
+    /// named, because that is the directory `compose down` runs in.
+    ///
+    /// Read back afterwards it was always the `None` that had just been written, so every stop fell
+    /// through to the path it was handed instead. From the tray and on quit that is `default_root`,
+    /// and a deployment somebody put anywhere else was left running: `compose down` in
+    /// `~/OpenBot`, five containers still up, and no window left to stop them from. `take` is both
+    /// halves in one, in the only order they work in.
+    fn deployment_being_stopped(&self, fallback: &Path) -> PathBuf {
+        self.root
+            .lock()
+            .unwrap()
+            .take()
+            .unwrap_or_else(|| fallback.to_path_buf())
+    }
+}
+
 #[derive(Serialize, Clone)]
 struct Progress {
     step: String,
@@ -300,29 +323,22 @@ fn stop_everything(app: &tauri::AppHandle, fallback_root: &Path) -> Result<(), S
     shell
         .generation
         .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-    *shell.root.lock().unwrap() = None;
+    // Taken with the run it belongs to, in one step, because the next thing this needs is where
+    // that deployment is. The window may also be a second one, holding no handles to a stack that
+    // is still up: then there is nothing to take, and the deployment it was told about is the one
+    // to stop, or Stop is a button that does nothing and reports success.
+    let root = shell.deployment_being_stopped(fallback_root);
     for (_, mut child) in shell.children.lock().unwrap().drain(..) {
         let _ = child.kill();
         let _ = child.wait();
     }
 
-    // The window may be a second one, holding no handles to a stack that is still up. Stop what is
-    // there rather than only what this window started, or Stop is a button that does nothing and
-    // reports success.
-    let root = shell
-        .root
-        .lock()
-        .unwrap()
-        .clone()
-        .unwrap_or_else(|| fallback_root.to_path_buf());
     stack::stop_processes_under(&root);
 
-    let outcome = match engine::detect().address {
+    match engine::detect().address {
         Some(found) => stack::down(&found, &root),
         None => Ok(()),
-    };
-    *shell.root.lock().unwrap() = None;
-    outcome
+    }
 }
 
 /// Show OpenBot itself in this window.
@@ -719,8 +735,11 @@ fn main() {
             // nobody is watching.
             if matches!(event, tauri::RunEvent::Exit) {
                 let shell = app.state::<Shell>();
+                // Taken before anything is killed, for the reason `deployment_being_stopped` gives:
+                // this ends the run, and the containers below have to be taken down in the
+                // deployment that run raised rather than in the default path.
+                let root = shell.deployment_being_stopped(&PathBuf::from(default_root()));
                 {
-                    *shell.root.lock().unwrap() = None;
                     let mut children = shell.children.lock().unwrap();
                     for (_, child) in children.iter_mut() {
                         ask_to_stop(child);
@@ -736,12 +755,6 @@ fn main() {
                 // The containers too. Leaving five of them running behind an application that is
                 // no longer on screen is the one outcome nobody can act on: there is no window to
                 // stop them from and nothing to say they are there.
-                let root = shell
-                    .root
-                    .lock()
-                    .unwrap()
-                    .clone()
-                    .unwrap_or_else(|| PathBuf::from(default_root()));
                 stack::stop_processes_under(&root);
                 if let Some(found) = engine::detect().address {
                     let _ = stack::down(&found, &root);
@@ -762,4 +775,68 @@ fn ask_to_stop(child: &std::process::Child) {
     }
     #[cfg(not(unix))]
     let _ = child;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_stop_takes_down_the_deployment_this_window_raised() {
+        // The tray's Stop and the exit handler both pass `default_root` as the fallback, because
+        // neither of them is looking at the box the person typed a path into. Reading the root
+        // after the run had been ended handed them that fallback every time, so a deployment
+        // anywhere else was left running with nothing on screen able to stop it.
+        let shell = Shell::default();
+        *shell.root.lock().unwrap() = Some(PathBuf::from("/srv/openbot"));
+
+        let stopping = shell.deployment_being_stopped(Path::new("/home/me/OpenBot"));
+
+        assert_eq!(
+            stopping,
+            PathBuf::from("/srv/openbot"),
+            "the containers would have been taken down in the wrong directory"
+        );
+    }
+
+    #[test]
+    fn ending_a_run_is_what_naming_it_does() {
+        // Taken, not read: the watcher stops on an empty root, and leaving one behind would have it
+        // start a process again into a stack that is being taken down.
+        let shell = Shell::default();
+        *shell.root.lock().unwrap() = Some(PathBuf::from("/srv/openbot"));
+
+        let _ = shell.deployment_being_stopped(Path::new("/home/me/OpenBot"));
+
+        assert!(
+            shell.root.lock().unwrap().is_none(),
+            "the run has to end with the deployment being named"
+        );
+    }
+
+    #[test]
+    fn a_window_that_raised_nothing_stops_the_deployment_it_was_told_about() {
+        // A second window holds no handles to a stack an earlier one raised, and Stop there must
+        // still be a button that does something.
+        let shell = Shell::default();
+
+        assert_eq!(
+            shell.deployment_being_stopped(Path::new("/home/me/OpenBot")),
+            PathBuf::from("/home/me/OpenBot")
+        );
+    }
+
+    #[test]
+    fn stopping_twice_falls_back_the_second_time_rather_than_repeating_itself() {
+        // Stop, then quit: the second pass has nothing of its own left and must not go looking for
+        // a deployment that has already been taken down.
+        let shell = Shell::default();
+        *shell.root.lock().unwrap() = Some(PathBuf::from("/srv/openbot"));
+
+        let first = shell.deployment_being_stopped(Path::new("/home/me/OpenBot"));
+        let second = shell.deployment_being_stopped(Path::new("/home/me/OpenBot"));
+
+        assert_eq!(first, PathBuf::from("/srv/openbot"));
+        assert_eq!(second, PathBuf::from("/home/me/OpenBot"));
+    }
 }


### PR DESCRIPTION
Put OpenBot somewhere other than the default — type `/srv/openbot` into "Where OpenBot lives" —
start it, and then quit from the menu bar. The window goes away and the stack does not: postgres,
the supervisor, `agent-computer` and both Bots are still up. `Stop OpenBot` from the tray does the
same nothing. There is no window left to stop them from, and nothing on screen ever said they were
still there.

The same person who typed that path and pressed Start in the window can press Stop *in the window*
and it works, which is what makes this hard to see: the button that is right next to the box works,
and the two that are not do not.

## Why

Stop and Quit both do the same two things, in this order:

```rust
shell.generation.fetch_add(1, Ordering::SeqCst);
*shell.root.lock().unwrap() = None;            // end the run
... kill the host processes ...
let root = shell.root.lock().unwrap().clone()  // ask where the deployment is
    .unwrap_or_else(|| fallback_root.to_path_buf());
stack::down(&found, &root);                    // compose down, in that directory
```

Ending the run is what clears `Shell::root`, and that has to happen first: the watcher in
`supervise_host_processes` reads an empty root as "no run", and without that it would start a
process again into a stack that is being taken down. But the second half needs the same value, and
by the time it asks, the answer is the `None` the first half wrote. `unwrap_or_else` then hands back
the fallback — every time, on every path.

The fallback is where the damage is. `stop_stack` is called from the window, which passes the path
out of the box, so it lands on the right directory by coincidence. The tray's Stop and the exit
handler have no box to read and pass `default_root()`. So `compose down` runs in `~/OpenBot`, which
for this person is either absent or somebody else's deployment, and the containers that are actually
running are never named. The exit handler discards the result (`let _ =`), so not a word is printed.

The comment above the read says what it was for — "The window may be a second one, holding no
handles to a stack that is still up" — and that case is real and still has to work. It is the other
one, a window that raised the stack itself, that had been quietly turned into it.

## The fix

Naming the deployment and ending the run become one `take` on `Shell`, so there is no order left to
get wrong:

```rust
fn deployment_being_stopped(&self, fallback: &Path) -> PathBuf {
    self.root.lock().unwrap().take().unwrap_or_else(|| fallback.to_path_buf())
}
```

Both call sites use it, and the two now-redundant `= None` writes go. Nothing else moves.

## Reproduction

`stop_everything` takes an `AppHandle`, and the only thing the root decides is which directory
`compose down` runs in, so there is no seam on `main` to call and no observable without an engine.
The reproduction is therefore the shipped `Shell` driven through the two statements
`stop_everything` runs today, in that order — the four lines above, quoted into a test on
`1c7bd92` with nothing else changed:

```
---- repro::a_stop_takes_down_the_deployment_that_is_running stdout ----
thread '...' panicked at src\main.rs:791:9:
assertion `left == right` failed: the containers were taken down in the wrong directory
  left: "/home/me/OpenBot"
 right: "/srv/openbot"

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

`left` is the fallback; `right` is the deployment that was running.

The four tests this PR ships pin the fixed contract rather than re-running that transcription: the
deployment a window raised is the one stopped, ending the run is what naming it does, a window that
raised nothing stops the one it was told about, and a second stop falls back rather than going
looking for a deployment that has already been taken down.

## Verification

```
cargo fmt --check                              # clean
cargo clippy --all-targets -- -D warnings      # clean
cargo test --lib                               # 88 passed, 0 failed  (unchanged)
cargo test                                     # 88 + 4 new, 0 failed
```

Run from `desktop/src-tauri` on Windows with Rust 1.98.0.

One thing to flag: `desktop.yml` runs `cargo test --lib`, which does not include the binary target,
so these four run under `cargo test` and not in CI. `Shell` is the shell's own state and does not
belong in the library beside `.env` and Compose, so I have left it where it is rather than move a
struct to make a test reachable. If you would rather that job ran `cargo test`, say so and I will
add it here.

## Note on the changelog

The entry goes at the top of `## Unreleased`, which is the line every open PR touching the changelog
inserts at, so it will conflict with any other that lands first. Happy to rebase.
