### PR TITLE
Make Enter act while a person is driving the browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### Pressing Enter works while a person is driving a Bot's browser
+
+Taking the wheel of a Bot's browser is mostly for the sign-in it cannot do itself, and Enter is how a
+sign-in ends. Every keystroke reached the page, and Enter reached it as a key press that produces no
+character — which Chrome delivers to the page's own listeners and then does nothing further with. So
+the form did not submit, a new line in a text box did not start, and a button somebody had tabbed to
+was not pressed, while anything on the page listening for the key saw it arrive. There was nothing on
+screen to explain it: the keystroke was not refused, it simply had no effect, and the way out was to
+click the submit button instead. Enter now carries the carriage return a keyboard sends, which is
+what makes Chrome carry out what the key means. Measured against Chromium 151: every other editing
+key — Backspace, Delete, Tab, Home, End and the arrows — already did what it meant and is unchanged,
+and a single-line field still holds exactly what was typed into it.
+
 ### A deployment directory pasted with a stray space goes where it says
 
 The desktop setup screen asks where OpenBot should live, enables Start once that box is not blank

--- a/agent-computer/src/screencast.ts
+++ b/agent-computer/src/screencast.ts
@@ -93,6 +93,29 @@ const VIRTUAL_KEY_CODES: Record<string, number> = {
   "'": 222,
 };
 
+/**
+ * The character a key stands for, where Chrome will not act on the key without one.
+ *
+ * `Input.dispatchKeyEvent` has two kinds of key-down. `rawKeyDown` is a key that produces no
+ * character: Chrome delivers it to the page and stops there, so a listener fires and nothing else
+ * happens. `keyDown` carries text, and that is what makes Chrome perform the key's own default
+ * action.
+ *
+ * Sending text only for a printable character therefore left Enter as a key a page could hear and
+ * not act on. Measured against Chromium 151 through this file: with a person holding the wheel,
+ * Enter did not submit the form they had just filled in, did not start a new line in a textarea and
+ * did not press the button they had tabbed to, while the page's own `keydown` listener saw every
+ * one of them. Which is the sign-in at the end of almost every takeover.
+ *
+ * One key rather than a list, measured the same way: Backspace, Delete, Tab, Home, End and the four
+ * arrows all do what they mean as a `rawKeyDown`, because their default action is not the insertion
+ * of a character.
+ *
+ * A carriage return, which is what a keyboard's Enter carries. Chrome turns it into whatever the
+ * field it lands in needs, so a single-line input is left holding no extra character.
+ */
+const TEXT_FOR_KEY: Record<string, string | undefined> = { Enter: "\r" };
+
 function virtualKeyCode(key: string): number {
   if (VIRTUAL_KEY_CODES[key] !== undefined) return VIRTUAL_KEY_CODES[key];
   // A single printable character carries its own code point, upper-cased, which is what Chrome expects
@@ -204,19 +227,26 @@ export async function startScreencast(
           (offeredCode ?? 0) <= 255
             ? (offeredCode as number)
             : virtualKeyCode(message.key);
+        /*
+         * The text this key carries: the surface supplies it for a printable character, and
+         * `TEXT_FOR_KEY` fills in the keys whose default action Chrome will not perform without one.
+         *
+         * Only on the way down, because that is where a default action happens. A key going up
+         * carries whatever it was given and nothing more.
+         */
+        const text =
+          message.event === "up"
+            ? message.text
+            : (message.text ?? TEXT_FOR_KEY[message.key]);
         await client.send("Input.dispatchKeyEvent", {
           // `keyDown` only when there is text to insert; otherwise `rawKeyDown`, which is what Chrome
           // expects for keys that do not produce a character. Sending keyDown with no text makes
           // editing keys arrive as nothing.
           type:
-            message.event === "up"
-              ? "keyUp"
-              : message.text
-                ? "keyDown"
-                : "rawKeyDown",
+            message.event === "up" ? "keyUp" : text ? "keyDown" : "rawKeyDown",
           key: message.key,
           code: message.code,
-          ...(message.text ? { text: message.text } : {}),
+          ...(text ? { text } : {}),
           windowsVirtualKeyCode: code,
           nativeVirtualKeyCode: code,
           modifiers: message.modifiers ?? 0,

--- a/agent-computer/tests/screencast.test.ts
+++ b/agent-computer/tests/screencast.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import type { Page } from "playwright";
+import { type InputMessage, startScreencast } from "../src/screencast";
+
+/**
+ * What a person's keystroke turns into on the wire.
+ *
+ * `screencast.ts` imports Playwright for its types only, and a type import is gone at run time, so
+ * this reaches the translation without a browser. What it cannot reach is what Chrome then does with
+ * it, which is the half that was wrong: `rawKeyDown` and `keyDown` are both delivered to the page,
+ * and only one of them makes Chrome carry out what the key means. That difference was measured
+ * against Chromium 151 rather than guessed, and this file pins the parameters that measurement
+ * settled on.
+ */
+
+/** A CDP session that records what was asked of it, and answers everything. */
+function recording() {
+  const sent: { method: string; params: Record<string, unknown> }[] = [];
+  const client = {
+    on() {},
+    async send(method: string, params: Record<string, unknown> = {}) {
+      sent.push({ method, params });
+    },
+    async detach() {},
+  };
+  const page = {
+    context: () => ({ newCDPSession: async () => client }),
+  } as unknown as Page;
+  return { page, sent };
+}
+
+/** The parameters of the one key event a message produced. */
+async function dispatched(message: InputMessage) {
+  const { page, sent } = recording();
+  const cast = await startScreencast(page, () => {});
+  sent.length = 0;
+  await cast.send(message);
+  const keyEvents = sent.filter(
+    (call) => call.method === "Input.dispatchKeyEvent",
+  );
+  expect(keyEvents).toHaveLength(1);
+  return keyEvents[0]?.params as Record<string, unknown>;
+}
+
+/** A keystroke exactly as the live screen sends one: text only for a printable character. */
+function typed(
+  event: "down" | "up",
+  key: string,
+  code: string,
+  keyCode: number,
+): InputMessage {
+  return {
+    type: "key",
+    event,
+    key,
+    code,
+    windowsVirtualKeyCode: keyCode,
+    ...(key.length === 1 ? { text: key } : {}),
+    modifiers: 0,
+  };
+}
+
+describe("a key a person presses while they hold the wheel", () => {
+  test("Enter is a press the page acts on, not one it merely hears", async () => {
+    // Measured through this file against Chromium 151: as a `rawKeyDown` the page's own `keydown`
+    // listener saw Enter and nothing else happened -- the sign-in form did not submit, a textarea
+    // did not take a new line, and a focused button was not pressed.
+    const params = await dispatched(typed("down", "Enter", "Enter", 13));
+    expect(params.type).toBe("keyDown");
+    expect(params.text).toBe("\r");
+  });
+
+  test("a printable character keeps the text the person typed", async () => {
+    const params = await dispatched(typed("down", "a", "KeyA", 65));
+    expect(params.type).toBe("keyDown");
+    expect(params.text).toBe("a");
+  });
+
+  test("a key that produces no character is still a rawKeyDown", async () => {
+    // Backspace, Delete, Tab, Home, End and the arrows were all measured to do what they mean
+    // without text, so filling one in for them would be inventing an insertion.
+    for (const [key, code, keyCode] of [
+      ["Backspace", "Backspace", 8],
+      ["Delete", "Delete", 46],
+      ["Tab", "Tab", 9],
+      ["ArrowLeft", "ArrowLeft", 37],
+      ["Home", "Home", 36],
+    ] as const) {
+      const params = await dispatched(typed("down", key, code, keyCode));
+      expect(params.type).toBe("rawKeyDown");
+      expect(params).not.toHaveProperty("text");
+    }
+  });
+
+  test("Enter going up is a key up carrying nothing it was not given", async () => {
+    // The fill-in belongs to the way down, where a default action happens. A key up that carried a
+    // carriage return would be a second one.
+    const params = await dispatched(typed("up", "Enter", "Enter", 13));
+    expect(params.type).toBe("keyUp");
+    expect(params).not.toHaveProperty("text");
+  });
+
+  test("the virtual key code the surface offered is the one that is sent", async () => {
+    // A form field ignores a bare Enter or Backspace without this, which is why it is sent at all.
+    const params = await dispatched(typed("down", "Enter", "Enter", 13));
+    expect(params.windowsVirtualKeyCode).toBe(13);
+    expect(params.nativeVirtualKeyCode).toBe(13);
+  });
+});


### PR DESCRIPTION
A Bot hits a sign-in it cannot do itself and asks for help. A person takes the wheel, types their
email and password into the page — the characters appear — and presses Enter. Nothing happens. The
form does not submit. Nothing is refused, nothing is said, and the only way on is to find the button
and click it.

The same Enter does nothing in a text box (no new line) and nothing on a button somebody has tabbed
to. Every other key works, which is what makes it hard to believe: the typing lands, so the wheel
must be working.

## Why

`Input.dispatchKeyEvent` has two kinds of key-down. `rawKeyDown` is a key that produces no
character: Chrome delivers the event to the page and stops there, so listeners fire and nothing else
happens. `keyDown` carries text, and that is what makes Chrome perform the key's own default action.

`screencast.ts` picks between them by whether the surface sent text, and the surface sends text only
for a printable character:

```ts
// live-screen.tsx
...(event.key.length === 1 ? { text: event.key } : {}),

// screencast.ts
type: message.event === "up" ? "keyUp" : message.text ? "keyDown" : "rawKeyDown",
```

`"Enter".length` is 5. So Enter went as a `rawKeyDown`, forever.

## Measured, not reasoned

Driven through the shipped `startScreencast` against Chromium 151 (playwright-core 1.62.1's own
build), with the message `live-screen.tsx` actually constructs for a keydown — `text` present only
when `key.length === 1`:

```
=== as sent today: Enter with no text ===
  Enter submits the form        : false
  single-line input holds       : "h"
  textarea after a, Enter, b    : "ab"
  Enter activates a focused btn : false

=== with text: '\r' on Enter ===
  Enter submits the form        : true
  single-line input holds       : "h"
  textarea after a, Enter, b    : "a\nb"
  Enter activates a focused btn : true
```

The page's own `keydown` listener saw `Enter/13` in both runs. It was heard and not acted on.

## One key, and that was measured too

Every other editing key already does what it means as a `rawKeyDown`, so filling text in for them
would be inventing an insertion. Same harness, same browser, caret and value read back after each
press in a textarea holding `hello world`:

```
Home        -> [0,0,"hello world"]
End         -> [11,11,"hello world"]
ArrowRight  -> [1,1,"hello world"]
ArrowUp     -> [0,0,"hello world"]
Delete      -> [0,0,"ello world"]
Backspace   -> [1,1,"elo world"]
Tab         -> [0,0,"hello world"]
```

Identical before and after the change.

## The fix

A carriage return for Enter when the surface sent no text, in `screencast.ts` rather than in the
surface, because this is a fact about the protocol and the file already holds the neighbouring one —
its `VIRTUAL_KEY_CODES` comment names Enter for the same reason.

`\r` rather than `\n`: it is what a keyboard's Enter carries, and Chrome turns it into whatever the
field it lands in needs. The measurement above shows the single-line input left holding exactly what
was typed and no extra character.

Filled in only on the way down, where a default action happens. A key going up carries what it was
given and nothing more.

## Tests

New: `agent-computer/tests/screencast.test.ts`, 5 tests. `screencast.ts` imports Playwright for its
types only and a type import is erased at run time, so these reach the translation with a fake CDP
session and no browser — they run anywhere the suite does.

- Against `origin/main` (`1c7bd92`) with only the new file applied: **4 pass, 1 fail**.

```
expect(params.type).toBe("keyDown");
error: expect(received).toBe(expected)
Expected: "keyDown"
Received: "rawKeyDown"
(fail) a key a person presses while they hold the wheel > Enter is a press the page acts on, not one it merely hears
```

- With the change: **5 pass, 0 fail**.

The other four are the guard against over-correcting and pass before and after: a printable
character keeps its own text, Backspace / Delete / Tab / ArrowLeft / Home stay `rawKeyDown` with no
text at all, Enter going up is a `keyUp` carrying nothing, and the virtual key code the surface
offered is still the one sent.

`bun test agent-computer/tests` — **236 pass, 15 skip, 20 fail**. The same 20 fail on `origin/main`
(231 pass there): 11 in `shell.test.ts`, which spawns `/bin/bash`, and 9 in `workspace.test.ts`,
which creates symlinks — neither is available on the Windows machine these were run on, and neither
is touched here.

Also run, clean: `bunx biome check` on both files, `bun run typecheck` in `agent-computer`.

## Note on the changelog

A person driving a browser behaves differently afterwards, so there is an entry. It goes at the top
of `## Unreleased`, the line every open PR touching the changelog inserts at, so it will conflict
with any other that lands first. Happy to rebase.
