### PR TITLE
Read a half-ticked box as not ticked, not as ticked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A half-ticked box is no longer described to a Bot as ticked
+
+The snapshot a Bot reads before it acts on a page says whether each box is ticked, and Playwright
+writes that as `[checked]` for one that is and `[checked=mixed]` for one that is neither — which is
+what the "select all" above a partly-ticked list carries. The parser treated any value other than
+the string `false` as ticked, and `mixed` is one, so a half-ticked box was reported as done. A Bot
+asked to select everything read it as already selected, clicked nothing, and said the rows were
+chosen when most of them were not. `mixed` is now reported as not ticked, which is both the true
+half of a yes-or-no answer and the one that gets the right action: clicking a half-ticked box ticks
+it. An ordinary tick and an ordinary empty box are unchanged.
+
 ### A deployment directory pasted with a stray space goes where it says
 
 The desktop setup screen asks where OpenBot should live, enables Start once that box is not blank

--- a/agent-computer/src/aria-snapshot.ts
+++ b/agent-computer/src/aria-snapshot.ts
@@ -184,8 +184,15 @@ function toElement(
   // Playwright emits `[checked]` only when something is checked, so absence is ambiguous on its own: a
   // Bot cannot tell an unticked box from a control that does not tick. Reported as false for the roles
   // that can be checked, and left off entirely for the ones that cannot.
+  //
+  // `[checked=mixed]` is the third state and the one spelling Playwright gives the flag a value for:
+  // `aria-checked="mixed"`, which is what the box above a partly-ticked list carries. It is not
+  // ticked, and a Bot told it was left the rows underneath unselected and reported the job done. The
+  // contract this fills in is `checked?: boolean`, so "neither" has to be said as false — which is
+  // also the answer that gets the right action, since clicking a mixed box ticks it.
   if (descriptor.flags.has("checked")) {
-    element.checked = descriptor.flags.get("checked") !== "false";
+    const state = descriptor.flags.get("checked");
+    element.checked = state !== "mixed" && state !== "false";
   } else if (CHECKABLE_ROLES.has(descriptor.role)) {
     element.checked = false;
   }

--- a/agent-computer/tests/aria-snapshot.test.ts
+++ b/agent-computer/tests/aria-snapshot.test.ts
@@ -105,6 +105,39 @@ describe("parseAriaSnapshot, against captured output", () => {
     expect(byName.get("Submit order")).not.toHaveProperty("checked");
   });
 
+  /**
+   * A half-ticked "select all", which is the shape this got wrong.
+   *
+   * `aria-checked="mixed"` is what a box above a partly-ticked list carries, and Playwright writes
+   * it as `[checked=mixed]` -- a value, where an ordinary tick is the bare `[checked]`.
+   */
+  const MIXED = `- generic [ref=e2]:
+  - checkbox "Select all" [checked=mixed] [ref=e3]
+  - checkbox "Bacon" [checked] [ref=e4]
+  - checkbox "Extra Cheese" [ref=e5]`;
+
+  test("the mixed fixture is genuinely valid YAML", () => {
+    expect(() => Bun.YAML.parse(MIXED)).not.toThrow();
+  });
+
+  test("a half-ticked box is not reported as ticked", () => {
+    const byName = new Map(
+      parseAriaSnapshot(MIXED).elements.map((e) => [e.name, e]),
+    );
+    // Not checked, so a Bot asked to tick it clicks it. Told it was already checked, it left the
+    // rows underneath unselected and said they were done.
+    expect(byName.get("Select all")?.checked).toBe(false);
+    // And the two beside it are unchanged, so this is not a swap.
+    expect(byName.get("Bacon")?.checked).toBe(true);
+    expect(byName.get("Extra Cheese")?.checked).toBe(false);
+  });
+
+  test("a half-ticked box is still a control a Bot can act on", () => {
+    const [first] = parseAriaSnapshot(MIXED).elements;
+    // The ref is what a click needs, and it sits after the flag Playwright gave a value to.
+    expect(first).toMatchObject({ ref: "e3", role: "checkbox" });
+  });
+
   test("empty and unparseable input produce no elements rather than throwing", () => {
     expect(parseAriaSnapshot("").elements).toEqual([]);
     expect(parseAriaSnapshot("\t- [[[ not yaml").elements).toEqual([]);

--- a/agent-computer/tests/aria-snapshot.test.ts
+++ b/agent-computer/tests/aria-snapshot.test.ts
@@ -106,15 +106,27 @@ describe("parseAriaSnapshot, against captured output", () => {
   });
 
   /**
-   * A half-ticked "select all", which is the shape this got wrong.
+   * A half-ticked "select all", captured the same way the fixture above was.
    *
-   * `aria-checked="mixed"` is what a box above a partly-ticked list carries, and Playwright writes
-   * it as `[checked=mixed]` -- a value, where an ordinary tick is the bare `[checked]`.
+   * `ariaSnapshot({ mode: "ai" })` against a fieldset of three boxes in Chromium 151, with the first
+   * one's `indeterminate` set — which is what a box above a partly-ticked list carries. Playwright
+   * writes that as `[checked=mixed]`: a value, where an ordinary tick is the bare `[checked]`. It is
+   * the only flag in this output that carries one, which is the whole of the bug.
+   *
+   * Captured rather than written, for the reason the note at the top of this file gives. Guessed at,
+   * the entry loses the `generic` wrapper each box sits inside and the `text` node beside it, and the
+   * guess would pass while the shipped parser walked something else.
    */
-  const MIXED = `- generic [ref=e2]:
-  - checkbox "Select all" [checked=mixed] [ref=e3]
-  - checkbox "Bacon" [checked] [ref=e4]
-  - checkbox "Extra Cheese" [ref=e5]`;
+  const MIXED = `- group "Toppings" [ref=e2]:
+  - generic [ref=e4]:
+    - checkbox "Select all" [checked=mixed] [ref=e5]
+    - text: Select all
+  - generic [ref=e6]:
+    - checkbox "Bacon" [checked] [ref=e7]
+    - text: Bacon
+  - generic [ref=e8]:
+    - checkbox "Extra Cheese" [ref=e9]
+    - text: Extra Cheese`;
 
   test("the mixed fixture is genuinely valid YAML", () => {
     expect(() => Bun.YAML.parse(MIXED)).not.toThrow();
@@ -135,7 +147,7 @@ describe("parseAriaSnapshot, against captured output", () => {
   test("a half-ticked box is still a control a Bot can act on", () => {
     const [first] = parseAriaSnapshot(MIXED).elements;
     // The ref is what a click needs, and it sits after the flag Playwright gave a value to.
-    expect(first).toMatchObject({ ref: "e3", role: "checkbox" });
+    expect(first).toMatchObject({ ref: "e5", role: "checkbox" });
   });
 
   test("empty and unparseable input produce no elements rather than throwing", () => {


### PR DESCRIPTION
Ask a Bot to tick every row on a page whose "select all" box is half-ticked — some rows already
selected, some not — and it clicks nothing and tells the person the rows are selected. They are not.
The same happens on any tri-state checkbox: a consent tree, a permissions matrix, a partly expanded
filter list.

## Why

The snapshot a Bot reads before it acts carries `checked` per control. Here is what
`ariaSnapshot({ mode: "ai" })` actually produces, captured against Chromium 151 (playwright-core
1.62.1's own build) for a fieldset of three boxes with the first one's `indeterminate` set:

```
- group "Toppings" [ref=e2]:
  - generic [ref=e4]:
    - checkbox "Select all" [checked=mixed] [ref=e5]
    - text: Select all
  - generic [ref=e6]:
    - checkbox "Bacon" [checked] [ref=e7]
    - text: Bacon
  - generic [ref=e8]:
    - checkbox "Extra Cheese" [ref=e9]
    - text: Extra Cheese
```

An ordinary tick is the bare `[checked]`; the third state is `[checked=mixed]` — the only flag in
that output carrying a value. Playwright's renderer says the same thing in two lines:

```js
if (ariaNode.checked === "mixed")
  key += ` [checked=mixed]`;
if (ariaNode.checked === true)
  key += ` [checked]`;
```

`toElement` read the flag like this:

```ts
element.checked = descriptor.flags.get("checked") !== "false";
```

`"false"` is a spelling Playwright does not emit. `"mixed"`, the one it does, is not `"false"`, so a
half-ticked box arrived as `checked: true` and the Bot went on from a snapshot that said the job was
done.

## The fix

```ts
const state = descriptor.flags.get("checked");
element.checked = state !== "mixed" && state !== "false";
```

The defensive `"false"` branch stays, since removing it would be a second change in one line.

Why `false` and not "leave it off": the published contract is `checked?: boolean`
(`server/src/computer/schema.ts`), and for a checkable role this file always fills it in on purpose —
its own comment says absence would otherwise be ambiguous between an unticked box and a control that
does not tick. `false` is the true half of a yes-or-no answer about a box that is not ticked, and it
is also the answer that produces the right action, because clicking a half-ticked box ticks it.

## Measured

`bun test agent-computer/tests/aria-snapshot.test.ts`

- Against `origin/main` (`1c7bd92`) with only the three new tests applied: **26 pass, 1 fail**.

```
expect(byName.get("Select all")?.checked).toBe(false);
error: expect(received).toBe(expected)
Expected: false
Received: true
(fail) parseAriaSnapshot, against captured output > a half-ticked box is not reported as ticked
```

- With the change: **27 pass, 0 fail**.

The fixture is the captured output above rather than a hand-written entry, for the reason the note at
the top of that file gives: a guess loses the `generic` wrapper each box sits inside and the `text`
node beside it, and would pass while the shipped parser walked something else.

The other two new tests are the guard against over-correcting and pass before and after: the fixture
is valid YAML, and a half-ticked box is still a control with a usable `ref` — its flag carries a value
and `ref` comes after it, which is the parse that would break if this were done with a pattern. The
existing case, an ordinary `[checked]` and an ordinary empty box, is asserted in the same test and is
unchanged.

`bun test agent-computer/tests` — **234 pass, 15 skip, 20 fail**. The same 20 fail on `origin/main`
(231 pass there, so the three new ones are the whole difference): 11 in `shell.test.ts`, which spawns
`/bin/bash`, and 9 in `workspace.test.ts`, which creates symlinks. Neither is available on the Windows
machine these were run on and neither is touched here.

Also run, clean: `bunx biome check` on both changed files, and `bun run typecheck` in
`agent-computer`.

## Note on the changelog

A Bot behaves differently afterwards, so there is an entry. It goes at the top of `## Unreleased`,
which is the line every open PR touching the changelog inserts at, so it will conflict with any other
that lands first. Happy to rebase.
