### PR TITLE
Split the credentials out of a proxy URL written without a scheme

### DIFF
--- a/agent-computer/src/egress.ts
+++ b/agent-computer/src/egress.ts
@@ -41,29 +41,56 @@ export function egressFor(
 ): Egress | null {
   const raw = env[egressVariableFor(botId)] ?? env.EGRESS_PROXY_DEFAULT;
   if (!raw?.trim()) return null;
+  return splitProxyCredentials(raw);
+}
 
-  // Credentials commonly arrive inside the URL, which is how proxies are handed out. They are split
-  // out so that the server string this returns can be shown to a person without leaking a password.
+/**
+ * Split a proxy string into a server and its credentials.
+ *
+ * Credentials commonly arrive inside the URL, which is how proxies are handed out. They are split out
+ * so that the server string can be shown to a person without leaking a password.
+ *
+ * Two shapes reach here, and only one of them is a URL as far as the parser is concerned. A bare
+ * `host:port` is what an operator writes when they are not thinking about URLs, and Playwright and
+ * curl both take it; `new URL` reads `proxy.internal:8080` as the scheme `proxy.internal:` and the
+ * path `8080` with an empty host, rather than throwing. `username` and `password` come back empty for
+ * that shape, so a proxy written `bot:s3cret@proxy.internal:8080` would keep its password in the
+ * string it hands back. Re-parsing behind a synthetic scheme makes the split happen for both shapes;
+ * the synthetic scheme is then removed so the server reads the way it was written.
+ */
+export function splitProxyCredentials(raw: string): Egress {
+  const trimmed = raw.trim();
+
+  let url: URL | null = null;
+  let synthetic = "";
   try {
-    const url = new URL(raw.trim());
-    const username = url.username
-      ? decodeURIComponent(url.username)
-      : undefined;
-    const password = url.password
-      ? decodeURIComponent(url.password)
-      : undefined;
-    url.username = "";
-    url.password = "";
-    return {
-      server: url.toString().replace(/\/$/, ""),
-      ...(username ? { username } : {}),
-      ...(password ? { password } : {}),
-    };
-  } catch {
-    // Not a URL. Passed through as a bare `host:port`, which Playwright also accepts, so an operator
-    // who writes the obvious thing is not told they are wrong.
-    return { server: raw.trim() };
+    const asWritten = new URL(trimmed);
+    if (asWritten.host !== "") url = asWritten;
+  } catch (e) {
+    if (!(e instanceof TypeError)) throw e;
   }
+  if (!url) {
+    synthetic = "http://";
+    try {
+      url = new URL(`${synthetic}${trimmed}`);
+    } catch (e) {
+      if (!(e instanceof TypeError)) throw e;
+      // Not addressable either way. Passed through, so an operator who writes the obvious thing is
+      // not told they are wrong.
+      return { server: trimmed };
+    }
+  }
+
+  const username = url.username ? decodeURIComponent(url.username) : undefined;
+  const password = url.password ? decodeURIComponent(url.password) : undefined;
+  url.username = "";
+  url.password = "";
+
+  return {
+    server: url.toString().replace(/\/$/, "").slice(synthetic.length),
+    ...(username ? { username } : {}),
+    ...(password ? { password } : {}),
+  };
 }
 
 /**

--- a/agent-computer/src/shell.ts
+++ b/agent-computer/src/shell.ts
@@ -1,5 +1,7 @@
 import { spawn } from "node:child_process";
 
+import { splitProxyCredentials } from "./egress";
+
 /**
  * Running a command on the Bot's computer.
  *
@@ -188,16 +190,9 @@ function extraShellEnvNames(raw: string | undefined): readonly string[] {
  * the network without `env` printing a password. Same split `egress.ts` uses for the browser proxy.
  */
 function withoutUserinfo(raw: string): string {
-  try {
-    const url = new URL(raw.trim());
-    if (url.username === "" && url.password === "") return raw;
-    url.username = "";
-    url.password = "";
-    return url.toString().replace(/\/$/, "");
-  } catch (e) {
-    if (e instanceof TypeError) return raw;
-    throw e;
-  }
+  const { server, username, password } = splitProxyCredentials(raw);
+  if (username === undefined && password === undefined) return raw;
+  return server;
 }
 
 function clamp(text: string): { text: string; truncated: boolean } {

--- a/agent-computer/tests/egress.test.ts
+++ b/agent-computer/tests/egress.test.ts
@@ -67,6 +67,35 @@ describe("resolving a Bot's proxy", () => {
       server: "proxy.internal:8080",
     });
   });
+
+  test("a bare host:port carrying credentials is split like any other", () => {
+    // The shape above, written the way a proxy is actually handed out. `new URL` reads it as the
+    // scheme `bot:` and a path, so username and password come back empty and the password rides
+    // along in `server` -- into the label, the admin page and the API.
+    const proxy = egressFor("sales", {
+      EGRESS_PROXY_SALES: "bot:s3cret@proxy.internal:8080",
+    });
+    expect(proxy).toEqual({
+      server: "proxy.internal:8080",
+      username: "bot",
+      password: "s3cret",
+    });
+    expect(proxy?.server).not.toContain("s3cret");
+  });
+
+  test("a bare host:port with an encoded password decodes it too", () => {
+    const proxy = egressFor("sales", {
+      EGRESS_PROXY_SALES: "bot:p%40ss%3Aword@proxy.internal:8080",
+    });
+    expect(proxy?.password).toBe("p@ss:word");
+    expect(proxy?.server).toBe("proxy.internal:8080");
+  });
+
+  test("something that is not addressable at all is still passed through", () => {
+    expect(egressFor("sales", { EGRESS_PROXY_SALES: "::::" })).toEqual({
+      server: "::::",
+    });
+  });
 });
 
 describe("what gets shown to people", () => {
@@ -84,5 +113,13 @@ describe("what gets shown to people", () => {
     expect(
       egressLabel("sales", { EGRESS_PROXY_SALES: "proxy.internal:8080" }),
     ).toBe("proxy.internal:8080");
+  });
+
+  test("a bare host:port with credentials labels as the host only", () => {
+    const label = egressLabel("sales", {
+      EGRESS_PROXY_SALES: "bot:s3cret@proxy.internal:8080",
+    });
+    expect(label).toBe("proxy.internal:8080");
+    expect(label).not.toContain("s3cret");
   });
 });

--- a/agent-computer/tests/shell.test.ts
+++ b/agent-computer/tests/shell.test.ts
@@ -126,6 +126,24 @@ describe("what a command inherits", () => {
     expect(JSON.stringify(env)).not.toContain("p@ss");
   });
 
+  test("a proxy URL's userinfo does not pass when it was written without a scheme", () => {
+    // `HTTPS_PROXY=bot:s3cret@proxy.internal:8443` is a shape curl and wget accept. `new URL` reads
+    // it as the scheme `bot:` and a path, so the redaction above found no userinfo to strip and the
+    // password reached the Bot's shell, where `env` prints it.
+    const env = environmentForCommand(
+      source({
+        HTTP_PROXY: "bot:s3cret@proxy.internal:8080",
+        HTTPS_PROXY: "bot:p%40ss@proxy.internal:8443",
+      }),
+      workspaceHome,
+    );
+    expect(env.HTTP_PROXY).toBe("proxy.internal:8080");
+    expect(env.HTTPS_PROXY).toBe("proxy.internal:8443");
+    expect(JSON.stringify(env)).not.toContain("s3cret");
+    expect(JSON.stringify(env)).not.toContain("p%40ss");
+    expect(JSON.stringify(env)).not.toContain("p@ss");
+  });
+
   test("a proxy without userinfo is left alone", () => {
     const env = environmentForCommand(source(), workspaceHome);
     expect(env.HTTP_PROXY).toBe(allowed.HTTP_PROXY);


### PR DESCRIPTION
## What happens

A proxy handed to a deployment as `bot:s3cret@proxy.internal:8080` — no scheme, the shape curl, wget and Playwright all take — keeps its password. `egressLabel` then renders it on the admin page and returns it from the API, and `shellEnv` puts it in the Bot's shell where `env` prints it.

`tests/egress.test.ts` already pins the two neighbouring shapes:

```ts
egressFor("sales", { EGRESS_PROXY_SALES: "http://bot:s3cret@proxy.internal:8080" })
// { server: "http://proxy.internal:8080", username: "bot", password: "s3cret" }   ✅

egressFor("sales", { EGRESS_PROXY_SALES: "proxy.internal:8080" })
// { server: "proxy.internal:8080" }                                                ✅
```

The third combination — the bare form *with* credentials — is the one that was never asserted:

```ts
egressFor("sales", { EGRESS_PROXY_SALES: "bot:s3cret@proxy.internal:8080" })
// { server: "bot:s3cret@proxy.internal:8080" }                                     ❌
```

## Why

`new URL` does not throw on the bare form, so it never reaches the `catch` that handles it — it parses as a scheme plus a path, with an empty host:

```js
new URL("bot:s3cret@proxy.internal:8080")
// protocol: "bot:"
// username: ""          <- so nothing gets stripped
// password: ""
// host:     ""
// pathname: "s3cret@proxy.internal:8080"

new URL("http://bot:s3cret@proxy.internal:8080")
// protocol: "http:"  username: "bot"  password: "s3cret"  host: "proxy.internal:8080"
```

With `username` and `password` empty, `egressFor` clears two already-empty fields and `url.toString()` round-trips the input, so the credentials come back inside `server`. `withoutUserinfo` in `shell.ts` has the same shape and the same early return, so `HTTPS_PROXY` written that way passes through untouched.

Both places say in their own comments what they are for — *"so the shell can still reach the network without `env` printing a password"* and *"this string is rendered in a browser and returned by an API"* — and `egress.test.ts` opens with:

> a proxy URL usually carries a password, and the label is rendered on an admin page and returned by an API. A test that only checked the happy parse would have been perfectly green while publishing credentials.

That is what happened, one input shape over.

## The change

`egress.ts` grows one exported helper, `splitProxyCredentials`. It parses as written; if that yields an empty host, it re-parses behind a synthetic `http://` so the split happens on the same shapes the caller already accepts, then removes the synthetic scheme so the server reads the way the operator wrote it. `egressFor` and `withoutUserinfo` both call it, which also removes the duplicated parse the two files were carrying (`shell.ts` says "Same split `egress.ts` uses").

Behaviour that does not change:

- A full URL splits exactly as before, encoded passwords included.
- A bare `host:port` with no credentials is returned verbatim, still without a scheme.
- Anything not addressable either way is still passed through rather than rejected — there is a test pinning `"::::"` for that.
- `withoutUserinfo` still returns the original string byte-for-byte when there is no userinfo, so `NO_PROXY` and friends are untouched.

## Verification

`bun test tests/egress.test.ts tests/shell.test.ts`, on `main` with only this PR's test changes applied:

```
(fail) resolving a Bot's proxy > a bare host:port carrying credentials is split like any other
    expect(received).toEqual(expected)
      {
    -   "password": "s3cret",
    -   "server": "proxy.internal:8080",
    -   "username": "bot",
    +   "server": "bot:s3cret@proxy.internal:8080",
      }

(fail) resolving a Bot's proxy > a bare host:port with an encoded password decodes it too
    Expected: "p@ss:word"
    Received: undefined

(fail) what gets shown to people > a bare host:port with credentials labels as the host only
(fail) what a command inherits > a proxy URL's userinfo does not pass when it was written without a scheme

 22 pass
 15 fail
```

With the change:

```
 26 pass
 11 fail
```

The 11 are the same on `main` before any of this — they are the `spawn`-backed cases in `shell.test.ts` ("the command that actually runs", the timeout group), which do not run on this Windows machine. Baseline on unmodified `main` is `21 pass, 11 fail`; the delta is the five tests added here, four of which fail beforehand and one of which (`"::::"`) passes both before and after, on purpose — it pins the passthrough so this is a fix and not a widening.

`bunx @biomejs/biome check` and `bunx prettier --check` are clean on all four files, and `bun run typecheck` passes.

## Note

`bun run typecheck` needs `@types/bun`, which is not in `agent-computer/package.json` — without it `tsc` stops at `TS2688: Cannot find type definition file for 'bun'` before it looks at any source. That is there on `main` too; I left it out of this PR rather than mix a dependency change in, but happy to send it separately if it is not deliberate.
