### PR TITLE
Refuse a blank question put to a person, the way a blank task handed to a Bot is refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### A Bot cannot end its turn by asking a person nothing
+
+`ask_person` is how a Bot stops and puts something to a person instead of guessing, and a call with
+no question in it was already meant to come back as a sentence telling it to say what it needs. That
+only happened when the field was missing altogether. A question that was present and empty was
+carried out: the Bot was told its question had been put to somebody, its turn ended there, and the
+trail took an escalation row with nothing in its question — the row an administrator counts these by,
+saying a person was asked something that was never said. On a deployment whose escalation route is a
+duty desk rather than the person already in the conversation, it is a page to somebody with no
+question on it. A blank question is now refused with the sentence that was already written for it,
+and a question typed with room around it is recorded as the question rather than as the spacing.
 ### A deployment directory pasted with a stray space goes where it says
 
 The desktop setup screen asks where OpenBot should live, enables Start once that box is not blank

--- a/server/src/agents/escalation.ts
+++ b/server/src/agents/escalation.ts
@@ -102,12 +102,31 @@ export function escalationTool(options: {
         return "That was not put to anybody: say what you need a person to answer.";
       }
 
+      /*
+       * A question field that is present and empty is a call with nothing in it.
+       *
+       * `z.string()` accepts "" and a run of spaces, so the refusal above — which is the sentence
+       * written for exactly this — only ever fired when the field was missing altogether. Spelled
+       * the other way it went straight through: the Bot was told its question had been put to
+       * somebody, the turn ended on that, and the trail took an `agent.escalated` row with nothing
+       * in its question, which is the row an operator counts escalations by. Where a route is a duty
+       * desk rather than the person already here, it is a page to somebody with no question on it.
+       *
+       * `message_bot`, which this competes with for the same decision, refuses a blank task and says
+       * so. This is the other half of that, and the trimmed text is what travels, for the same
+       * reason a handoff sends the trimmed task: what was recorded should be what was asked.
+       */
+      const question = parsed.data.question.trim();
+      if (!question) {
+        return "That was not put to anybody: say what you need a person to answer.";
+      }
+
       const outcome = await route({
         actorId: from.actorId,
         botId: from.botId,
         ...(from.threadId ? { threadId: from.threadId } : {}),
         runId: from.runId,
-        question: parsed.data.question,
+        question,
         ...(parsed.data.why ? { why: parsed.data.why } : {}),
       });
 
@@ -128,7 +147,7 @@ export function escalationTool(options: {
           payload: {
             bot: from.botId,
             run: from.runId,
-            question: parsed.data.question,
+            question,
             ...(parsed.data.why ? { why: parsed.data.why } : {}),
             ...("reached" in outcome
               ? { reached: outcome.reached }

--- a/server/tests/agent-escalation.test.ts
+++ b/server/tests/agent-escalation.test.ts
@@ -128,6 +128,58 @@ describe("asking a person", () => {
 
     expect(said).toContain("say what you need");
   });
+
+  /*
+   * The same call, spelled the other way.
+   *
+   * A question field that is present and empty is a call with nothing in it too, and the refusal
+   * above is the sentence written for it. `message_bot`, the tool this competes with for the same
+   * decision, refuses a blank task and says so; this is the other half of that.
+   */
+  test.each([
+    ["an empty question", ""],
+    ["a question of spaces", "   "],
+  ])("%s is refused as a sentence", async (_name, question) => {
+    const tool = escalationTool({ from: FROM, route: askTheirOwnPerson });
+
+    const said = await tool.execute({ question });
+
+    expect(said).toContain("say what you need");
+    expect(said).not.toContain(PUT_TO);
+  });
+
+  test("a blank question reaches nobody and leaves no row saying it did", async () => {
+    const { written, store } = recorder();
+    let reached = 0;
+    const tool = escalationTool({
+      from: FROM,
+      route: async () => {
+        reached += 1;
+        return { reached: "the on-call engineer" };
+      },
+      auditStore: store,
+    });
+
+    await tool.execute({ question: "  " });
+
+    // An `agent.escalated` row with no question in it is the row an operator counts escalations by,
+    // saying a person was asked something that was never said.
+    expect(reached).toBe(0);
+    expect(written).toEqual([]);
+  });
+
+  test("a question with room around it is recorded as the question", async () => {
+    const { written, store } = recorder();
+    const tool = escalationTool({
+      from: FROM,
+      route: askTheirOwnPerson,
+      auditStore: store,
+    });
+
+    await tool.execute({ question: "  which account?  " });
+
+    expect(written[0]?.payload).toMatchObject({ question: "which account?" });
+  });
 });
 
 /*


### PR DESCRIPTION
A Bot calls `ask_person` with `{"question": ""}`. It is told:

> That was put to the person in this conversation. Ask it in your own words now, plainly, and stop
> there: do not answer it yourself and do not hand it to another Bot.

so it stops, and its turn ends. On the Audit screen there is now an `agent.escalated` row — the row
an administrator counts escalations by — whose `question` is empty. It says a person was asked
something that was never said.

On a deployment whose `EscalationRoute` is a duty desk or an on-call rota rather than the person
already in the conversation, which is the seam the module is explicitly built around, that is a page
to somebody with no question on it.

## Why

`server/src/agents/escalation.ts` already has the sentence for this case:

```ts
const parsed = parameters.safeParse(args);
if (!parsed.success) {
  return "That was not put to anybody: say what you need a person to answer.";
}
```

and `server/tests/agent-escalation.test.ts` already asserts it, under
`a call with nothing in it is refused as a sentence`, by calling `execute({})`.

But `question` is `z.string()`, which accepts `""` and a run of spaces. So the refusal fired only
when the field was **missing**. Present and empty is the same call spelled the other way, and it went
straight through.

The tool this sits beside and competes with for the same decision does check. `handoff.ts`:

```ts
const task = envelope.task?.trim() ?? "";
if (!task) {
  return refuse(from, target, "no_task",
    "Nothing was sent: a handoff has to say what the other Bot is being asked to do.");
}
```

A blank task handed to a Bot is refused, recorded as `no_task`, and answered with a sentence. A blank
question put to a person was not.

## The fix

Trim the question, and refuse it with the sentence that was already written for this. The trimmed
text is then what travels to the route and onto the row — for the same reason a handoff sends the
trimmed task: what is recorded should be what was asked, not the spacing around it.

Deliberately not changed: `why` stays optional and is left as the model wrote it, and every other
path through the tool is untouched.

## Measured

`bun test server/tests/agent-escalation.test.ts`

- Against `origin/main` with only the new tests applied: **8 pass, 4 fail**.
  - `an empty question is refused as a sentence` — returns the "That was put to…" sentence.
  - `a question of spaces is refused as a sentence` — same.
  - `a blank question reaches nobody and leaves no row saying it did` — the route is called and an
    `agent.escalated` row is written.
  - `a question with room around it is recorded as the question` — the row carries
    `"  which account?  "`.
- With the change: **12 pass, 0 fail**.

The pins are the eight cases already in that file, which pass before and after: a real question still
reaches the route and comes back with the `PUT_TO` marker the transcript matches on, the row still
carries the question and the `why`, a routine's escalation is still filed under its initiator, a
route that reaches nobody is still recorded as `agent.escalation_failed`, and `execute({})` is still
refused.

Also run, all green:

- `bun test server/tests/agent-handoff-tool.test.ts server/tests/agent-handoff.test.ts server/tests/control-refusal-end-to-end.test.ts server/tests/human-input-end-to-end.test.ts` — 41 pass, 0 fail
- `bun run --filter server typecheck` — exit 0
- `bunx biome check` on both changed files — clean

## Note on the CHANGELOG

A turn that used to end now does not, so there is an entry. It goes at the top of `## Unreleased`,
the one line every entry goes at, so it will conflict with any other PR open against that anchor.
Happy to rebase whenever it suits you.
