### PR TITLE
fix: keep integration-test fixtures out of the app database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,18 +187,19 @@ jobs:
       postgres:
         image: pgvector/pgvector:pg17
         env:
-          POSTGRES_DB: openbot
+          POSTGRES_DB: openbot_test
           POSTGRES_USER: openbot
           POSTGRES_PASSWORD: openbot
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U openbot -d openbot"
+          --health-cmd "pg_isready -U openbot -d openbot_test"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
     env:
-      DATABASE_URL: postgres://openbot:openbot@localhost:5432/openbot
+      DATABASE_URL: postgres://openbot:openbot@localhost:5432/openbot_test
+      TEST_DATABASE_URL: postgres://openbot:openbot@localhost:5432/openbot_test
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/docs/development.md
+++ b/docs/development.md
@@ -111,11 +111,9 @@ bun run test
 bun run build
 ```
 
-Integration tests expect a PostgreSQL database with pgvector. Use `start.sh` or point `DATABASE_URL` at a compatible database.
+Integration tests expect a PostgreSQL database with pgvector. Point `TEST_DATABASE_URL` at a dedicated database such as `postgres://openbot:openbot@localhost:5432/openbot_test` before running them.
 
-They write to whichever database `DATABASE_URL` names and leave their rows behind, so running
-them against a deployment you are using puts test Bots in its audit trail and its activity
-reports. Point `DATABASE_URL` at a database of their own to keep the two apart.
+They refuse to use the application `openbot` database. `DATABASE_URL` is still the application setting, and the database client removes it from the process environment after opening a connection to preserve the Windows Bun connection fix, so tests use `TEST_DATABASE_URL` as their immutable fixture address. Running them against a deployment you are using puts test Bots in its audit trail and its activity reports, so create a separate database and migrate that before running the integration suite.
 
 CI uses `bun run test:ci` to verify the expected test count in addition to normal tests.
 

--- a/server/tests/agent-handoff-endtoend.integration.test.ts
+++ b/server/tests/agent-handoff-endtoend.integration.test.ts
@@ -18,7 +18,7 @@ import {
   workItems,
 } from "../src/db/schema";
 import { createWorkQueue } from "../src/work/queue";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * A hop from end to end: a Bot calls the tool, and another replica delivers it.
@@ -32,11 +32,7 @@ import { TEST_POOL } from "./support/database";
  * question the two files either side already answer.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const suite = randomUUID().slice(0, 8);
 const ASKER = `e2e-asker-${suite}`;

--- a/server/tests/agent-handoff-runner.integration.test.ts
+++ b/server/tests/agent-handoff-runner.integration.test.ts
@@ -9,7 +9,7 @@ import type { AuditStore } from "../src/audit";
 import { createDatabase } from "../src/db/client";
 import { workItems } from "../src/db/schema";
 import { createWorkQueue } from "../src/work/queue";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * Two replicas and one batch of hops, against a real PostgreSQL.
@@ -18,11 +18,7 @@ import { TEST_POOL } from "./support/database";
  * whatever it was told to. The whole suite was green while the tail of every batch was delivered
  * twice, because a fake cannot let a lease quietly run out.
  */
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 const queue = createWorkQueue(database);
 const kind = "bot.message";
 

--- a/server/tests/agent-handoff.integration.test.ts
+++ b/server/tests/agent-handoff.integration.test.ts
@@ -13,7 +13,7 @@ import {
   workItems,
 } from "../src/db/schema";
 import { createWorkQueue } from "../src/work/queue";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * A hop, driven against the real database rather than through fakes.
@@ -24,11 +24,7 @@ import { TEST_POOL } from "./support/database";
  * author expected, which is the wrong witness for exactly the questions worth asking.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const suite = randomUUID().slice(0, 8);
 const ASKER = `handoff-asker-${suite}`;

--- a/server/tests/agent-key-rotation.integration.test.ts
+++ b/server/tests/agent-key-rotation.integration.test.ts
@@ -5,6 +5,7 @@ import { createAgentProfileStore } from "../src/agents/profile-store";
 import type { AgentActor } from "../src/agents/profile-types";
 import { createCredentialStore } from "../src/credentials";
 import { createDatabase } from "../src/db/client";
+import { testDatabaseUrl } from "./support/database";
 import { agentProfiles, agents, credentials, users } from "../src/db/schema";
 
 /**
@@ -23,11 +24,7 @@ import { agentProfiles, agents, credentials, users } from "../src/db/schema";
  * effect, so one connection is the honest setting for the question being asked.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  { max: 1 },
-);
+const database = createDatabase(testDatabaseUrl(), { max: 1 });
 
 const encryptionKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 const store = createCredentialStore(database);

--- a/server/tests/agent-profile-store.integration.test.ts
+++ b/server/tests/agent-profile-store.integration.test.ts
@@ -27,11 +27,9 @@ import {
   intelligenceChannelMappings,
   users,
 } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 const managedAgentAgUiUrl = new URL("https://managed.example.test/ag-ui");
 const store: AgentProfileStore = createAgentProfileStore(

--- a/server/tests/attachment-routes.test.ts
+++ b/server/tests/attachment-routes.test.ts
@@ -30,12 +30,10 @@ import {
   intelligenceChannelMappings,
   users,
 } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 import { testEnvironment } from "./support/environment";
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 
 const testPrefix = `attachment-routes-${randomUUID()}`;

--- a/server/tests/attachment-store.test.ts
+++ b/server/tests/attachment-store.test.ts
@@ -18,12 +18,10 @@ import {
   channels,
   users,
 } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 import { testEnvironment } from "./support/environment";
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 
 const testPrefix = `attachment-store-${randomUUID()}`;

--- a/server/tests/attachment-sweeper.test.ts
+++ b/server/tests/attachment-sweeper.test.ts
@@ -5,11 +5,9 @@ import { eq, inArray, notInArray, sql } from "drizzle-orm";
 import { cullStagedAttachments } from "../scripts/cull-staged-attachments";
 import { createDatabase, type Database } from "../src/db/client";
 import { attachments, channels, users } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 
 const testPrefix = `attachment-sweeper-${randomUUID()}`;

--- a/server/tests/audit-initiator.integration.test.ts
+++ b/server/tests/audit-initiator.integration.test.ts
@@ -7,11 +7,9 @@ import {
 } from "../src/audit";
 import { createDatabase } from "../src/db/client";
 import { auditEvents } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 const store = createAuditStore(database);
 const reader = createAuditReader(database);

--- a/server/tests/audit-retention.integration.test.ts
+++ b/server/tests/audit-retention.integration.test.ts
@@ -4,7 +4,7 @@ import postgres from "postgres";
 import { sweepAuditTrail } from "../src/audit-retention";
 import { createDatabase } from "../src/db/client";
 import { auditEvents } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * The audit trail has to be able to stop growing.
@@ -18,9 +18,7 @@ import { TEST_POOL } from "./support/database";
  * server sweeps, the batching, and the interval arithmetic.
  */
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 
 /** The id column is a uuid, so the rows are found by their target rather than by a marker in the id. */

--- a/server/tests/channel-activity.integration.test.ts
+++ b/server/tests/channel-activity.integration.test.ts
@@ -19,11 +19,9 @@ import {
   intelligenceChannelMappings,
   users,
 } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 const profileStore = createAgentProfileStore(
   database,

--- a/server/tests/channel-events.integration.test.ts
+++ b/server/tests/channel-events.integration.test.ts
@@ -26,7 +26,7 @@ import {
   intelligenceChannelMappings,
   users,
 } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 function event(overrides: Partial<ChannelActivityEvent> = {}) {
   return {
@@ -134,9 +134,7 @@ describe("channel event hub", () => {
   });
 });
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 const profileStore = createAgentProfileStore(
   database,

--- a/server/tests/channel-routes.test.ts
+++ b/server/tests/channel-routes.test.ts
@@ -41,7 +41,7 @@ import {
   intelligenceChannelMappings,
   users,
 } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 import { testEnvironment } from "./support/environment";
 
 const actor = {
@@ -678,9 +678,7 @@ describe("channel route composition", () => {
   });
 });
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 const profileStore = createAgentProfileStore(
   database,

--- a/server/tests/channel-summary.integration.test.ts
+++ b/server/tests/channel-summary.integration.test.ts
@@ -24,11 +24,9 @@ import {
   workItems,
 } from "../src/db/schema";
 import { createWorkQueue } from "../src/work/queue";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 const profileStore = createAgentProfileStore(
   database,

--- a/server/tests/component-store.integration.test.ts
+++ b/server/tests/component-store.integration.test.ts
@@ -14,7 +14,7 @@ import {
   componentFunctions,
   components,
 } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * The grant surface, against a real database.
@@ -24,10 +24,7 @@ import { TEST_POOL } from "./support/database";
  * withholdings with it, a primary key that has to make withholding twice a no-op.
  */
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
-const database = createDatabase(databaseUrl, TEST_POOL);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 const store: ComponentStore = createComponentStore(database);
 
 const suite = randomUUID().slice(0, 8);
@@ -35,8 +32,11 @@ const componentName = `testComponent_${suite}`;
 const otherName = `testOther_${suite}`;
 const botA = `agent_test_a_${suite}`;
 const botB = `agent_test_b_${suite}`;
+const fixtureComponentNames = new Set<string>();
+const fixtureAgentIds = new Set([botA, botB]);
 
 async function makeComponent(name: string, published: boolean) {
+  fixtureComponentNames.add(name);
   await database.insert(components).values({
     name,
     title: `Test ${name}`,
@@ -60,20 +60,16 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  // Register before writes so a failed assertion or partially completed setup still has teardown.
+  const names = [...fixtureComponentNames];
   await database
     .delete(componentFunctions)
-    .where(
-      inArray(componentFunctions.componentName, [componentName, otherName]),
-    );
+    .where(inArray(componentFunctions.componentName, names));
   await database
     .delete(componentExclusions)
-    .where(
-      inArray(componentExclusions.componentName, [componentName, otherName]),
-    );
-  await database
-    .delete(components)
-    .where(inArray(components.name, [componentName, otherName]));
-  await database.delete(agents).where(inArray(agents.id, [botA, botB]));
+    .where(inArray(componentExclusions.componentName, names));
+  await database.delete(components).where(inArray(components.name, names));
+  await database.delete(agents).where(inArray(agents.id, [...fixtureAgentIds]));
 });
 
 describe("deciding whether a Bot may use a component", () => {
@@ -157,6 +153,7 @@ describe("withholding", () => {
 
   test("deleting a Bot takes its withholdings with it", async () => {
     const doomed = `agent_test_doomed_${suite}`;
+    fixtureAgentIds.add(doomed);
     await database.insert(agents).values({
       id: doomed,
       name: doomed,
@@ -244,6 +241,7 @@ describe("learning what a build ships", () => {
     kind: "card",
     description: "Arrived from a build rather than from a list on the server.",
   };
+  fixtureComponentNames.add(announced.name);
 
   test("a component the deployment has never seen is added, published and available to every Bot", async () => {
     const { added } = await store.syncCatalogue([announced]);
@@ -302,6 +300,7 @@ describe("learning what a build ships", () => {
       kind: "card",
       description: "Announced by two page loads at the same moment.",
     };
+    fixtureComponentNames.add(racer.name);
 
     const [first, second] = await Promise.all([
       store.syncCatalogue([racer]),
@@ -320,15 +319,6 @@ describe("learning what a build ships", () => {
     const before = (await store.list()).length;
     expect((await store.syncCatalogue([])).added).toEqual([]);
     expect((await store.list()).length).toBe(before);
-  });
-
-  afterAll(async () => {
-    await database
-      .delete(componentExclusions)
-      .where(eq(componentExclusions.componentName, announced.name));
-    await database
-      .delete(components)
-      .where(eq(components.name, announced.name));
   });
 });
 

--- a/server/tests/computer-culler.integration.test.ts
+++ b/server/tests/computer-culler.integration.test.ts
@@ -13,7 +13,7 @@ import {
   suspendClaimedComputers,
 } from "../src/work/culler";
 import { createWorkQueue } from "../src/work/queue";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * Spinning a computer down when nobody is using it, which is the whole reason the fleet does not
@@ -23,11 +23,7 @@ import { TEST_POOL } from "./support/database";
  * computer nothing is known about. Suspending either takes a person's session away mid-task, and
  * both are easy to get wrong in a way no error ever reports.
  */
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 const queue = createWorkQueue(database);
 const suite = randomUUID().slice(0, 8);
 const botOf = (name: string) => `cull-${suite}-${name}`;

--- a/server/tests/computer-page-frame-store.integration.test.ts
+++ b/server/tests/computer-page-frame-store.integration.test.ts
@@ -3,7 +3,7 @@ import { eq } from "drizzle-orm";
 import { createPageFrameStore } from "../src/computer/page-frames";
 import { createDatabase } from "../src/db/client";
 import { computerPageFrame } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * A conversation is a record, and a record must not change its mind.
@@ -18,11 +18,7 @@ import { TEST_POOL } from "./support/database";
  * database's: which rows collide, and what happens when they do.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const store = createPageFrameStore(database);
 const computers: string[] = [];

--- a/server/tests/computer-session-guard-replicas.integration.test.ts
+++ b/server/tests/computer-session-guard-replicas.integration.test.ts
@@ -10,7 +10,7 @@ import { createSnapshotStore } from "../src/computer/snapshot-store";
 import { createDockerSupervisorProvider } from "../src/computer/supervisor";
 import { createDatabase } from "../src/db/client";
 import { computerSnapshot } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * Two replicas, one Postgres, a container replaced between them.
@@ -21,11 +21,7 @@ import { TEST_POOL } from "./support/database";
  * this Bot, gets the click after the container was replaced.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const suite = randomUUID().slice(0, 8);
 const botId = `agent_replica_${suite}`;

--- a/server/tests/computer-snapshot-store.integration.test.ts
+++ b/server/tests/computer-snapshot-store.integration.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../src/computer/snapshot-store";
 import { createDatabase } from "../src/db/client";
 import { computerSnapshot } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * The snapshot a ref resolves against has to cross to another server.
@@ -23,11 +23,7 @@ import { TEST_POOL } from "./support/database";
  * remembers what it was told a moment ago, which is not the property in question.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 function snapshot(
   snapshotId: number,

--- a/server/tests/credentials.test.ts
+++ b/server/tests/credentials.test.ts
@@ -15,16 +15,12 @@ import {
 } from "../src/credentials";
 import { createDatabase } from "../src/db/client";
 import { credentials } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 import { testEnvironment } from "./support/environment";
 
 const key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 const config = loadConfig(testEnvironment({ KEY_ENCRYPTION_KEY: key }));
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 const credentialIds: string[] = [];
 
 afterEach(async () => {

--- a/server/tests/db-client-address.test.ts
+++ b/server/tests/db-client-address.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createDatabase } from "../src/db/client";
+import { testDatabaseUrl } from "./support/database";
 
 /**
  * The address goes to Bun in parts, and `$DATABASE_URL` does not survive the call.
@@ -112,16 +113,19 @@ describe("the database address", () => {
 
 describe("connection parameters on the URL", () => {
   test("survive, because a dropped application_name turns a lock test into a timeout", async () => {
-    const named = createDatabase(
-      "postgres://openbot:openbot@127.0.0.1:5432/openbot?application_name=db_client_address_probe",
-    );
+    const address = new URL(testDatabaseUrl());
+    address.searchParams.set("application_name", "db_client_address_probe");
+    const named = createDatabase(address.toString());
 
-    const rows = await named.execute(
-      "select application_name from pg_stat_activity where pid = pg_backend_pid()",
-    );
-
-    expect(
-      (rows as Array<{ application_name: string }>)[0]?.application_name,
-    ).toBe("db_client_address_probe");
+    try {
+      const rows = await named.execute(
+        "select application_name from pg_stat_activity where pid = pg_backend_pid()",
+      );
+      expect(
+        (rows as Array<{ application_name: string }>)[0]?.application_name,
+      ).toBe("db_client_address_probe");
+    } finally {
+      await named.$client.close();
+    }
   });
 });

--- a/server/tests/dev-actor.integration.test.ts
+++ b/server/tests/dev-actor.integration.test.ts
@@ -4,11 +4,9 @@ import { eq } from "drizzle-orm";
 import { DEV_ACTOR, initializeDevActorUser } from "../src/auth/dev-actor";
 import { createDatabase } from "../src/db/client";
 import { users } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 
 afterAll(async () => {

--- a/server/tests/jsonb-encoding.integration.test.ts
+++ b/server/tests/jsonb-encoding.integration.test.ts
@@ -4,7 +4,7 @@ import { eq, sql } from "drizzle-orm";
 import { createAuditStore, recordAuditEvent } from "../src/audit";
 import { createDatabase } from "../src/db/client";
 import { agents } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * A jsonb column must hold JSON, not a string that looks like it.
@@ -17,11 +17,7 @@ import { TEST_POOL } from "./support/database";
  * value rather than on what comes back through the application.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 const suite = randomUUID().slice(0, 8);
 const agentId = `agent_jsonb_${suite}`;
 

--- a/server/tests/last-sign-in-backfill.integration.test.ts
+++ b/server/tests/last-sign-in-backfill.integration.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { inArray, sql } from "drizzle-orm";
 import { createDatabase } from "../src/db/client";
 import { sessions, users } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * The migration that gives an existing deployment its answer, run against a real database.
@@ -26,11 +26,7 @@ const entry = JOURNAL.entries.find((candidate) =>
   candidate.tag.endsWith("_backfill_last_signed_in_at"),
 );
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const PREFIX = "backfill-test-";
 const NEWEST = new Date("2026-09-05T09:00:00.000Z");

--- a/server/tests/page-frame-retention.integration.test.ts
+++ b/server/tests/page-frame-retention.integration.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../src/computer/page-frames";
 import { createDatabase } from "../src/db/client";
 import { computerPageFrame } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * The screenshots have to be able to stop growing, in every deployment rather than in one.
@@ -20,9 +20,7 @@ import { TEST_POOL } from "./support/database";
  * Against a real database because the interval arithmetic and the batching are both SQL.
  */
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 const store = createPageFrameStore(database);
 

--- a/server/tests/people-last-sign-in.integration.test.ts
+++ b/server/tests/people-last-sign-in.integration.test.ts
@@ -4,13 +4,9 @@ import { stampSignIn } from "../src/auth";
 import { createDatabase } from "../src/db/client";
 import { revokedAccess, sessions, users } from "../src/db/schema";
 import { createPeopleStore } from "../src/people/store";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const store = createPeopleStore(database, []);
 const PREFIX = "last-sign-in-test-";

--- a/server/tests/people-paging.integration.test.ts
+++ b/server/tests/people-paging.integration.test.ts
@@ -3,7 +3,7 @@ import { inArray } from "drizzle-orm";
 import { createDatabase } from "../src/db/client";
 import { sessions, users } from "../src/db/schema";
 import { createPeopleStore } from "../src/people/store";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * The people list has to stop growing with the company.
@@ -18,11 +18,7 @@ import { TEST_POOL } from "./support/database";
  * was written to return.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const store = createPeopleStore(database, []);
 const PREFIX = "paging-test-";

--- a/server/tests/plugin-credential-binding.integration.test.ts
+++ b/server/tests/plugin-credential-binding.integration.test.ts
@@ -16,7 +16,7 @@ import {
   CustomServerRefusedError,
   createPluginStore,
 } from "../src/plugins/store";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * Which address a stored credential may be spent against, and whose it has to be.
@@ -35,11 +35,7 @@ import { TEST_POOL } from "./support/database";
  * second, which is why they are one question here rather than two.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const KEY = `${"x".repeat(43)}=`;
 const tag = randomUUID().slice(0, 8);

--- a/server/tests/plugin-credential-rotation.integration.test.ts
+++ b/server/tests/plugin-credential-rotation.integration.test.ts
@@ -12,7 +12,7 @@ import {
   users,
 } from "../src/db/schema";
 import { createPluginStore } from "../src/plugins/store";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * Registering a client twice, and connecting twice, against a real vault.
@@ -24,11 +24,7 @@ import { TEST_POOL } from "./support/database";
  * it.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const ENCRYPTION_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 const policy: ActionPolicy = { mode: "enforce", deny: [], allow: ["true"] };

--- a/server/tests/plugin-curated-credential.integration.test.ts
+++ b/server/tests/plugin-curated-credential.integration.test.ts
@@ -10,7 +10,7 @@ import {
   CustomServerRefusedError,
   createPluginStore,
 } from "../src/plugins/store";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * Which credential a curated server is allowed to be pointed at.
@@ -28,11 +28,7 @@ import { TEST_POOL } from "./support/database";
  * which the catalogue's own comment invites.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const store = createPluginStore({
   database,

--- a/server/tests/plugin-routes.integration.test.ts
+++ b/server/tests/plugin-routes.integration.test.ts
@@ -8,7 +8,7 @@ import { encryptSecret } from "../src/credentials";
 import { createDatabase } from "../src/db/client";
 import { credentials, mcpServers, mcpTools } from "../src/db/schema";
 import { createPluginStore } from "../src/plugins/store";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 import { testEnvironment } from "./support/environment";
 
 /**
@@ -23,11 +23,7 @@ import { testEnvironment } from "./support/environment";
  * next refresh spends. So this asks the question end to end and then looks in the table.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const store = createPluginStore({
   database,

--- a/server/tests/plugin-store.integration.test.ts
+++ b/server/tests/plugin-store.integration.test.ts
@@ -8,7 +8,7 @@ import {
 } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { MCPMock } from "@copilotkit/aimock/mcp";
-import { and, eq, inArray, like, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { createAuditStore } from "../src/audit";
 import type { ActionPolicy } from "../src/computer/policy";
 import {
@@ -42,7 +42,7 @@ import {
   TokenRefusedError,
   unlistedAdvertisedTools,
 } from "../src/plugins/store";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * The two questions a tool call has to pass, and the row each answer leaves behind.
@@ -53,11 +53,7 @@ import { TEST_POOL } from "./support/database";
  * the vendor, so there is nothing to stub.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const suite = randomUUID().slice(0, 8);
 const holderId = `agent_plugin_holder_${suite}`;
@@ -76,8 +72,9 @@ let policy: ActionPolicy = { mode: "enforce", deny: [], allow: ["true"] };
  * The id is a real catalogue key rather than a suite-scoped one, because what is under test includes
  * the vendor's own read/write classification. On a database somebody is using, that key is their
  * configured server, so it is removed only when the test is what created it.
+ * Assume it belongs to the deployment until setup has checked, including when setup fails early.
  */
-let serverWasAlreadyConfigured = false;
+let serverWasAlreadyConfigured = true;
 /**
  * Whether this deployment already advertised the tool this suite inserts.
  *
@@ -85,10 +82,12 @@ let serverWasAlreadyConfigured = false;
  * vendor rather than the suite's fixture. Deleting by name regardless would take a real one; leaving
  * it always would leave a fixture that reads on screen as a tool the vendor offers.
  */
-let toolWasAlreadyAdvertised = false;
+let toolWasAlreadyAdvertised = true;
 
 const revokedCredentialIds: string[] = [];
 const issuedCredentialIds: string[] = [];
+const removalServerIds = new Set<string>();
+const removalUserIds = new Set<string>();
 const store = createPluginStore({
   database,
   auditStore: createAuditStore(database),
@@ -206,6 +205,16 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  // removeServer is under test, so teardown must not depend on it succeeding. Delete the exact
+  // attempted fixtures before their credentials, including when setup failed partway through.
+  if (removalServerIds.size > 0) {
+    await database
+      .delete(mcpServers)
+      .where(inArray(mcpServers.id, [...removalServerIds]));
+  }
+  if (removalUserIds.size > 0) {
+    await database.delete(users).where(inArray(users.id, [...removalUserIds]));
+  }
   /*
    * Scoped to this suite's own Bots, never to the ref alone.
    *
@@ -604,6 +613,7 @@ describe("removing an MCP server", () => {
     // `credentials_active_key_idx`. The audit trail also carries the
     // revocation with `reason: mcp_server_removed`.
     const removalServerId = `removal-target-${suite}`;
+    removalServerIds.add(removalServerId);
     revokedCredentialIds.length = 0;
     const [credentialRow] = await database
       .insert(credentialRows)
@@ -667,6 +677,8 @@ describe("removing an MCP server", () => {
   test("revokes every person's grant for the server it removes", async () => {
     const removalServerId = `removal-target-people-${suite}`;
     const connectedUserId = `user_removal_${suite}`;
+    removalServerIds.add(removalServerId);
+    removalUserIds.add(connectedUserId);
     revokedCredentialIds.length = 0;
 
     await database
@@ -742,6 +754,7 @@ describe("removing an MCP server", () => {
 
   test("does not call revoke when the server had no credential", async () => {
     const removalServerId = `removal-target-nocred-${suite}`;
+    removalServerIds.add(removalServerId);
     revokedCredentialIds.length = 0;
     await database.insert(mcpServers).values({
       id: removalServerId,
@@ -1136,14 +1149,14 @@ describe("refresh token rotation", () => {
     sent.length = 0;
   }
 
-  let notionWasAlreadyConfigured = false;
+  let notionWasAlreadyConfigured = true;
   /**
    * The OAuth client this deployment had before the suite ran, restored afterwards.
    *
-   * `mcp_servers.credential_id` is live configuration, and this suite repoints it. Restored
-   * unconditionally, because the delete below removes the row it would otherwise still address.
+   * `mcp_servers.credential_id` is live configuration, and this suite repoints it. Restore the
+   * snapshot before deleting our credentials; an early setup failure has no snapshot to restore.
    */
-  let clientBefore: string | null = null;
+  let clientBefore: string | null | undefined;
 
   beforeAll(async () => {
     await database
@@ -1212,10 +1225,12 @@ describe("refresh token rotation", () => {
         ),
       );
     // Before the deletes, because the column addresses one of the rows they remove.
-    await database
-      .update(mcpServers)
-      .set({ credentialId: clientBefore })
-      .where(eq(mcpServers.id, rotationServerId));
+    if (clientBefore !== undefined) {
+      await database
+        .update(mcpServers)
+        .set({ credentialId: clientBefore })
+        .where(eq(mcpServers.id, rotationServerId));
+    }
     for (const id of vaultRows) {
       await database.delete(credentials).where(eq(credentials.id, id));
     }
@@ -2116,7 +2131,7 @@ describe("a dynamic client the vendor has evicted", () => {
       actorId: dynamicUserId,
     });
 
-  let notionWasAlreadyConfigured = false;
+  let notionWasAlreadyConfigured = true;
 
   // The vendor refuses the ordinary way unless a test says otherwise, so a test that varies the
   // refusal cannot leave the next one asserting against somebody else's setup.
@@ -2968,7 +2983,15 @@ describe("a custom server may only be pointed at its own kind of credential", ()
    */
   const upsertCredentialId = randomUUID();
   const customServerId = `custom-cred-${suffix}`;
-  const madeServerIds: string[] = [];
+  const attemptedServerIds = new Set<string>();
+
+  function addCustomFixture(
+    input: Parameters<typeof store.addCustomServer>[0],
+  ) {
+    // Refusal tests may fail because the write succeeded. Track the attempt before calling it.
+    attemptedServerIds.add(input.id);
+    return store.addCustomServer(input);
+  }
 
   beforeAll(async () => {
     const encrypted = await encryptSecret(
@@ -3014,11 +3037,11 @@ describe("a custom server may only be pointed at its own kind of credential", ()
   });
 
   afterAll(async () => {
-    // By prefix, not by the ids this suite meant to make: before the fix the refused adds succeed,
-    // and a row left behind holds a foreign key onto the credentials deleted just below.
-    await database
-      .delete(mcpServers)
-      .where(like(mcpServers.id, `${customServerId}%`));
+    if (attemptedServerIds.size > 0) {
+      await database
+        .delete(mcpServers)
+        .where(inArray(mcpServers.id, [...attemptedServerIds]));
+    }
     await database
       .delete(credentialRows)
       .where(
@@ -3034,7 +3057,7 @@ describe("a custom server may only be pointed at its own kind of credential", ()
   test("somebody else's connector token is refused, and no server is written", async () => {
     const id = `${customServerId}-personal`;
     await expect(
-      store.addCustomServer({
+      addCustomFixture({
         id,
         title: "Collector",
         url: "https://collector.example/mcp",
@@ -3057,7 +3080,7 @@ describe("a custom server may only be pointed at its own kind of credential", ()
     // client secret as a bearer token is the mistake `refreshTools` was already changed to avoid.
     const id = `${customServerId}-client`;
     await expect(
-      store.addCustomServer({
+      addCustomFixture({
         id,
         title: "Collector",
         url: "https://collector.example/mcp",
@@ -3071,7 +3094,7 @@ describe("a custom server may only be pointed at its own kind of credential", ()
     // Same message as the wrong-kind refusal on purpose. A caller who can tell "wrong kind" from
     // "no such row" can ask this endpoint which ids are real, which is a vault oracle.
     const id = `${customServerId}-missing`;
-    const missing = store.addCustomServer({
+    const missing = addCustomFixture({
       id,
       title: "Collector",
       url: "https://collector.example/mcp",
@@ -3080,15 +3103,13 @@ describe("a custom server may only be pointed at its own kind of credential", ()
     });
     await expect(missing).rejects.toBeInstanceOf(CustomServerRefusedError);
 
-    const wrongKind = store
-      .addCustomServer({
-        id: `${customServerId}-kind-message`,
-        title: "Collector",
-        url: "https://collector.example/mcp",
-        credentialId: personalCredentialId,
-        by: "admin@example.com",
-      })
-      .catch((error: Error) => error.message);
+    const wrongKind = addCustomFixture({
+      id: `${customServerId}-kind-message`,
+      title: "Collector",
+      url: "https://collector.example/mcp",
+      credentialId: personalCredentialId,
+      by: "admin@example.com",
+    }).catch((error: Error) => error.message);
     const missingMessage = await missing.catch((error: Error) => error.message);
     expect(await wrongKind).toBe(missingMessage);
   });
@@ -3096,8 +3117,7 @@ describe("a custom server may only be pointed at its own kind of credential", ()
   test("the server's own token still works", async () => {
     // The case that must keep passing, so the refusal above is a rule and not a wall. The URL is
     // unreachable and that is fine: a failed refresh is recorded on the row rather than thrown.
-    madeServerIds.push(customServerId);
-    const added = await store.addCustomServer({
+    const added = await addCustomFixture({
       id: customServerId,
       title: "Collector",
       url: "https://collector.example/mcp",
@@ -3118,7 +3138,7 @@ describe("a custom server may only be pointed at its own kind of credential", ()
     // route passes the body field through untouched, so this is reachable with one curl.
     for (const notAnId of ["not-a-uuid", "' OR 1=1 --"]) {
       await expect(
-        store.addCustomServer({
+        addCustomFixture({
           id: `${customServerId}-shape`,
           title: "Collector",
           url: "https://collector.example/mcp",
@@ -3133,8 +3153,7 @@ describe("a custom server may only be pointed at its own kind of credential", ()
     // Not the same as a wrong one. An empty string used to reach the insert and break the foreign
     // key; the honest reading is that the administrator named nothing.
     const id = `${customServerId}-empty`;
-    madeServerIds.push(id);
-    const added = await store.addCustomServer({
+    const added = await addCustomFixture({
       id,
       title: "Collector",
       url: "https://collector.example/mcp",
@@ -3155,8 +3174,7 @@ describe("a custom server may only be pointed at its own kind of credential", ()
     // already holds its own token can be re-added naming somebody else's. The guard has to run
     // before the write, and the pointer already on the row has to survive the refusal.
     const id = `${customServerId}-upsert`;
-    madeServerIds.push(id);
-    await store.addCustomServer({
+    await addCustomFixture({
       id,
       title: "Collector",
       url: "https://collector.example/mcp",
@@ -3165,7 +3183,7 @@ describe("a custom server may only be pointed at its own kind of credential", ()
     });
 
     await expect(
-      store.addCustomServer({
+      addCustomFixture({
         id,
         title: "Collector",
         url: "https://collector.example/mcp",
@@ -3183,8 +3201,7 @@ describe("a custom server may only be pointed at its own kind of credential", ()
 
   test("a custom server with no credential at all still works", async () => {
     const id = `${customServerId}-none`;
-    madeServerIds.push(id);
-    const added = await store.addCustomServer({
+    const added = await addCustomFixture({
       id,
       title: "Collector",
       url: "https://collector.example/mcp",

--- a/server/tests/plugin-user-credential.integration.test.ts
+++ b/server/tests/plugin-user-credential.integration.test.ts
@@ -15,7 +15,7 @@ import {
   users,
 } from "../src/db/schema";
 import { createPluginStore, PluginRefusedError } from "../src/plugins/store";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * Whose credential a call to a `user-oauth` server goes out with.
@@ -31,11 +31,7 @@ import { TEST_POOL } from "./support/database";
  * property: a call with no grant behind it must not leave the building.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const suite = randomUUID().slice(0, 8);
 const botId = `agent_oauth_bot_${suite}`;

--- a/server/tests/policy-durability.integration.test.ts
+++ b/server/tests/policy-durability.integration.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../src/computer/policy-store";
 import { createDatabase } from "../src/db/client";
 import { actionPolicy } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * The boundary has to survive a restart.
@@ -20,11 +20,7 @@ import { TEST_POOL } from "./support/database";
  * one store would only prove it remembers what it was told a moment ago.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const configured = DEFAULT_ACTION_POLICY;
 const rule = 'intent == "activate" && contains(element.name, "submit")';

--- a/server/tests/policy-fanout.integration.test.ts
+++ b/server/tests/policy-fanout.integration.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../src/computer/policy-store";
 import { createDatabase } from "../src/db/client";
 import { actionPolicy } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * A boundary an administrator changes has to reach every server, not the one that served the request.
@@ -27,9 +27,7 @@ import { TEST_POOL } from "./support/database";
  * prove it remembers what it was told a moment ago, which was never the failure.
  */
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 
 const RULE = 'contains(element.name, "submit")';

--- a/server/tests/routine-sweep.integration.test.ts
+++ b/server/tests/routine-sweep.integration.test.ts
@@ -33,7 +33,7 @@ import {
   ROUTINE_FIRE_KIND,
 } from "../src/routines/sweep";
 import { createWorkQueue, DEFAULT_MAX_ATTEMPTS } from "../src/work/queue";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * Both halves of the sweep against a real PostgreSQL and the real `work_items` queue.
@@ -54,9 +54,7 @@ import { TEST_POOL } from "./support/database";
  * whether the consumer honours the booleans the queue hands back: a `renew` that says the lease has
  * gone, a `finish` that says the item was not ours, an attempt count that has reached its cap.
  */
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 const profileStore = createAgentProfileStore(
   database,

--- a/server/tests/routines-store.integration.test.ts
+++ b/server/tests/routines-store.integration.test.ts
@@ -23,11 +23,9 @@ import {
   RoutineNotFoundError,
   RoutineRefusedError,
 } from "../src/routines/store";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 const profileStore = createAgentProfileStore(
   database,

--- a/server/tests/runtime-agents.integration.test.ts
+++ b/server/tests/runtime-agents.integration.test.ts
@@ -18,11 +18,9 @@ import {
   intelligenceChannelMappings,
   users,
 } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 const managedEndpoint = new URL("https://managed.example.test/ag-ui");
 const mastraManagedEndpoint = new URL("https://managed.example.test/mastra");

--- a/server/tests/sandboxed-components.integration.test.ts
+++ b/server/tests/sandboxed-components.integration.test.ts
@@ -14,7 +14,7 @@ import {
   components,
   sandboxedComponents,
 } from "../src/db/schema";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * A component authored in a browser can be edited freely and still reach nobody until it is
@@ -26,11 +26,7 @@ import { TEST_POOL } from "./support/database";
  * capability, so that is asserted directly rather than inferred from the shape of the code.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const suite = randomUUID().slice(0, 8).replace(/-/g, "");
 const slug = `test_card_${suite}`;

--- a/server/tests/server-side-tools.integration.test.ts
+++ b/server/tests/server-side-tools.integration.test.ts
@@ -14,7 +14,7 @@ import {
 import { createPluginStore } from "../src/plugins/store";
 import { grantedTools, REFUSAL_MARKER } from "../src/plugins/tools";
 import type { ActionPolicy } from "../src/policy/engine";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * A tool call that happens with no browser involved.
@@ -29,11 +29,7 @@ import { TEST_POOL } from "./support/database";
  * else's server.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const suite = randomUUID().slice(0, 8);
 const holderId = `agent_tools_holder_${suite}`;

--- a/server/tests/skill-ownership.integration.test.ts
+++ b/server/tests/skill-ownership.integration.test.ts
@@ -7,7 +7,7 @@ import { createDatabase } from "../src/db/client";
 import { agentProfiles, agents, skills, users } from "../src/db/schema";
 import { createPluginRoutes } from "../src/plugins/routes";
 import { createPluginStore } from "../src/plugins/store";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * Whose skill is whose, and which Bots a person may put one on.
@@ -18,11 +18,7 @@ import { TEST_POOL } from "./support/database";
  * author owns.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const policy: ActionPolicy = { mode: "enforce", deny: [], allow: ["true"] };
 

--- a/server/tests/skill-tools.integration.test.ts
+++ b/server/tests/skill-tools.integration.test.ts
@@ -13,7 +13,7 @@ import {
   users,
 } from "../src/db/schema";
 import { createPluginStore, PluginRefusedError } from "../src/plugins/store";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * A skill saying which tools it needs, and that saying so grants nothing.
@@ -24,11 +24,7 @@ import { TEST_POOL } from "./support/database";
  * callable, writing a skill would be a way to grant yourself one.
  */
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 
 const policy: ActionPolicy = { mode: "enforce", deny: [], allow: ["true"] };
 

--- a/server/tests/support/database.test.ts
+++ b/server/tests/support/database.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { testDatabaseUrlFrom } from "./database";
+
+describe("TEST_DATABASE_URL", () => {
+  test("requires an explicit test database URL", () => {
+    expect(() => testDatabaseUrlFrom({})).toThrow(/TEST_DATABASE_URL/);
+  });
+
+  test("refuses the live development database even when DATABASE_URL names it", () => {
+    expect(() =>
+      testDatabaseUrlFrom({
+        TEST_DATABASE_URL: "postgres://openbot:openbot@localhost:5432/openbot",
+        DATABASE_URL: "postgres://openbot:openbot@localhost:5432/openbot_test",
+      }),
+    ).toThrow(/live openbot database/);
+  });
+
+  test("does not read DATABASE_URL as a fallback", () => {
+    expect(() =>
+      testDatabaseUrlFrom({
+        DATABASE_URL: "postgres://openbot:openbot@localhost:5432/openbot_test",
+      }),
+    ).toThrow(/TEST_DATABASE_URL/);
+  });
+
+  test("accepts a dedicated test database", () => {
+    expect(
+      testDatabaseUrlFrom({
+        TEST_DATABASE_URL:
+          "postgres://openbot:openbot@localhost:5432/openbot_test",
+      }),
+    ).toBe("postgres://openbot:openbot@localhost:5432/openbot_test");
+  });
+});

--- a/server/tests/support/database.ts
+++ b/server/tests/support/database.ts
@@ -1,4 +1,53 @@
 /**
+ * The database integration suite must never fall back to the developer's application database.
+ * `createDatabase` deliberately removes `process.env.DATABASE_URL` after opening a connection so Bun
+ * cannot ignore the explicit connection parts on Windows. That means a later test that reads
+ * `process.env.DATABASE_URL ?? localhost/openbot` can silently fall into the live development DB.
+ * Resolve one explicit test URL before opening a test pool and make the unsafe shape impossible.
+ */
+let cachedTestDatabaseUrl: string | undefined;
+
+export function testDatabaseUrl() {
+  cachedTestDatabaseUrl ??= testDatabaseUrlFrom(process.env);
+  return cachedTestDatabaseUrl;
+}
+
+export function testDatabaseUrlFrom(
+  environment: Record<string, string | undefined>,
+) {
+  const raw = environment.TEST_DATABASE_URL?.trim();
+  if (!raw) {
+    throw new Error(
+      "TEST_DATABASE_URL must point at a dedicated PostgreSQL test database. Do not rely on DATABASE_URL; createDatabase removes it to preserve the Windows Bun connection fix.",
+    );
+  }
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(
+      "TEST_DATABASE_URL must be a PostgreSQL URL such as postgres://openbot:openbot@localhost:5432/openbot_test.",
+    );
+  }
+  if (!/^postgres(?:ql)?:$/.test(url.protocol)) {
+    throw new Error(
+      "TEST_DATABASE_URL must use the postgres:// or postgresql:// protocol.",
+    );
+  }
+  const database = decodeURIComponent(url.pathname.replace(/^\//, ""));
+  if (!database) {
+    throw new Error("TEST_DATABASE_URL must name a database.");
+  }
+  if (database === "openbot") {
+    throw new Error(
+      "TEST_DATABASE_URL must not point at the live openbot database. Use a dedicated database such as openbot_test.",
+    );
+  }
+  return raw;
+}
+
+/**
  * How many connections one test file may hold.
  *
  * The suite runs in a single process, so every file that opens a pool holds it for the whole run and

--- a/server/tests/tenant-package.test.ts
+++ b/server/tests/tenant-package.test.ts
@@ -26,13 +26,9 @@ import {
   validateTenantPackage,
   validateThemeCss,
 } from "../src/tenant-package";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 const createdAgentIds: string[] = [];
 const createdChannelIds: string[] = [];
 const createdPackageIds: string[] = [];

--- a/server/tests/test-database-url.integration.test.ts
+++ b/server/tests/test-database-url.integration.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { createDatabase } from "../src/db/client";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
+
+describe("TEST_DATABASE_URL isolation", () => {
+  test("survives createDatabase deleting DATABASE_URL before a later connection opens", async () => {
+    const databaseUrl = testDatabaseUrl();
+    const databaseName = new URL(databaseUrl).pathname.replace(/^\//, "");
+    process.env.DATABASE_URL =
+      "postgres://openbot:openbot@localhost:5432/openbot";
+
+    const first = createDatabase(databaseUrl, TEST_POOL);
+    try {
+      const [firstRow] = await first.execute<{ name: string }>(
+        "select current_database() as name",
+      );
+      expect(process.env.DATABASE_URL).toBeUndefined();
+
+      const second = createDatabase(testDatabaseUrl(), TEST_POOL);
+      try {
+        const [secondRow] = await second.execute<{ name: string }>(
+          "select current_database() as name",
+        );
+
+        expect(firstRow?.name).toBe(databaseName);
+        expect(secondRow?.name).toBe(databaseName);
+        expect(databaseName).not.toBe("openbot");
+      } finally {
+        await second.$client.close();
+      }
+    } finally {
+      await first.$client.close();
+    }
+  });
+});

--- a/server/tests/user-instructions.integration.test.ts
+++ b/server/tests/user-instructions.integration.test.ts
@@ -8,11 +8,9 @@ import {
   INSTRUCTIONS_LIMIT,
   InstructionsTooLongError,
 } from "../src/user-instructions";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
-const databaseUrl =
-  process.env.DATABASE_URL ??
-  "postgres://openbot:openbot@localhost:5432/openbot";
+const databaseUrl = testDatabaseUrl();
 const database = createDatabase(databaseUrl, TEST_POOL);
 const store = createUserInstructionsStore(database);
 

--- a/server/tests/work-queue.integration.test.ts
+++ b/server/tests/work-queue.integration.test.ts
@@ -4,7 +4,7 @@ import { and, eq } from "drizzle-orm";
 import { createDatabase } from "../src/db/client";
 import { workItems } from "../src/db/schema";
 import { createWorkQueue } from "../src/work/queue";
-import { TEST_POOL } from "./support/database";
+import { TEST_POOL, testDatabaseUrl } from "./support/database";
 
 /**
  * The one mechanism suspending idle computers, running routines and handing work between Bots all
@@ -14,11 +14,7 @@ import { TEST_POOL } from "./support/database";
  * the database makes about two transactions racing, and a stub that returns rows in order would pass
  * every test below while the real thing handed one item to two replicas.
  */
-const database = createDatabase(
-  process.env.DATABASE_URL ??
-    "postgres://openbot:openbot@localhost:5432/openbot",
-  TEST_POOL,
-);
+const database = createDatabase(testDatabaseUrl(), TEST_POOL);
 const queue = createWorkQueue(database);
 const kind = `test.${randomUUID().slice(0, 8)}`;
 


### PR DESCRIPTION
Integration tests could write fixtures into the application database: createDatabase removes DATABASE_URL to avoid a Bun Windows connection bug, and later test files then fell back to localhost/openbot. This left repeated “Raced” components and “removal target” plugins visible after reinstalling the app with its existing database.

Require an explicit, cached TEST_DATABASE_URL and refuse the default application database. All query-backed server tests and the CI test job use that address. Track every fixture in the component/plugin suites and remove it even when the operation under test fails. Most changed files only replace their database URL fallback with the shared helper; production database code is unchanged.

Validation:
- 720 tests passed across all 47 affected test files on a separately created and migrated PostgreSQL database.
- Real connections still reached the test database after createDatabase deleted DATABASE_URL.
- Actual suite startup refused missing TEST_DATABASE_URL and an address naming the application database.
- Three deliberately injected plugin-removal failures left zero plugin, credential, agent, or user fixtures; the normal focused run also left zero component fixtures.
- Server typecheck/build, changed-file formatting/lint, actionlint, and diff checks passed.
- Backed up and removed the exact legacy test records from the affected local install, then inspected both pages in the running Mac app and confirmed the app API remained clean after the test run.
