### PR TITLE
Read 7 as Sunday when describing a routine's schedule, the way the scheduler does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A routine scheduled for Sunday says Sundays, whichever number it was written with
+
+Crontab has always let Sunday be either 0 or 7, the scheduler here takes both, and a routine written
+with 7 is stored and fires on Sunday like any other. Only the 0 spelling was recognised by the
+sentence the Routines page draws and the Bot reads back, so a working weekend routine appeared on
+that page as `0 9 * * 7` while its neighbour said "Sundays at 09:00" — the same schedule, described
+two ways, with the raw one looking like something had gone wrong. Both spellings now read as Sunday,
+and a list that names the day under both of its numbers says it once.
 ### A deployment directory pasted with a stray space goes where it says
 
 The desktop setup screen asks where OpenBot should live, enables Start once that box is not blank

--- a/server/src/routines/schedule.ts
+++ b/server/src/routines/schedule.ts
@@ -214,6 +214,27 @@ function joinWords(words: string[]): string {
   return `${rest.join(", ")} and ${last}`;
 }
 
+/**
+ * The days a plain day-of-week field names, or null when it is not one.
+ *
+ * SUNDAY IS 0 AND IT IS ALSO 7. Both are ordinary crontab, `cron-parser` fires on Sunday for either,
+ * and `nextOccurrence` above accepts both — so a routine written `0 9 * * 7` is scheduled, fires on
+ * Sunday, and was then described to its owner and back to the model as `0 9 * * 7`, because only the
+ * 0 spelling was recognised here. That is not the raw-expression fallback doing its job on a shape
+ * this cannot render; it is one of this function's own shapes arriving under the other of the two
+ * names its own scheduler takes.
+ *
+ * De-duplicated, because 7 and 0 are one day and `0,7` would otherwise render as "Sundays and
+ * Sundays", which is worse than the raw expression it replaced. Order is left as written, like the
+ * weekday list always has been.
+ */
+function weekdays(field: string): number[] | null {
+  if (!/^[0-7](,[0-7])*$/.test(field)) return null;
+  return [
+    ...new Set(field.split(",").map((digit) => Number.parseInt(digit, 10) % 7)),
+  ];
+}
+
 function parsePlainInt(field: string, min: number, max: number): number | null {
   if (!/^\d{1,2}$/.test(field)) return null;
   const value = Number.parseInt(field, 10);
@@ -295,14 +316,12 @@ export function describeCron(cron: string): string {
       if (dayOfWeekField === "1-5") {
         return `Weekdays at ${time}`;
       }
-      if (/^[0-6]$/.test(dayOfWeekField)) {
-        const dayIndex = Number.parseInt(dayOfWeekField, 10);
-        return `${WEEKDAY_NAMES[dayIndex]}s at ${time}`;
+      const days = weekdays(dayOfWeekField);
+      if (days?.length === 1) {
+        return `${WEEKDAY_NAMES[days[0] as number]}s at ${time}`;
       }
-      if (/^[0-6](,[0-6])+$/.test(dayOfWeekField)) {
-        const names = dayOfWeekField
-          .split(",")
-          .map((digit) => `${WEEKDAY_NAMES[Number.parseInt(digit, 10)]}s`);
+      if (days && days.length > 1) {
+        const names = days.map((day) => `${WEEKDAY_NAMES[day]}s`);
         return `${joinWords(names)} at ${time}`;
       }
     }

--- a/server/tests/routine-schedule.test.ts
+++ b/server/tests/routine-schedule.test.ts
@@ -194,6 +194,34 @@ describe("describeCron", () => {
     expect(describeCron("0 9,17 * * *")).toBe("0 9,17 * * *");
   });
 
+  /*
+   * Sunday is 0 and it is also 7.
+   *
+   * Both spellings are ordinary crontab, `cron-parser` fires on Sunday for either, and the routine
+   * this describes is already scheduled. So this is not a shape the renderer has never been taught:
+   * it is one of its own shapes, arriving under the other of the two names its own scheduler accepts.
+   */
+  test("the scheduler fires on Sunday for either spelling", () => {
+    const from = new Date("2026-09-10T00:00:00Z");
+    expect(nextOccurrence("0 9 * * 0", "UTC", from).toISOString()).toBe(
+      nextOccurrence("0 9 * * 7", "UTC", from).toISOString(),
+    );
+    // A Sunday, so the assertion above is not two equal wrong answers.
+    expect(nextOccurrence("0 9 * * 7", "UTC", from).getUTCDay()).toBe(0);
+  });
+
+  test("a single weekday written as 7", () => {
+    expect(describeCron("0 9 * * 7")).toBe("Sundays at 09:00");
+  });
+
+  test("a listed set of weekdays ending on 7", () => {
+    expect(describeCron("0 9 * * 6,7")).toBe("Saturdays and Sundays at 09:00");
+  });
+
+  test("one day named under both of its numbers is said once", () => {
+    expect(describeCron("0 9 * * 0,7")).toBe("Sundays at 09:00");
+  });
+
   test("never throws, even on garbage", () => {
     expect(describeCron("not a cron expression")).toBe("not a cron expression");
   });


### PR DESCRIPTION
Ask a Bot for a routine every Sunday morning. If the expression it writes is `0 9 * * 0` the Routines
page says **Sundays at 09:00**. If it writes `0 9 * * 7` — the other number crontab has always used
for Sunday — the same page says **`0 9 * * 7`**, and so does the Bot when it lists what is standing.

Two routines, the same schedule, one of them shown as a raw cron expression next to one shown in
words. The raw one reads as something having gone wrong with it, and nothing has: it is scheduled and
it fires.

Measured against `origin/main`, from a fixed 2026-09-10:

```
0 9 * * 0      next=Sun, 13 Sep 2026 09:00:00 GMT    says=Sundays at 09:00
0 9 * * 7      next=Sun, 13 Sep 2026 09:00:00 GMT    says=0 9 * * 7
0 9 * * 6,7    next=Sat, 12 Sep 2026 09:00:00 GMT    says=0 9 * * 6,7
0 9 * * 1-5    next=Thu, 10 Sep 2026 09:00:00 GMT    says=Weekdays at 09:00
```

## Why

`nextOccurrence` accepts `7` (via `cron-parser`) and fires on Sunday for it, so the routine is real.
`describeCron` a few lines below keys its two weekday branches on `/^[0-6]$/` and
`/^[0-6](,[0-6])+$/`, so `7` misses both and lands on the raw-expression fallback.

That fallback is deliberate and this does not change it. The file says unrecognized shapes fall back
rather than raise, and a comment in `routine-schedule.test.ts` says an hour list staying on the
fallback "is the contract, not a gap". This is not one of those: a single weekday and a comma list of
weekdays are shapes `describeCron` already renders. What was missing is that one of the two numbers
its own scheduler accepts for one of the seven days was not recognised as that day.

## The fix

One helper that reads a plain day-of-week field into day indexes, with `7` normalised onto `0`, used
by both weekday branches.

De-duplicated, because 7 and 0 are one day: without that, `0,7` would render "Sundays and Sundays",
which is worse than the raw expression it replaced. Order within a list is left as written, which is
what the weekday list has always done.

Untouched: `*`, `1-5` and every range or step form, which are matched before this and after it
respectively, and the raw-expression fallback for everything else.

## Measured

`bun test server/tests/routine-schedule.test.ts`

- Against `origin/main` with only the new tests applied: **25 pass, 3 fail**.
  - `a single weekday written as 7` — got `0 9 * * 7`, wanted `Sundays at 09:00`
  - `a listed set of weekdays ending on 7` — got `0 9 * * 6,7`
  - `one day named under both of its numbers is said once` — got `0 9 * * 0,7`
- With the change: **28 pass, 0 fail**.

A fourth new test is the one that makes the other three a defect rather than a preference, and it
passes before and after: `the scheduler fires on Sunday for either spelling` asserts that
`nextOccurrence` gives the same instant for `0 9 * * 0` and `0 9 * * 7`, and that the instant is a
Sunday.

The pins are the twelve `describeCron` cases already in that file, which pass before and after —
including the two that assert a shape stays on the raw-expression fallback (`*/40 * * * *` and
`0 9,17 * * *`), the single weekday `3`, the list `1,3,5`, and `1-5`.

Also run, all green:

- `bun test server/tests/routine-runner.test.ts server/tests/routine-routes.test.ts server/tests/routine-endpoint.test.ts server/tests/builtin-routines.test.ts` — 66 pass, 0 fail
- `bun run --filter server typecheck` — exit 0
- `bunx biome check` on both changed files — clean

## Note on the CHANGELOG

The Routines page says something different afterwards, so there is an entry. It goes at the top of
`## Unreleased`, the one line every entry goes at, so it will conflict with any other PR open against
that anchor. Happy to rebase whenever it suits you.
