### PR TITLE
Read a comment in a tenant theme as a comment, not as something the theme defines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A tenant package's theme may carry a comment
+
+A package's `theme.css` is checked at start-up against what it is allowed to define: the `:root` and
+`.dark` blocks, the approved variables, no imports and no URLs. A CSS comment defines none of those
+and was being read as though it did. One above the blocks — the line a hand-written stylesheet opens
+with, saying whose brand it is and where the colours came from — was left over once the blocks were
+set aside and refused as a second selector; one inside a block was split on the semicolons around it
+and refused as a variable name, with the comment quoted back as the name it was not. Because the
+package is read while the deployment starts, that was not a warning: the deployment did not come up,
+over a comment, saying nothing about comments. Comments are now taken out before the file is read as
+definitions, which also closes a comment wedged into the middle of `url(` as a way past the rule
+above it.
 ### A deployment directory pasted with a stray space goes where it says
 
 The desktop setup screen asks where OpenBot should live, enables Start once that box is not blank

--- a/server/src/tenant-package.ts
+++ b/server/src/tenant-package.ts
@@ -51,7 +51,30 @@ const approvedThemeVariables = new Set([
   "--sidebar-ring",
 ]);
 
-export function validateThemeCss(css: string) {
+export function validateThemeCss(rawCss: string) {
+  /*
+   * A comment is not something a theme defines, so it is taken out before anything below reads the
+   * text as definitions.
+   *
+   * Every rule here is about what a theme may DEFINE — two blocks, approved variables, no imports
+   * and no URLs — and a comment defines nothing. They were applied to the raw file anyway, so a
+   * stylesheet carrying the line every hand-written stylesheet opens with, saying whose brand it is
+   * and where the colours came from, was refused twice over. Above the blocks it survived the
+   * removal of them and read as a second selector: "Tenant theme may only define :root and .dark
+   * blocks". Inside one it was split on the semicolons around it and read as a variable name, so the
+   * refusal quoted the comment back as the variable it was not. A tenant package is loaded at
+   * start-up, so neither of those is a warning: the deployment does not come up, over a comment, and
+   * says nothing about comments.
+   *
+   * Taking them out first is stricter than leaving them in, never weaker. A comment wedged into the
+   * middle of the word `url` makes something a browser does not read as a URL token, and the test
+   * below did not read it as one either; with the comment gone, both do, and it is refused. A
+   * comment that is never closed does not match and is not removed, so it stays as the nonsense it
+   * is and is still refused. What a comment cannot do here is hide anything: what is left once they
+   * are gone is what a browser would act on.
+   */
+  const css = rawCss.replace(/\/\*[\s\S]*?\*\//g, " ");
+
   if (/@import|url\s*\(/i.test(css)) {
     throw new Error("Tenant theme must not contain imports or URLs");
   }

--- a/server/tests/tenant-package.test.ts
+++ b/server/tests/tenant-package.test.ts
@@ -140,6 +140,60 @@ describe("tenant theme validation", () => {
       "is not an approved theme variable",
     );
   });
+
+  /*
+   * A comment is not something a theme defines.
+   *
+   * The rule this enforces, as `docs/configuration.md` states it, is about what a theme may define:
+   * two blocks, approved variables, no imports and no URLs. A comment defines nothing, and a
+   * stylesheet written by hand has one at the top saying whose brand it is.
+   */
+  test("accepts a comment above the blocks", () => {
+    expect(() =>
+      validateThemeCss(`
+        /* Acme brand colours. Regenerate from the design tokens, do not hand-edit. */
+        :root { --primary: oklch(0.32 0.09 250); }
+      `),
+    ).not.toThrow();
+  });
+
+  test("accepts a comment inside a block", () => {
+    expect(() =>
+      validateThemeCss(`
+        :root {
+          /* The one colour everything else is derived from. */
+          --primary: oklch(0.32 0.09 250);
+          --border: oklch(0.9 0 0); /* deliberately flat */
+        }
+      `),
+    ).not.toThrow();
+  });
+
+  test("accepts a comment between the blocks", () => {
+    expect(() =>
+      validateThemeCss(`
+        :root { --primary: oklch(0.32 0.09 250); }
+        /* and the same again for dark mode */
+        .dark { --primary: oklch(0.87 0.03 250); }
+      `),
+    ).not.toThrow();
+  });
+
+  /*
+   * The guard against over-correcting. A comment must not become a way to smuggle in the two things
+   * this refuses, and a comment that is never closed is not a comment.
+   */
+  test("still refuses what a comment is wrapped around", () => {
+    expect(() =>
+      validateThemeCss(
+        ':root { --primary: url("https://example.com/x.png"); }',
+      ),
+    ).toThrow("must not contain imports or URLs");
+    expect(() => validateThemeCss("/* theme */ body { color: red; }")).toThrow(
+      "only define :root and .dark blocks",
+    );
+    expect(() => validateThemeCss(":root { /* --primary: red; }")).toThrow();
+  });
 });
 
 describe("tenant YAML validation", () => {


### PR DESCRIPTION
Put the line a hand-written stylesheet opens with at the top of a tenant package's `theme.css`:

```css
/* Acme brand colours. Regenerate from the design tokens, do not hand-edit. */
:root { --primary: oklch(0.32 0.09 250); }
```

and the deployment does not start. `loadTenantPackage` is a top-level `await` in
`server/src/index.ts`, so the throw comes out before anything is listening. What it says is:

```
comment above the blocks:            Tenant theme may only define :root and .dark blocks
comment inside a block:              Tenant theme variable /* the one colour */
                                       --primary is not an approved theme variable
trailing comment on a declaration:   Tenant theme variable /* flat * is not an approved theme variable
```

(verbatim, from calling `validateThemeCss` on `origin/main`.)

None of those sentences mentions a comment, so the thing to remove is not in the message. The middle
one quotes the comment back as the name of a variable.

## Why

`docs/configuration.md` states the rule as: "Theme CSS may define only `:root` and `.dark` blocks,
approved theme variables, and no `@import` or `url()`." Every clause of that is about what a theme
**defines**. A comment defines nothing — but `validateThemeCss` applies all three checks to the raw
file, so a comment is read as a definition:

- Above or between the blocks, it survives `css.replace(/(:root|\.dark)\s*\{[^{}]*\}/g, "")` and lands
  in `remaining`, which is the test for a second selector.
- Inside a block, `body.split(";")` hands it to the variable loop as a declaration, and it is
  refused under whatever the comment happens to say.

## The fix

One line, before the three checks: take the comments out, then read what is left as definitions.

Removing them first is **stricter** than leaving them, not weaker, which is the part worth checking:

- A comment wedged into the middle of `url` makes something a browser does not tokenise as a URL, and
  the `url\s*\(` test did not read it as one either. With the comment gone, both do, and it is
  refused.
- A comment that is never closed does not match, so it is not removed, stays as the nonsense it is,
  and is still refused.
- What a comment cannot do here is hide anything: what is left once they are gone is exactly what a
  browser would act on.

No doc change: the sentence in `docs/configuration.md` was already true, and is still true.

## Measured

`bun test server/tests/tenant-package.test.ts`

- Against `origin/main` with only the new tests applied: **30 pass, 19 fail**.
  - The three new cases fail: `accepts a comment above the blocks`, `accepts a comment inside a
    block`, `accepts a comment between the blocks`.
  - The other 16 are pre-existing on this machine — this file's `describe`s for package
    synchronisation talk to Postgres, and there is none here. They fail identically on unmodified
    `main` (29 pass, 16 fail before any of my tests were added).
- With the change: **33 pass, 16 fail** — the same 16 Postgres failures, and nothing else.

The fourth new test, `still refuses what a comment is wrapped around`, is the guard against
over-correcting and passes both before and after: a `url()` in a value is still refused, a comment
followed by `body { }` is still refused as a selector, and an unterminated comment is still refused.
So do the two theme tests that were already there.

Also run, all green:

- `bun run --filter server typecheck` — exit 0
- `bunx biome check` on both changed files — clean

## Note on the CHANGELOG

A deployment that would not start now starts, so there is an entry. It goes at the top of
`## Unreleased`, the one line every entry goes at, so it will conflict with any other PR open against
that anchor. Happy to rebase whenever it suits you.
