### PR TITLE
Add mxmzb as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,4 @@
 # Adding a name here grants both powers. Add people who know this codebase well
 # enough to say no.
 
-*  @davidmckayv @guidovizoso @tylerslaton @MikeRyanDev
+*  @davidmckayv @guidovizoso @tylerslaton @MikeRyanDev @mxmzb


### PR DESCRIPTION
Grants approval and merge rights on `main`, which is what an entry in this file means.

The account already has write access on the repository. That matters: GitHub does not count an approving review from anyone without it, so a name added here without write access looks correct and silently does nothing.