### PR TITLE
feat: enable generative UI, A2UI actions, tables and forms (S8)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,11 +22,7 @@ SERVER_PORT=3001
 TENANT_PACKAGE_DIR=../examples/fintech
 # Let a Bot answer with an interface it wrote itself: markup, styles and a script it generates for
 # that one answer, streamed into the transcript and rendered in a sandboxed iframe with no
-# same-origin access to this app. Off unless you set this to `true` or `1`.
-#
-# Asked for rather than inherited, unlike most of the switches in this file. It decides whether a
-# model may put code it wrote on somebody's screen, so a deployment should choose it rather than
-# acquire it by upgrading — including a deployment that builds its default branch automatically.
+# same-origin access to this app. On by default; set this to `false` or `0` to opt out.
 #
 # This is not the component catalogue. A component is something this deployment holds and an
 # administrator grants per Bot; this has nothing to grant, because the Bot writes it on the spot and
@@ -35,8 +31,8 @@ TENANT_PACKAGE_DIR=../examples/fintech
 #
 # What the interface can reach is what the sandbox hands it, and this deployment hands it nothing: no
 # session, no same-origin access, and no route into your data. It can load libraries from a CDN, so a
-# deployment that must not reach the public internet from a browser tab should leave this off.
-# OPENBOT_GENERATIVE_UI=true
+# deployment that must not reach the public internet from a browser tab should set this to false.
+# OPENBOT_GENERATIVE_UI=false
 # What this deployment calls itself, when more than one shares an Intelligence project. A copy of a
 # deployment made for development uses the same project key, and threads are listed per Bot with
 # nothing to say which deployment a conversation came from. The name goes into every thread id this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### Generated interfaces, tables and forms
+
+Generative UI is enabled by default; set `OPENBOT_GENERATIVE_UI=false` or `0` to disable it.
+Bots can render A2UI interfaces, compare records in sortable tables, and collect related answers in
+a form that waits for submission. LangGraph receives the component schemas needed to draw these
+interfaces correctly.
+
+The playground rejects invalid JSON before saving or publishing, confirms successful saves, and
+shows published custom components in the administrator's gallery.
+
 ### A Bot's computer is rebuilt when it holds a token the deployment has stopped using
 
 A computer checks every caller against the `COMPUTER_TOKEN` it was created with, and holds that one

--- a/agent-bot/src/history.ts
+++ b/agent-bot/src/history.ts
@@ -17,6 +17,12 @@ export function toProviderMessages(
 ): OpenAI.Chat.ChatCompletionMessageParam[] {
   const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
     { role: "system", content: COMPUTER_GUIDANCE },
+    // AG-UI application context is separate from history. The A2UI catalog and tool instructions
+    // arrive here; omitting them leaves the model guessing component names and action schemas.
+    ...(input.context ?? []).map(({ description, value }) => ({
+      role: "system" as const,
+      content: `${description}\n${value}`,
+    })),
   ];
 
   /*

--- a/agent-bot/tests/history.test.ts
+++ b/agent-bot/tests/history.test.ts
@@ -31,6 +31,37 @@ function withoutGuidance(messages: ReturnType<typeof toProviderMessages>) {
   return messages.slice(1);
 }
 
+test("passes AG-UI catalog context to the model while preserving prompt and history order", () => {
+  const run = input([
+    { id: "standing", role: "system", content: "Help with travel planning." },
+    { id: "request", role: "user", content: "Draw a trip card." },
+  ]);
+  const withoutContext = toProviderMessages(run);
+  const catalog = JSON.stringify({
+    components: { Card: { properties: { component: { const: "Card" } } } },
+  });
+  run.context = [
+    { description: "A2UI Component Schema", value: catalog },
+    {
+      description: "A2UI render tool usage guide",
+      value: "Actions use event.name.",
+    },
+  ];
+
+  expect(toProviderMessages(run)).toEqual([
+    withoutContext[0],
+    { role: "system", content: `A2UI Component Schema\n${catalog}` },
+    {
+      role: "system",
+      content: "A2UI render tool usage guide\nActions use event.name.",
+    },
+    ...withoutContext.slice(1),
+  ]);
+  expect(run.messages).toHaveLength(2);
+  run.context = [];
+  expect(toProviderMessages(run)).toEqual(withoutContext);
+});
+
 describe("a tool call nothing ever answered", () => {
   test("is answered, so the next turn is not refused outright", () => {
     const messages = withoutGuidance(
@@ -241,13 +272,10 @@ describe("a tool call restored from the thread store", () => {
       ],
     } as never);
 
-    const withCalls = messages.find(
-      (message: Record<string, unknown>) => message.tool_calls,
-    ) as Record<string, unknown>;
-    const call = (withCalls.tool_calls as Array<Record<string, unknown>>)[0];
-    const fn = call.function as Record<string, unknown>;
+    const withCalls = messages.find((message) => message.role === "assistant");
+    const fn = withCalls?.tool_calls?.[0]?.function;
 
-    expect(fn.name).toBe("computer_navigate");
-    expect(fn.arguments).toBe('{"url":"https://news.ycombinator.com"}');
+    expect(fn?.name).toBe("computer_navigate");
+    expect(fn?.arguments).toBe('{"url":"https://news.ycombinator.com"}');
   });
 });

--- a/agent-langgraph-agui/src/main.py
+++ b/agent-langgraph-agui/src/main.py
@@ -15,7 +15,13 @@ from langchain.chat_models import init_chat_model
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import START, MessagesState, StateGraph
 
-from .tool_runtime import ToolAwareAgent, bind_tools, execute_tools, next_step
+from .tool_runtime import (
+    ToolAwareAgent,
+    bind_tools,
+    execute_tools,
+    model_messages,
+    next_step,
+)
 
 TOKEN_HEADER = "x-openbot-agent-token"
 
@@ -152,7 +158,8 @@ def _model():
 
 
 async def answer(state: MessagesState):
-    return {"messages": [await bind_tools(_model()).ainvoke(state["messages"])]}
+    messages = model_messages(state["messages"])
+    return {"messages": [await bind_tools(_model()).ainvoke(messages)]}
 
 
 builder = StateGraph(MessagesState)

--- a/agent-langgraph-agui/src/tool_runtime.py
+++ b/agent-langgraph-agui/src/tool_runtime.py
@@ -13,8 +13,8 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field
 
 import httpx
-from ag_ui.core import EventType, RunAgentInput, RunErrorEvent, Tool
-from langchain_core.messages import ToolMessage
+from ag_ui.core import Context, EventType, RunAgentInput, RunErrorEvent, Tool
+from langchain_core.messages import SystemMessage, ToolMessage
 from langgraph.graph import END
 
 from .parallel_tools import ParallelToolAgent
@@ -23,6 +23,7 @@ from .parallel_tools import ParallelToolAgent
 @dataclass(frozen=True)
 class RunTools:
     tools: tuple[Tool, ...] = ()
+    context: tuple[Context, ...] = ()
     deployment: frozenset[str] = frozenset()
     assertion: str = field(default="", repr=False)
 
@@ -45,6 +46,7 @@ class ToolAwareAgent(ParallelToolAgent):
         assertion = props.get("openbotRun", "")
         context = RunTools(
             tools=tuple(input.tools or []),
+            context=tuple(input.context or []),
             deployment=frozenset(name for name in names if isinstance(name, str))
             if isinstance(names, list)
             else frozenset(),
@@ -79,6 +81,22 @@ class ToolAwareAgent(ParallelToolAgent):
             )
         finally:
             _current.reset(token)
+
+
+def model_messages(messages):
+    """Pass AG-UI application context to the model without checkpointing it.
+
+    The maintained integration carries context separately from messages. Our
+    graph uses MessagesState, so its answer node must explicitly include the
+    current catalog/guidelines instead of silently discarding them.
+    """
+    return [
+        *[
+            SystemMessage(content=f"{entry.description}\n{entry.value}")
+            for entry in current_tools().context
+        ],
+        *messages,
+    ]
 
 
 def bind_tools(model):

--- a/agent-langgraph-agui/tests/test_tool_protocol.py
+++ b/agent-langgraph-agui/tests/test_tool_protocol.py
@@ -233,6 +233,51 @@ def snapshot(events):
 
 
 @pytest.mark.asyncio
+async def test_a2ui_catalog_context_reaches_model_without_entering_history(boundary):
+    body = run_input(
+        [],
+        messages=[{
+            "id": "context-request", "role": "user", "content": "Draw a trip card"
+        }],
+    )
+    catalog = json.dumps({
+        "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json",
+        "components": {"Card": {"properties": {"component": {"const": "Card"}}}},
+    })
+    body["context"] = [
+        {
+            "description": (
+                "A2UI Component Schema — available components for generating UI surfaces. "
+                "Use these component names and properties when creating A2UI operations."
+            ),
+            "value": catalog,
+        },
+        {
+            "description": "A2UI render tool usage guide",
+            "value": "Use component: Card, not type: card. Actions use event.name.",
+        },
+    ]
+
+    events = await run_protocol(body)
+    model_messages = boundary["model"][0]["messages"]
+    system = [
+        message["content"] for message in model_messages
+        if message["role"] == "system"
+    ]
+    assert any(catalog in content for content in system)
+    assert any("Actions use event.name." in content for content in system)
+    assert catalog not in json.dumps(snapshot(events))
+    assert "synthetic-run-assertion" not in json.dumps(model_messages)
+
+    # A later request on the same graph thread uses its current context, not a checkpointed catalog.
+    body["runId"] = str(uuid4())
+    body["messages"] = [{"id": "context-next", "role": "user", "content": "Continue"}]
+    body["context"] = []
+    await run_protocol(body)
+    assert catalog not in json.dumps(boundary["model"][-1]["messages"])
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("name", ["computer_navigate", "computer_run_command"])
 async def test_surface_tool_calls_end_then_consume_actual_client_result(boundary, name):
     body = run_input([name])

--- a/agent-langgraph/src/history.ts
+++ b/agent-langgraph/src/history.ts
@@ -23,7 +23,15 @@ export { NO_ANSWER_CAME };
 
 /** Translate the conversation AG-UI carries into LangChain's message classes. */
 export function toLangChainMessages(input: RunAgentInput): BaseMessage[] {
-  const messages: BaseMessage[] = [new SystemMessage(COMPUTER_GUIDANCE)];
+  const messages: BaseMessage[] = [
+    new SystemMessage(COMPUTER_GUIDANCE),
+    // AG-UI carries application context separately from conversation history. CopilotKit puts
+    // the A2UI catalog and tool instructions here; dropping it leaves the model guessing the
+    // component schema and can strand the renderer on an invalid, never-painted surface.
+    ...(input.context ?? []).map(
+      ({ description, value }) => new SystemMessage(`${description}\n${value}`),
+    ),
+  ];
 
   /*
    * Which calls in this history were ever answered.

--- a/agent-langgraph/tests/history.test.ts
+++ b/agent-langgraph/tests/history.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { AIMessage, ToolMessage } from "@langchain/core/messages";
 import type { RunAgentInput } from "@ag-ui/core";
+import {
+  AIMessage,
+  SystemMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
 import { NO_ANSWER_CAME, toLangChainMessages } from "../src/history";
 
 /**
@@ -29,6 +33,37 @@ const assistantAsking = {
     },
   ],
 };
+
+test("passes the caller's A2UI catalog and tool instructions to the model", () => {
+  // The live failure emitted `type: "card"` instead of `component: "Card"`: the model saw the
+  // permissive render_a2ui tool schema, but this adapter had discarded its actual catalog context.
+  const catalog = JSON.stringify({
+    catalogId: "https://a2ui.org/specification/v0_9/basic_catalog.json",
+    components: {
+      Card: {
+        properties: { component: { const: "Card" }, child: { type: "string" } },
+      },
+    },
+  });
+  const instructions =
+    "Use flat components with component names from the catalog. Button actions use event.name and event.context.";
+  const run = input([
+    { role: "user", content: "Show a Trip preferences card." },
+  ]);
+  run.context = [
+    { description: "A2UI Component Schema", value: catalog },
+    { description: "A2UI render tool usage guide", value: instructions },
+  ];
+  const messages = toLangChainMessages(run);
+  const system = messages.filter((message) => message instanceof SystemMessage);
+  expect(system.map((message) => message.content)).toContain(
+    `A2UI Component Schema\n${catalog}`,
+  );
+  expect(system.map((message) => message.content)).toContain(
+    `A2UI render tool usage guide\n${instructions}`,
+  );
+  expect(messages.at(-1)?.content).toBe("Show a Trip preferences card.");
+});
 
 describe("history with a tool call nobody answered", () => {
   test("closes it, so the next turn is not rejected", () => {

--- a/app/package.json
+++ b/app/package.json
@@ -17,6 +17,7 @@
     "@ag-ui/core": "0.0.59",
     "@base-ui/react": "^1.6.0",
     "@better-auth/sso": "^1.7.1",
+    "@copilotkit/a2ui-renderer": "1.70.1",
     "@copilotkit/react-core": "1.70.1",
     "@fontsource-variable/inter": "^5.3.0",
     "@shadcn/react": "^0.3.0",

--- a/app/src/components/channels/channel-chat.tsx
+++ b/app/src/components/channels/channel-chat.tsx
@@ -1,6 +1,7 @@
 import type { Message } from "@ag-ui/core";
 import {
   type Attachment,
+  CopilotChatConfigurationProvider,
   UseAgentUpdate,
   useAgent,
   useCopilotKit,
@@ -235,8 +236,9 @@ export function ChannelChat({
   const { copilotkit } = useCopilotKit();
   // Mentions are scoped to the channel's permitted agents.
   const { data: agentProfiles } = useQuery(agentListQueryOptions());
+  const channelAgentId = `channel:${channel.id}`;
   const { agent, isReady } = useAgent({
-    agentId: `channel:${channel.id}`,
+    agentId: channelAgentId,
     runtimeAgentId,
     threadId: channel.threadId,
     updates: [
@@ -797,101 +799,108 @@ export function ChannelChat({
   }, []);
 
   return (
-    <ConversationProvider ask={askFromComponent}>
-      <ConversationView
-        agents={toAgentOptions(agentProfiles, channel.agentIds)}
-        channelId={channel.id}
-        /*
-         * THE TURN, not the run. `say` waits for the runtime agent and the join before a run starts,
-         * and `agent.isRunning` alone leaves that gap unmarked — which is the one moment the
-         * "Thinking" line exists for. Same value as `pending`, deliberately.
-         */
-        busy={agent.isRunning || turnsInFlight > 0}
-        // The `/` menu exposes only skills granted to this Bot.
-        commands={skillCommands}
-        // Readiness is handled by `say`; deletion is the only disabled-chat state.
-        disabled={!channel.active}
-        messages={transcriptMessages(agent.messages, seed)}
-        notice={
+    // Activity renderers resolve their agent through this SDK context. It must match useAgent's
+    // channel instance so an action continues this thread instead of looking for a default agent.
+    <CopilotChatConfigurationProvider
+      agentId={channelAgentId}
+      threadId={channel.threadId}
+    >
+      <ConversationProvider ask={askFromComponent}>
+        <ConversationView
+          agents={toAgentOptions(agentProfiles, channel.agentIds)}
+          channelId={channel.id}
           /*
-           * Two things can be worth saying at once — a deleted coworker and a history with holes in
-           * it — and they are independent, so neither is an `else` for the other.
+           * THE TURN, not the run. `say` waits for the runtime agent and the join before a run starts,
+           * and `agent.isRunning` alone leaves that gap unmarked — which is the one moment the
+           * "Thinking" line exists for. Same value as `pending`, deliberately.
            */
-          <>
-            {historyNotice ? (
-              <p className="pb-2 text-sm text-muted-foreground" role="status">
-                {historyNotice}
-              </p>
-            ) : null}
-            {channel.active ? null : (
-              <p className="pb-2 text-sm text-muted-foreground" role="status">
-                This coworker has been deleted. The conversation stays readable,
-                but it can no longer reply.
-              </p>
-            )}
-          </>
-        }
-        onSubmit={async (draft) => {
-          // `draft.agentId` carries the @mentioned coworker, but nothing routes on it yet: this
-          // channel is pinned to one `runtimeAgentId` for the life of its thread, so honouring a
-          // per-message mention is a change to that binding, not to the composer.
-          //
-          // `commandIds` are the `/` chips that survived into the send, in the order they were
-          // typed. Resolved against the same list the menu was built from, so a chip left over from
-          // a skill that has since been revoked resolves to nothing rather than to a stale
-          // instruction — the menu is refetched, and this reads from it.
-          const skillInstructions = draft.commandIds
-            .map(
-              (id) =>
-                skillCommands.find((command) => command.id === id)?.prompt,
-            )
-            .filter((instruction): instruction is string =>
-              Boolean(instruction),
-            );
+          busy={agent.isRunning || turnsInFlight > 0}
+          // The `/` menu exposes only skills granted to this Bot.
+          commands={skillCommands}
+          // Readiness is handled by `say`; deletion is the only disabled-chat state.
+          disabled={!channel.active}
+          messages={transcriptMessages(agent.messages, seed)}
+          notice={
+            /*
+             * Two things can be worth saying at once — a deleted coworker and a history with holes in
+             * it — and they are independent, so neither is an `else` for the other.
+             */
+            <>
+              {historyNotice ? (
+                <p className="pb-2 text-sm text-muted-foreground" role="status">
+                  {historyNotice}
+                </p>
+              ) : null}
+              {channel.active ? null : (
+                <p className="pb-2 text-sm text-muted-foreground" role="status">
+                  This coworker has been deleted. The conversation stays
+                  readable, but it can no longer reply.
+                </p>
+              )}
+            </>
+          }
+          onSubmit={async (draft) => {
+            // `draft.agentId` carries the @mentioned coworker, but nothing routes on it yet: this
+            // channel is pinned to one `runtimeAgentId` for the life of its thread, so honouring a
+            // per-message mention is a change to that binding, not to the composer.
+            //
+            // `commandIds` are the `/` chips that survived into the send, in the order they were
+            // typed. Resolved against the same list the menu was built from, so a chip left over from
+            // a skill that has since been revoked resolves to nothing rather than to a stale
+            // instruction — the menu is refetched, and this reads from it.
+            const skillInstructions = draft.commandIds
+              .map(
+                (id) =>
+                  skillCommands.find((command) => command.id === id)?.prompt,
+              )
+              .filter((instruction): instruction is string =>
+                Boolean(instruction),
+              );
 
-          await say(draft.text, skillInstructions, draft.attachments);
-        }}
-        /**
-         * Stop through the core so the abort signal reaches frontend tools; `say` repairs any
-         * unanswered tool call before the next turn.
-         */
-        onStop={() => {
-          awaitingReply.current = false;
-          copilotkit.stopAgent({ agent });
-        }}
-        /*
-         * The turn, not the run. A browser action ends one run and starts another, and telling the
-         * conversation it is idle in between is what would drain a parked correction into the
-         * middle of an answer: a second turn racing the first on one thread, with a fabricated
-         * result stitched over a tool call that is still executing.
-         */
-        pending={agent.isRunning || turnsInFlight > 0}
-        /*
-         * A channel outlives its turns, so it is the screen where waiting is worth offering. A
-         * correction typed mid-answer is held here, in this tab, and runs as one follow-up turn the
-         * moment this one is over — including when it is over because somebody pressed the button
-         * above.
-         */
-        queueWhileBusy
-        restoring={restoring}
-        /*
-         * The run, not the turn. Stop reaches a run through the core's abort controller, and that
-         * controller does not exist until `say` has finished waiting for the runtime agent — so
-         * this is the one place the narrower fact is the honest one to draw a button from.
-         */
-        stoppable={agent.isRunning || runsInFlight > 0}
-        /*
-         * At the END OF THE TRANSCRIPT rather than above the composer, which is where this used to
-         * be. A turn that ends without an answer leaves a gap exactly where the reply was going to
-         * appear, and the person is already looking at it; an explanation in the composer area is a
-         * different part of the screen from the thing it explains.
-         *
-         * `runError` carries whatever ended the turn, in that thing's own words. A Bot that stopped
-         * streaming says so, because the deployment's stall watchdog writes that sentence into the
-         * run before closing it; see server/src/channels/stall-guard.ts.
-         */
-        stopped={runError ?? undefined}
-      />
-    </ConversationProvider>
+            await say(draft.text, skillInstructions, draft.attachments);
+          }}
+          /**
+           * Stop through the core so the abort signal reaches frontend tools; `say` repairs any
+           * unanswered tool call before the next turn.
+           */
+          onStop={() => {
+            awaitingReply.current = false;
+            copilotkit.stopAgent({ agent });
+          }}
+          /*
+           * The turn, not the run. A browser action ends one run and starts another, and telling the
+           * conversation it is idle in between is what would drain a parked correction into the
+           * middle of an answer: a second turn racing the first on one thread, with a fabricated
+           * result stitched over a tool call that is still executing.
+           */
+          pending={agent.isRunning || turnsInFlight > 0}
+          /*
+           * A channel outlives its turns, so it is the screen where waiting is worth offering. A
+           * correction typed mid-answer is held here, in this tab, and runs as one follow-up turn the
+           * moment this one is over — including when it is over because somebody pressed the button
+           * above.
+           */
+          queueWhileBusy
+          restoring={restoring}
+          /*
+           * The run, not the turn. Stop reaches a run through the core's abort controller, and that
+           * controller does not exist until `say` has finished waiting for the runtime agent — so
+           * this is the one place the narrower fact is the honest one to draw a button from.
+           */
+          stoppable={agent.isRunning || runsInFlight > 0}
+          /*
+           * At the END OF THE TRANSCRIPT rather than above the composer, which is where this used to
+           * be. A turn that ends without an answer leaves a gap exactly where the reply was going to
+           * appear, and the person is already looking at it; an explanation in the composer area is a
+           * different part of the screen from the thing it explains.
+           *
+           * `runError` carries whatever ended the turn, in that thing's own words. A Bot that stopped
+           * streaming says so, because the deployment's stall watchdog writes that sentence into the
+           * run before closing it; see server/src/channels/stall-guard.ts.
+           */
+          stopped={runError ?? undefined}
+        />
+      </ConversationProvider>
+    </CopilotChatConfigurationProvider>
   );
 }

--- a/app/src/components/component-preview.tsx
+++ b/app/src/components/component-preview.tsx
@@ -1,5 +1,111 @@
-import { useEffect, useRef, useState } from "react";
+import { OpenGenerativeUIActivityRenderer } from "@copilotkit/react-core/v2";
+import { useQuery } from "@tanstack/react-query";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { galleryComponent } from "@/lib/copilot/gallery-registry";
+import {
+  type SandboxedRecord,
+  sandboxedListQueryOptions,
+} from "@/lib/sandboxed/queries";
+
+/** Sample arguments belong to the administrator's working copy, so only Admin fetches them. */
+export function AdminComponentPreview({
+  name,
+  kind,
+}: {
+  name: string;
+  kind: string;
+}) {
+  const sandboxed = useQuery({
+    ...sandboxedListQueryOptions(),
+    enabled: kind === "sandboxed",
+  });
+  if (kind === "sandboxed" && sandboxed.isPending) return null;
+  if (kind === "sandboxed" && sandboxed.error) {
+    return <PreviewNotice>Preview could not be loaded.</PreviewNotice>;
+  }
+  return (
+    <ComponentPreview
+      kind={kind}
+      name={name}
+      sandboxed={sandboxed.data?.find((component) => component.name === name)}
+    />
+  );
+}
+
+function PreviewNotice({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-full w-full items-center justify-center p-4">
+      {/* The artwork stays pale in both themes, so this text must stay dark. */}
+      <p className="text-center text-neutral-700 text-xs">{children}</p>
+    </div>
+  );
+}
+
+export function ComponentPreview({
+  name,
+  kind,
+  sandboxed,
+  fill = PREVIEW_FILL,
+}: {
+  name: string;
+  kind?: string;
+  sandboxed?: SandboxedRecord;
+  fill?: number;
+}) {
+  const entry = galleryComponent(name);
+  if (entry?.preview) {
+    return (
+      <FittedPreview fill={fill}>
+        <entry.Component {...entry.preview} />
+      </FittedPreview>
+    );
+  }
+
+  if (sandboxed?.name === name) {
+    if (!sandboxed.published || sandboxed.publishedHtml === null) {
+      return (
+        <PreviewNotice>
+          Publish in the playground to see a preview.
+        </PreviewNotice>
+      );
+    }
+    const content = {
+      css: sandboxed.publishedCss ?? "",
+      cssComplete: true,
+      html: [sandboxed.publishedHtml],
+      htmlComplete: true,
+      jsFunctions: `window.__args = ${JSON.stringify(sandboxed.sampleArguments)};\n${sandboxed.publishedJsFunctions ?? ""}`,
+      jsFunctionsComplete: true,
+      generating: false,
+    };
+    return (
+      <FittedPreview fill={fill}>
+        <div
+          className="w-full"
+          title="Published component with saved sample arguments"
+        >
+          <OpenGenerativeUIActivityRenderer
+            activityType="open-generative-ui"
+            agent={null}
+            content={content}
+            key={JSON.stringify(content)}
+            message={null}
+          />
+        </div>
+      </FittedPreview>
+    );
+  }
+
+  return (
+    <PreviewNotice>
+      {entry
+        ? "This one is only drawn in a conversation."
+        : kind === "sandboxed"
+          ? "Published in the playground."
+          : "This build cannot draw this."}
+    </PreviewNotice>
+  );
+}
 
 /**
  * The width a gallery component is given to lay out against, standing in for the conversation
@@ -40,14 +146,13 @@ export const PREVIEW_FILL = 0.85;
  * card here has a real note field and real Approve and Decline buttons; nothing in Admin should be
  * able to reach them, and a screen reader should not find a second set of them on the page.
  */
-export function ComponentPreview({
-  name,
-  fill = PREVIEW_FILL,
+function FittedPreview({
+  children,
+  fill,
 }: {
-  name: string;
-  fill?: number;
+  children: ReactNode;
+  fill: number;
 }) {
-  const entry = galleryComponent(name);
   const box = useRef<HTMLDivElement>(null);
   const content = useRef<HTMLDivElement>(null);
   const [scale, setScale] = useState(0);
@@ -88,26 +193,6 @@ export function ComponentPreview({
     return () => observer.disconnect();
   }, [fill]);
 
-  if (!entry?.preview) {
-    return (
-      <div className="flex h-full w-full items-center justify-center p-4">
-        {/*
-         * A fixed dark grey rather than `text-muted-foreground`. That token lightens in the dark
-         * theme — 0.5 to 0.708 — while the artwork behind this text does not: it is the same pale
-         * gradient either way, with no dark variant. Following the theme therefore moved the text
-         * towards its background exactly when it needed to move away from it.
-         */}
-        <p className="text-center text-neutral-700 text-xs">
-          {entry
-            ? "This one is only drawn in a conversation."
-            : "This build cannot draw this."}
-        </p>
-      </div>
-    );
-  }
-
-  const { Component } = entry;
-
   return (
     <div
       aria-hidden="true"
@@ -133,7 +218,7 @@ export function ComponentPreview({
           width: PREVIEW_LAYOUT_WIDTH,
         }}
       >
-        <Component {...entry.preview} />
+        {children}
       </div>
     </div>
   );

--- a/app/src/components/gallery/form.tsx
+++ b/app/src/components/gallery/form.tsx
@@ -1,0 +1,417 @@
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type { GalleryComponent } from "@/lib/copilot/gallery-registry";
+import { Badge, GalleryFrame } from "./frame";
+
+const Field = z
+  .object({
+    id: z
+      .string()
+      .regex(/^[a-zA-Z][a-zA-Z0-9_]{0,47}$/)
+      .describe("Unique key returned with the answer"),
+    label: z.string().trim().min(1).max(100),
+    type: z.enum(["text", "email", "number", "select", "textarea"]),
+    required: z.boolean().optional(),
+    help: z.string().max(250).optional(),
+    options: z
+      .array(z.string().trim().min(1).max(100))
+      .min(1)
+      .max(20)
+      .optional()
+      .describe("Required for select fields"),
+    min: z.number().optional().describe("Minimum for a number field"),
+    max: z.number().optional().describe("Maximum for a number field"),
+  })
+  .refine(
+    (field) =>
+      (field.type !== "select" || Boolean(field.options?.length)) &&
+      (!field.options ||
+        new Set(field.options).size === field.options.length) &&
+      (field.min === undefined ||
+        field.max === undefined ||
+        field.min <= field.max),
+    "Select fields need unique options; minimum must not exceed maximum",
+  );
+
+export const FormCardArgs = z
+  .object({
+    title: z.string().trim().min(1).max(120),
+    description: z.string().max(500).optional(),
+    fields: z.array(Field).min(1).max(8),
+    submitLabel: z.string().trim().min(1).max(40).optional(),
+  })
+  .refine(
+    (form) =>
+      new Set(form.fields.map((field) => field.id)).size === form.fields.length,
+    "Field IDs must be unique",
+  );
+
+const Submitted = z.object({
+  status: z.literal("submitted"),
+  values: z.record(z.string(), z.union([z.string(), z.number()])),
+});
+type FormArgs = z.infer<typeof FormCardArgs>;
+type FormAnswer = z.infer<typeof Submitted>;
+type Respond = (
+  answer: FormAnswer | { status: "invalid"; message: string },
+) => Promise<void>;
+
+function isRespond(value: unknown): value is Respond {
+  return typeof value === "function";
+}
+function readAnswer(result: unknown): FormAnswer | null {
+  try {
+    const parsed = Submitted.safeParse(
+      typeof result === "string" ? JSON.parse(result) : result,
+    );
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Decision render props remain wrapped, just like askApproval and askChoice. */
+export function FormCard(props: Record<string, unknown>) {
+  const parsed = FormCardArgs.safeParse(props.args);
+  if (props.status === "inProgress") {
+    return (
+      <GalleryFrame title="Preparing your form…">
+        <p className="text-sm text-muted-foreground">
+          The assistant is putting the questions together.
+        </p>
+      </GalleryFrame>
+    );
+  }
+  if (!parsed.success) {
+    return (
+      <InvalidForm
+        complete={props.status === "complete"}
+        respond={isRespond(props.respond) ? props.respond : undefined}
+      />
+    );
+  }
+  return (
+    <FormEntry
+      args={parsed.data}
+      complete={props.status === "complete"}
+      result={readAnswer(props.result)}
+      respond={isRespond(props.respond) ? props.respond : undefined}
+    />
+  );
+}
+
+/** A malformed tool call must release the suspended run so the Bot can repair its questions. */
+function InvalidForm({
+  complete,
+  respond,
+}: {
+  complete: boolean;
+  respond?: Respond;
+}) {
+  const attempted = useRef(false);
+  const [failed, setFailed] = useState(false);
+  const [returned, setReturned] = useState(complete);
+  const returnToBot = useCallback(async () => {
+    if (!respond || attempted.current || complete) return;
+    attempted.current = true;
+    setFailed(false);
+    try {
+      await respond({
+        status: "invalid",
+        message:
+          "The form could not be displayed because its questions were invalid. Send a corrected form with unique field IDs, valid types, and options for each select field.",
+      });
+      setReturned(true);
+    } catch {
+      attempted.current = false;
+      setFailed(true);
+    }
+  }, [respond, complete]);
+  useEffect(() => {
+    void returnToBot();
+  }, [returnToBot]);
+  return (
+    <GalleryFrame title="Form unavailable">
+      <p role="alert" className="text-sm text-muted-foreground">
+        {returned
+          ? "The form had invalid questions. The Bot can send a corrected form."
+          : "The form has invalid questions and could not be displayed."}
+      </p>
+      {failed && (
+        <Button className="mt-3" size="sm" onClick={() => void returnToBot()}>
+          Return to the Bot
+        </Button>
+      )}
+    </GalleryFrame>
+  );
+}
+
+function FormEntry({
+  args,
+  complete,
+  result,
+  respond,
+}: {
+  args: FormArgs;
+  complete: boolean;
+  result: FormAnswer | null;
+  respond?: Respond;
+}) {
+  const prefix = useId();
+  const [values, setValues] = useState(new Map<string, string>());
+  const [errors, setErrors] = useState(new Map<string, string>());
+  const [failure, setFailure] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [submitted, setSubmitted] = useState<FormAnswer | null>(null);
+  const sendingRef = useRef(false);
+  const answer = result ?? submitted;
+  const finished = complete || answer !== null;
+
+  async function submit(form: HTMLFormElement) {
+    if (!respond || sendingRef.current || finished) return;
+    const problems = new Map<string, string>();
+    const entries: [string, string | number][] = [];
+    for (const field of args.fields) {
+      const control = form.elements.namedItem(field.id);
+      if (control instanceof HTMLInputElement && control.validity.badInput) {
+        problems.set(field.id, "Enter a valid number.");
+        continue;
+      }
+      const value = (values.get(field.id) ?? "").trim();
+      if (!value) {
+        if (field.required)
+          problems.set(field.id, `${field.label} is required.`);
+        continue;
+      }
+      if (value.length > 2000)
+        problems.set(field.id, "Use 2,000 characters or fewer.");
+      else if (field.type === "email" && !z.email().safeParse(value).success)
+        problems.set(field.id, "Enter a valid email address.");
+      else if (field.type === "select" && !field.options?.includes(value))
+        problems.set(field.id, "Choose one of the listed options.");
+      else if (field.type === "number") {
+        const number = Number(value);
+        if (!Number.isFinite(number))
+          problems.set(field.id, "Enter a valid number.");
+        else if (field.min !== undefined && number < field.min)
+          problems.set(field.id, `Enter ${field.min} or more.`);
+        else if (field.max !== undefined && number > field.max)
+          problems.set(field.id, `Enter ${field.max} or less.`);
+      }
+      entries.push([field.id, field.type === "number" ? Number(value) : value]);
+    }
+    setErrors(problems);
+    if (problems.size) {
+      const firstId = problems.keys().next().value;
+      const control = firstId ? form.elements.namedItem(firstId) : null;
+      if (control instanceof HTMLElement) control.focus();
+      return;
+    }
+    sendingRef.current = true;
+    setSending(true);
+    setFailure(false);
+    const response: FormAnswer = {
+      status: "submitted",
+      values: Object.fromEntries(entries),
+    };
+    try {
+      await respond(response);
+      setSubmitted(response);
+    } catch {
+      sendingRef.current = false;
+      setFailure(true);
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <GalleryFrame
+      title={args.title}
+      caption={args.description}
+      action={
+        <Badge tone={finished ? "positive" : "caution"}>
+          {finished ? "Submitted" : "Waiting on you"}
+        </Badge>
+      }
+    >
+      {finished ? (
+        <div role="status">
+          {answer ? (
+            <dl className="space-y-3">
+              {args.fields.map((field) => (
+                <div
+                  key={field.id}
+                  className="grid grid-cols-[minmax(0,1fr)_minmax(0,2fr)] gap-4 text-sm"
+                >
+                  <dt className="text-muted-foreground">{field.label}</dt>
+                  <dd className="whitespace-pre-wrap break-words font-medium">
+                    {Object.hasOwn(answer.values, field.id)
+                      ? answer.values[field.id]
+                      : "Not provided"}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              This form has been completed. Its saved answers are unavailable.
+            </p>
+          )}
+        </div>
+      ) : (
+        <form
+          noValidate
+          aria-label={args.title}
+          onSubmit={(event) => {
+            event.preventDefault();
+            void submit(event.currentTarget);
+          }}
+          className="space-y-4"
+        >
+          <p className="text-xs text-muted-foreground">
+            Fields marked * are required. Your answers will be shared with the
+            Bot.
+          </p>
+          {args.fields.map((field) => {
+            const id = `${prefix}-${field.id}`;
+            const error = errors.get(field.id);
+            const shared = {
+              id,
+              name: field.id,
+              required: field.required,
+              disabled: sending || !respond,
+              value: values.get(field.id) ?? "",
+              "aria-invalid": Boolean(error),
+              "aria-describedby":
+                [field.help ? `${id}-help` : "", error ? `${id}-error` : ""]
+                  .filter(Boolean)
+                  .join(" ") || undefined,
+            };
+            const change = (value: string) => {
+              setValues((current) => new Map(current).set(field.id, value));
+              setErrors((current) => {
+                const next = new Map(current);
+                next.delete(field.id);
+                return next;
+              });
+            };
+            return (
+              <div key={field.id} className="space-y-1.5">
+                <label htmlFor={id} className="block text-sm font-medium">
+                  {field.label}
+                  {field.required ? (
+                    <span
+                      aria-hidden="true"
+                      className="ml-1 text-muted-foreground"
+                    >
+                      *
+                    </span>
+                  ) : null}
+                </label>
+                {field.type === "textarea" ? (
+                  <Textarea
+                    {...shared}
+                    maxLength={2000}
+                    rows={3}
+                    onChange={(event) => change(event.target.value)}
+                  />
+                ) : field.type === "select" ? (
+                  <select
+                    {...shared}
+                    className="h-9 w-full rounded-lg border border-input bg-background px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50"
+                    onChange={(event) => change(event.target.value)}
+                  >
+                    <option value="">Choose an option</option>
+                    {field.options?.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <Input
+                    {...shared}
+                    type={field.type}
+                    min={field.min}
+                    max={field.max}
+                    step={field.type === "number" ? "any" : undefined}
+                    maxLength={2000}
+                    onChange={(event) => change(event.target.value)}
+                  />
+                )}
+                {field.help && (
+                  <p
+                    id={`${id}-help`}
+                    className="text-xs text-muted-foreground"
+                  >
+                    {field.help}
+                  </p>
+                )}
+                {error && (
+                  <p
+                    id={`${id}-error`}
+                    role="alert"
+                    className="text-xs text-destructive"
+                  >
+                    {error}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+          {failure && (
+            <p role="alert" className="text-sm text-destructive">
+              Your answers could not be sent. Try again.
+            </p>
+          )}
+          <div className="flex justify-end border-t border-border pt-3">
+            <Button type="submit" size="sm" disabled={sending || !respond}>
+              {sending ? "Sending…" : (args.submitLabel ?? "Submit answers")}
+            </Button>
+          </div>
+        </form>
+      )}
+    </GalleryFrame>
+  );
+}
+
+export const GALLERY: GalleryComponent[] = [
+  {
+    name: "askForm",
+    title: "Form",
+    kind: "decision",
+    description:
+      "Ask the person to fill in a short form and WAIT for their answers. Use when several related details are needed together. Provide up to eight labeled text, email, number, select, or textarea fields with unique IDs. Mark required fields and give options for selects. Never request passwords or secrets. The result has status submitted and values keyed by field ID; numbers are returned as numbers and blank optional fields are omitted.",
+    parameters: FormCardArgs,
+    Component: FormCard,
+    preview: {
+      status: "executing",
+      args: {
+        title: "Plan your next project",
+        description: "A few details to prepare a useful first draft.",
+        fields: [
+          { id: "team", label: "Team name", type: "text", required: true },
+          { id: "email", label: "Work email", type: "email", required: true },
+          {
+            id: "priority",
+            label: "Priority",
+            type: "select",
+            options: ["This week", "This month", "Exploring"],
+          },
+          { id: "seats", label: "People involved", type: "number", min: 1 },
+          {
+            id: "notes",
+            label: "What would a good outcome look like?",
+            type: "textarea",
+          },
+        ],
+        submitLabel: "Prepare my brief",
+      },
+      respond: async () => {},
+    },
+  },
+];

--- a/app/src/components/gallery/table.tsx
+++ b/app/src/components/gallery/table.tsx
@@ -1,0 +1,202 @@
+import { useState } from "react";
+import { z } from "zod";
+import type { GalleryComponent } from "@/lib/copilot/gallery-registry";
+import { Badge, GalleryFrame } from "./frame";
+
+export const DataTableProps = z
+  .object({
+    title: z.string().trim().min(1).max(120),
+    caption: z.string().max(500).optional(),
+    columns: z
+      .array(z.string().trim().min(1).max(80))
+      .min(1)
+      .max(8)
+      .describe("Unique column labels, in display order"),
+    rows: z
+      .array(
+        z.object({
+          cells: z
+            .array(z.union([z.string().max(2000), z.number()]))
+            .min(1)
+            .max(8),
+        }),
+      )
+      .max(100)
+      .describe(
+        "One cell per column. Use numbers for numeric sorting; strings for formatted values.",
+      ),
+  })
+  .refine(
+    (table) =>
+      new Set(table.columns).size === table.columns.length &&
+      table.rows.every((row) => row.cells.length === table.columns.length),
+    "Column labels must be unique and every row must have one cell per column",
+  );
+
+/** A real table: header buttons sort while the native row/column relationships stay intact. */
+export function DataTable(props: Record<string, unknown>) {
+  const [sort, setSort] = useState<{
+    column: number;
+    ascending: boolean;
+  } | null>(null);
+  const parsed = DataTableProps.safeParse(props);
+  if (!parsed.success) {
+    return (
+      <GalleryFrame title="Table">
+        <p className="text-sm text-muted-foreground">
+          Waiting for complete table data…
+        </p>
+      </GalleryFrame>
+    );
+  }
+  const { title, caption, columns, rows } = parsed.data;
+  const ordered = rows.map((row, position) => ({ ...row, position }));
+  if (sort) {
+    ordered.sort((left, right) => {
+      const a = left.cells[sort.column];
+      const b = right.cells[sort.column];
+      const order =
+        typeof a === "number" && typeof b === "number"
+          ? a - b
+          : String(a).localeCompare(String(b), undefined, { numeric: true });
+      return (
+        (sort.ascending ? order : -order) || left.position - right.position
+      );
+    });
+  }
+  return (
+    <GalleryFrame
+      title={title}
+      caption={caption}
+      action={
+        <Badge>
+          {rows.length} {rows.length === 1 ? "row" : "rows"}
+        </Badge>
+      }
+    >
+      <section
+        className="overflow-x-auto rounded-lg border border-border focus-visible:outline-2 focus-visible:outline-ring"
+        aria-label={`${title} table, scroll for more columns`}
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: Overflow regions need keyboard focus to scroll in Safari; the region has an accessible name.
+        tabIndex={0}
+      >
+        <table className="w-full border-collapse text-left text-sm">
+          <caption className="sr-only">
+            {title}. Select a column heading to sort.
+          </caption>
+          <thead className="bg-muted/50 text-xs text-muted-foreground">
+            <tr>
+              {columns.map((column, index) => (
+                <th
+                  key={column}
+                  scope="col"
+                  aria-sort={
+                    sort?.column === index
+                      ? sort.ascending
+                        ? "ascending"
+                        : "descending"
+                      : undefined
+                  }
+                  className="border-b border-border font-medium"
+                >
+                  <button
+                    type="button"
+                    className="flex w-full items-center justify-between gap-3 whitespace-nowrap px-3 py-2.5 text-left hover:bg-muted focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring"
+                    onClick={() =>
+                      setSort({
+                        column: index,
+                        ascending:
+                          sort?.column === index ? !sort.ascending : true,
+                      })
+                    }
+                  >
+                    {column}
+                    <span
+                      aria-hidden="true"
+                      className="text-muted-foreground/70"
+                    >
+                      {sort?.column === index
+                        ? sort.ascending
+                          ? "↑"
+                          : "↓"
+                        : "↕"}
+                    </span>
+                  </button>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {ordered.map((row) => (
+              <tr
+                key={row.position}
+                className="even:bg-muted/20 hover:bg-muted/40"
+              >
+                {columns.map((column, index) => (
+                  <td
+                    key={column}
+                    className={`min-w-24 max-w-xs break-words px-3 py-2.5 align-top ${typeof row.cells[index] === "number" ? "text-right tabular-nums" : ""}`}
+                  >
+                    {row.cells[index] === "" ? (
+                      <>
+                        <span
+                          className="text-muted-foreground"
+                          aria-hidden="true"
+                        >
+                          —
+                        </span>
+                        <span className="sr-only">Empty</span>
+                      </>
+                    ) : (
+                      row.cells[index]
+                    )}
+                  </td>
+                ))}
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td
+                  colSpan={columns.length}
+                  className="px-3 py-8 text-center text-muted-foreground"
+                >
+                  No rows to show.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </section>
+      {rows.length > 1 && (
+        <p className="mt-2 text-xs text-muted-foreground" aria-live="polite">
+          {sort
+            ? `Sorted by ${columns[sort.column]}, ${sort.ascending ? "ascending" : "descending"}.`
+            : "Select a column heading to sort."}
+        </p>
+      )}
+    </GalleryFrame>
+  );
+}
+
+export const GALLERY: GalleryComponent[] = [
+  {
+    name: "showTable",
+    title: "Data table",
+    kind: "card",
+    description:
+      "Show a sortable table to compare records, plans, or other structured facts. Supply up to eight columns and 100 rows, with exactly one cell per column. Use numbers for quantities so sorting is numeric. Show only data you have; do not invent rows.",
+    parameters: DataTableProps,
+    Component: DataTable,
+    confirmation: "The sortable table is now on screen for the person.",
+    preview: {
+      title: "Team capacity",
+      caption: "Three teams, one shared launch. Hours available this week.",
+      columns: ["Team", "Available hours", "Focus"],
+      rows: [
+        { cells: ["Product", 24, "Customer onboarding"] },
+        { cells: ["Engineering", 72, "Release readiness"] },
+        { cells: ["Design", 18, "Workspace polish"] },
+      ],
+    },
+  },
+];

--- a/app/src/lib/copilot/a2ui.css
+++ b/app/src/lib/copilot/a2ui.css
@@ -1,0 +1,63 @@
+/* biome-ignore-all lint/complexity/noImportantStyles: The SDK's primitive renderers use inline styles, so these narrowly scoped host-brand overrides need priority. */
+/* The public SDK catalog owns rendering and behavior; these hooks only match OpenBot's tokens.
+ * !important is scoped to our catalog because the shipped basic components use inline styles. */
+[data-openbot-a2ui] {
+  --a2ui-primary-color: var(--primary);
+  color: inherit;
+  font-family: var(--font-sans, Inter, ui-sans-serif, system-ui, sans-serif);
+  font-size: 0.9333rem;
+  line-height: 1.5;
+}
+
+[data-openbot-a2ui] > * {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+[data-openbot-a2ui="Card"] > div {
+  background: var(--card) !important;
+  color: var(--card-foreground);
+  border: 1px solid var(--border);
+  border-radius: var(--radius) !important;
+  box-shadow: none !important;
+  padding: 1rem !important;
+}
+
+[data-openbot-a2ui="Button"] > button {
+  background: var(--primary) !important;
+  color: var(--primary-foreground) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: var(--radius) !important;
+  font: inherit;
+  font-weight: 500;
+}
+
+[data-openbot-a2ui] :is(input, textarea, select) {
+  background: var(--background);
+  color: var(--foreground);
+  border-color: var(--input) !important;
+  border-radius: var(--radius) !important;
+  accent-color: var(--primary);
+  font: inherit;
+}
+
+[data-openbot-a2ui] :is(button, input, textarea, select):focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+[data-openbot-a2ui] :is(button, input, textarea, select):disabled {
+  cursor: not-allowed !important;
+  opacity: 0.5;
+}
+
+[data-openbot-a2ui="Divider"] > hr {
+  border-color: var(--border) !important;
+}
+
+[data-openbot-a2ui="Text"] :is(h1, h2, h3, h4, h5, h6) {
+  font-size: 1.067rem !important;
+  font-weight: 600 !important;
+  letter-spacing: -0.01em;
+}

--- a/app/src/lib/copilot/a2ui.tsx
+++ b/app/src/lib/copilot/a2ui.tsx
@@ -1,0 +1,41 @@
+import {
+  basicCatalog,
+  Catalog,
+  type ReactComponentImplementation,
+} from "@copilotkit/a2ui-renderer";
+import type { CopilotKitProviderProps } from "@copilotkit/react-core/v2";
+
+/**
+ * Keep the SDK's schemas, data bindings and action handlers. The wrapper only supplies a stable
+ * styling hook: the 1.70.1 basic catalog uses inline styles and does not consume the theme prop.
+ * These are declarative primitives, not the separately granted OpenBot gallery/custom components.
+ */
+function branded(
+  component: ReactComponentImplementation,
+): ReactComponentImplementation {
+  const Render = component.render;
+  return {
+    ...component,
+    render: (props) => (
+      <div data-openbot-a2ui={component.name} style={{ display: "contents" }}>
+        <Render {...props} />
+      </div>
+    ),
+  };
+}
+
+export const OPENBOT_A2UI_CATALOG = new Catalog(
+  basicCatalog.id,
+  Array.from(basicCatalog.components.values(), branded),
+  Array.from(basicCatalog.functions.values()),
+  basicCatalog.themeSchema,
+);
+
+const A2UI_OPTIONS = { catalog: OPENBOT_A2UI_CATALOG } satisfies NonNullable<
+  CopilotKitProviderProps["a2ui"]
+>;
+
+/** Prop presence activates the SDK, so an unresolved or disabled capability must omit it. */
+export function a2uiProviderOptions(enabled: boolean | undefined) {
+  return enabled ? { a2ui: A2UI_OPTIONS } : {};
+}

--- a/app/src/lib/copilot/provider.tsx
+++ b/app/src/lib/copilot/provider.tsx
@@ -2,6 +2,8 @@ import { CopilotKitProvider } from "@copilotkit/react-core/v2";
 import { useQuery } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { deploymentCapabilitiesQueryOptions } from "@/lib/deployment/queries";
+import { a2uiProviderOptions } from "./a2ui";
+import "./a2ui.css";
 import { ActiveBotProvider } from "./active-bot";
 import { BotTools } from "./bot-tools";
 import { ComputerTools } from "./computer-tools";
@@ -33,6 +35,7 @@ export function CopilotProvider({ children }: { children: ReactNode }) {
     <CopilotKitProvider
       runtimeUrl="/api/copilotkit"
       credentials="include"
+      {...a2uiProviderOptions(capabilities?.generativeUi)}
       /*
        * Passed only when this deployment actually has the capability, and this is the load-bearing
        * part rather than a tidiness. The SDK reads generative UI as on when EITHER the runtime says

--- a/app/src/routes/_authed/admin/components/$name.tsx
+++ b/app/src/routes/_authed/admin/components/$name.tsx
@@ -12,7 +12,7 @@ import {
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { type ReactNode, useState } from "react";
-import { ComponentPreview } from "@/components/component-preview";
+import { AdminComponentPreview } from "@/components/component-preview";
 import {
   PageRows,
   PageSection,
@@ -266,7 +266,8 @@ function ComponentDetail({
   const [draft, setDraft] = useState(component.draftDescription);
   const withheld = new Set(component.withheldFrom);
   const heldFunctions = new Set(component.functions);
-  const renderable = RENDERABLE_NAMES.has(component.name);
+  const renderable =
+    RENDERABLE_NAMES.has(component.name) || component.kind === "sandboxed";
 
   const granted = bots.filter((bot) => !withheld.has(bot.id));
   const held = dataFunctions.filter((fn) => heldFunctions.has(fn.name));
@@ -305,7 +306,7 @@ function ComponentDetail({
           <SettingsItemBackground className="h-full w-full" />
         </div>
         <div className="absolute inset-0 z-10">
-          <ComponentPreview name={component.name} />
+          <AdminComponentPreview kind={component.kind} name={component.name} />
         </div>
       </div>
 

--- a/app/src/routes/_authed/admin/components/index.tsx
+++ b/app/src/routes/_authed/admin/components/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { ComponentPreview } from "@/components/component-preview";
+import { AdminComponentPreview } from "@/components/component-preview";
 import { PageShell } from "@/components/layout/page-shell";
 import { SettingsItemBackground } from "@/components/settings/background";
 import {
@@ -90,7 +90,10 @@ function RouteComponent() {
                   <SettingsItemBackground className="h-full w-full rounded-md" />
                 </div>
                 <div className="absolute top-0 left-0 z-10 h-full w-full p-3">
-                  <ComponentPreview name={component.name} />
+                  <AdminComponentPreview
+                    kind={component.kind}
+                    name={component.name}
+                  />
                 </div>
               </div>
             </Link>

--- a/app/src/routes/_authed/admin/playground.tsx
+++ b/app/src/routes/_authed/admin/playground.tsx
@@ -12,7 +12,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Field, FieldLabel } from "@/components/ui/field";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -47,29 +47,90 @@ const STARTER = {
 
 type Draft = typeof STARTER;
 
+type JsonObjectResult =
+  | { ok: true; value: Record<string, unknown> }
+  | { ok: false; message: string };
+
+type PlaygroundValidation =
+  | { ok: true; input: SandboxedDraftInput }
+  | {
+      ok: false;
+      fields: { argumentSchema?: string; sampleArguments?: string };
+    };
+
+function jsonKind(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+export function parseJsonObject(raw: string, label: string): JsonObjectResult {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch (thrown) {
+    const reason =
+      thrown instanceof SyntaxError ? thrown.message : "invalid JSON";
+    return { ok: false, message: `${label} must be valid JSON: ${reason}` };
+  }
+
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {
+      ok: false,
+      message: `${label} must be a JSON object, not ${jsonKind(value)}.`,
+    };
+  }
+
+  return { ok: true, value: value as Record<string, unknown> };
+}
+
+export function validatePlaygroundDraft(draft: Draft): PlaygroundValidation {
+  const schema = parseJsonObject(
+    draft.argumentSchema,
+    "Arguments (JSON Schema)",
+  );
+  const sample = parseJsonObject(draft.sampleArguments, "Sample arguments");
+  if (!schema.ok || !sample.ok) {
+    return {
+      ok: false,
+      fields: {
+        ...(!schema.ok ? { argumentSchema: schema.message } : {}),
+        ...(!sample.ok ? { sampleArguments: sample.message } : {}),
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    input: {
+      slug: draft.slug,
+      title: draft.title,
+      description: draft.description,
+      html: draft.html,
+      css: draft.css,
+      jsFunctions: draft.jsFunctions,
+      argumentSchema: schema.value,
+      sampleArguments: sample.value,
+    },
+  };
+}
+
 function PlaygroundPage() {
   const [deleting, setDeleting] = useState<string | null>(null);
   const queryClient = useQueryClient();
   const { data: components } = useQuery(sandboxedListQueryOptions());
   const [draft, setDraft] = useState<Draft>(STARTER);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
 
-  const set = (field: keyof Draft) => (value: string) =>
+  const set = (field: keyof Draft) => (value: string) => {
+    setError(null);
+    setNotice(null);
     setDraft((current) => ({ ...current, [field]: value }));
-
-  const parsed = (raw: string): Record<string, unknown> | null => {
-    try {
-      const value = JSON.parse(raw);
-      return typeof value === "object" && value !== null
-        ? (value as Record<string, unknown>)
-        : null;
-    } catch {
-      return null;
-    }
   };
 
-  const sample = parsed(draft.sampleArguments);
-  const schema = parsed(draft.argumentSchema);
+  const validation = validatePlaygroundDraft(draft);
+  const sample = validation.ok ? validation.input.sampleArguments : null;
 
   /* Every write here reports into the same banner, so they share one failure handler. */
   const report = { onError: (thrown: Error) => setError(thrown.message) };
@@ -85,26 +146,37 @@ function PlaygroundPage() {
     ...deleteSandboxedMutationOptions(queryClient),
     ...report,
   });
-  /** What the editors currently describe, in the shape the server accepts. */
-  const input = (): SandboxedDraftInput => ({
-    slug: draft.slug,
-    title: draft.title,
-    description: draft.description,
-    html: draft.html,
-    css: draft.css,
-    jsFunctions: draft.jsFunctions,
-    argumentSchema: schema ?? {},
-    sampleArguments: sample ?? {},
-  });
+  const busy =
+    saveDraft.isPending || publishDraft.isPending || removeComponent.isPending;
+  const canWrite = Boolean(draft.slug && draft.title) && validation.ok && !busy;
+
+  const input = (): SandboxedDraftInput | null => {
+    const current = validatePlaygroundDraft(draft);
+    if (!current.ok) {
+      setNotice(null);
+      setError(
+        Object.values(current.fields)[0] ??
+          "Fix the JSON fields before saving.",
+      );
+      return null;
+    }
+    return current.input;
+  };
 
   const save = () => {
     setError(null);
-    saveDraft.mutate(input());
+    setNotice(null);
+    const payload = input();
+    if (!payload) return;
+    saveDraft.mutate(payload, { onSuccess: () => setNotice("Draft saved.") });
   };
 
   const publish = () => {
     setError(null);
-    publishDraft.mutate(input());
+    setNotice(null);
+    const payload = input();
+    if (!payload) return;
+    publishDraft.mutate(payload, { onSuccess: () => setNotice("Published.") });
   };
 
   const load = (component: SandboxedRecord) =>
@@ -143,7 +215,7 @@ function PlaygroundPage() {
         </div>
         <div className="flex gap-2">
           <Button
-            disabled={!(draft.slug && draft.title)}
+            disabled={!canWrite}
             onClick={save}
             size="sm"
             type="button"
@@ -153,7 +225,7 @@ function PlaygroundPage() {
           </Button>
           <Button
             /* `publish` saves first, since publishing acts on the stored draft, not the editors. */
-            disabled={!(draft.slug && draft.title)}
+            disabled={!canWrite}
             onClick={publish}
             size="sm"
             type="button"
@@ -169,6 +241,14 @@ function PlaygroundPage() {
           role="alert"
         >
           {error}
+        </div>
+      ) : null}
+      {notice ? (
+        <div
+          className="border-border border-b bg-emerald-50 px-6 py-2 text-emerald-700 text-sm"
+          role="status"
+        >
+          {notice}
         </div>
       ) : null}
 
@@ -202,13 +282,17 @@ function PlaygroundPage() {
             value={draft.jsFunctions}
           />
           <CodeField
-            invalid={schema === null}
+            error={
+              !validation.ok ? validation.fields.argumentSchema : undefined
+            }
             label="Arguments (JSON Schema)"
             onChange={set("argumentSchema")}
             value={draft.argumentSchema}
           />
           <CodeField
-            invalid={sample === null}
+            error={
+              !validation.ok ? validation.fields.sampleArguments : undefined
+            }
             label="Sample arguments"
             onChange={set("sampleArguments")}
             value={draft.sampleArguments}
@@ -220,8 +304,10 @@ function PlaygroundPage() {
             <div className="mb-2 text-sm font-medium">Preview</div>
             {sample === null ? (
               <p className="text-sm text-destructive">
-                The sample arguments are not valid JSON, so there is nothing to
-                draw with.
+                {validation.ok
+                  ? "The sample arguments are not available."
+                  : (validation.fields.sampleArguments ??
+                    "Fix the JSON fields before previewing.")}
               </p>
             ) : (
               <OpenGenerativeUIActivityRenderer
@@ -377,30 +463,31 @@ function CodeField({
   label,
   value,
   onChange,
-  invalid,
+  error,
 }: {
   label: string;
   value: string;
   onChange: (value: string) => void;
-  invalid?: boolean;
+  error?: string;
 }) {
   const id = useId();
   return (
-    <Field data-invalid={invalid}>
-      <FieldLabel htmlFor={id}>
-        {label}
-        {invalid ? (
-          <span className="ml-2 text-destructive">not valid JSON</span>
-        ) : null}
-      </FieldLabel>
+    <Field data-invalid={Boolean(error)}>
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
       <Textarea
-        aria-invalid={invalid}
+        aria-describedby={error ? `${id}-error` : undefined}
+        aria-invalid={Boolean(error)}
         className="h-32 font-mono text-xs"
         id={id}
         onChange={(event) => onChange(event.target.value)}
         spellCheck={false}
         value={value}
       />
+      {error ? (
+        <FieldDescription className="text-destructive" id={`${id}-error`}>
+          {error}
+        </FieldDescription>
+      ) : null}
     </Field>
   );
 }

--- a/app/src/routes/_authed/settings/components-gallery/$name.tsx
+++ b/app/src/routes/_authed/settings/components-gallery/$name.tsx
@@ -130,7 +130,7 @@ function RouteComponent() {
           <SettingsItemBackground className="h-full w-full" />
         </div>
         <div className="absolute inset-0 z-10">
-          <ComponentPreview name={component.name} />
+          <ComponentPreview kind={component.kind} name={component.name} />
         </div>
       </div>
 

--- a/app/src/routes/_authed/settings/components-gallery/index.tsx
+++ b/app/src/routes/_authed/settings/components-gallery/index.tsx
@@ -72,7 +72,10 @@ function RouteComponent() {
                   <SettingsItemBackground className="h-full w-full rounded-md" />
                 </div>
                 <div className="absolute top-0 left-0 z-10 h-full w-full p-3">
-                  <ComponentPreview name={component.name} />
+                  <ComponentPreview
+                    kind={component.kind}
+                    name={component.name}
+                  />
                 </div>
               </div>
             </Link>

--- a/app/tests/a2ui.test.tsx
+++ b/app/tests/a2ui.test.tsx
@@ -1,0 +1,120 @@
+import { afterAll, afterEach, beforeAll, expect, test } from "bun:test";
+import {
+  type A2UIClientEventMessage,
+  A2UIProvider,
+  A2UIRenderer,
+  type ServerToClientMessage,
+  useA2UIActions,
+} from "@copilotkit/a2ui-renderer";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
+import { a2uiProviderOptions, OPENBOT_A2UI_CATALOG } from "@/lib/copilot/a2ui";
+
+beforeAll(() => GlobalRegistrator.register());
+afterEach(cleanup);
+afterAll(() => GlobalRegistrator.unregister());
+
+const operations: ServerToClientMessage[] = [
+  {
+    version: "v0.9",
+    createSurface: { surfaceId: "trip", catalogId: OPENBOT_A2UI_CATALOG.id },
+  },
+  {
+    version: "v0.9",
+    updateComponents: {
+      surfaceId: "trip",
+      components: [
+        { id: "root", component: "Card", child: "fields" },
+        {
+          id: "fields",
+          component: "Column",
+          children: ["title", "destination", "confirm"],
+        },
+        {
+          id: "title",
+          component: "Text",
+          text: "Trip preferences",
+          variant: "h3",
+        },
+        {
+          id: "destination",
+          component: "TextField",
+          label: "Destination",
+          value: { path: "/destination" },
+        },
+        {
+          id: "confirm",
+          component: "Button",
+          variant: "primary",
+          child: "confirm-label",
+          action: {
+            event: {
+              name: "confirm_trip",
+              context: { destination: { path: "/destination" } },
+            },
+          },
+        },
+        { id: "confirm-label", component: "Text", text: "Confirm" },
+      ],
+    },
+  },
+  {
+    version: "v0.9",
+    updateDataModel: {
+      surfaceId: "trip",
+      path: "/",
+      value: { destination: "Paris" },
+    },
+  },
+];
+
+function TripSurface() {
+  const { processMessages } = useA2UIActions();
+  useEffect(() => {
+    processMessages(operations);
+  }, [processMessages]);
+  return <A2UIRenderer surfaceId="trip" />;
+}
+
+test("the public catalog renders a generated form and its action resolves the edited data", async () => {
+  const user = userEvent.setup({ document });
+  const actions: A2UIClientEventMessage[] = [];
+  const view = render(
+    <A2UIProvider
+      catalog={OPENBOT_A2UI_CATALOG}
+      onAction={(action) => {
+        actions.push(action);
+      }}
+    >
+      <TripSurface />
+    </A2UIProvider>,
+  );
+  expect(await view.findByText("Trip preferences")).toBeTruthy();
+  const field = view.getByRole("textbox", { name: "Destination" });
+  expect(field.getAttribute("value")).toBe("Paris");
+  await user.clear(field);
+  await user.type(field, "Kyoto");
+  await user.click(view.getByRole("button", { name: "Confirm" }));
+  await waitFor(() => expect(actions).toHaveLength(1));
+  expect(actions[0]).toMatchObject({
+    userAction: {
+      name: "confirm_trip",
+      surfaceId: "trip",
+      context: { destination: "Kyoto" },
+    },
+  });
+  expect(
+    view.container.querySelector('[data-openbot-a2ui="Card"]'),
+  ).toBeTruthy();
+});
+
+test("disabled and unresolved deployments do not activate or advertise the A2UI catalog", () => {
+  expect(a2uiProviderOptions(false)).toEqual({});
+  expect(a2uiProviderOptions(undefined)).toEqual({});
+  expect(a2uiProviderOptions(true).a2ui?.catalog).toBe(OPENBOT_A2UI_CATALOG);
+  // Existing OpenBot gallery components retain their separate per-Bot tool/grant path.
+  expect(OPENBOT_A2UI_CATALOG.components.has("showTable")).toBe(false);
+  expect(OPENBOT_A2UI_CATALOG.components.has("askForm")).toBe(false);
+});

--- a/app/tests/channel-history-refresh.test.tsx
+++ b/app/tests/channel-history-refresh.test.tsx
@@ -18,6 +18,7 @@ import {
   channelKeys,
 } from "@/lib/channels/queries";
 import { applyChannelEvent } from "@/lib/channels/use-channel-events";
+import { a2uiProviderOptions, OPENBOT_A2UI_CATALOG } from "@/lib/copilot/a2ui";
 import { queryClient } from "@/query-client";
 
 type ChannelCache = InfiniteData<ChannelPage>;
@@ -156,10 +157,13 @@ afterAll(() => {
   GlobalRegistrator.unregister();
 });
 
-function tree(selected: AgentChannel) {
+function tree(selected: AgentChannel, a2uiEnabled = false) {
   return (
     <QueryClientProvider client={queryClient}>
-      <CopilotKitProvider runtimeUrl="http://localhost/api/copilotkit">
+      <CopilotKitProvider
+        runtimeUrl="http://localhost/api/copilotkit"
+        {...a2uiProviderOptions(a2uiEnabled)}
+      >
         <CoreProbe />
         <ChannelChat channel={selected} runtimeAgentId="refresh-bot" />
       </CopilotKitProvider>
@@ -194,6 +198,7 @@ function mounting(
   read: typeof history = async () => stored([initial]),
   snapshot: readonly Message[] = [],
   cachedActivity: ActivityFixture | null = null,
+  a2uiEnabled = false,
 ) {
   historyReads = [];
   gatewaySnapshot = snapshot;
@@ -205,13 +210,93 @@ function mounting(
   ];
   history = read;
   cacheChannel(channel, cachedActivity);
-  return render(tree(channel));
+  return render(tree(channel, a2uiEnabled));
 }
 async function mounted() {
   const view = mounting();
   await view.findByText("Stored opening");
   return view;
 }
+
+test("A2UI activity actions run the actual channel agent and thread with edited values", async () => {
+  const activity = {
+    id: "channel-trip-form",
+    role: "activity",
+    activityType: "a2ui-surface",
+    content: {
+      a2ui_operations: [
+        {
+          version: "v0.9",
+          createSurface: {
+            surfaceId: "trip",
+            catalogId: OPENBOT_A2UI_CATALOG.id,
+          },
+        },
+        {
+          version: "v0.9",
+          updateComponents: {
+            surfaceId: "trip",
+            components: [
+              {
+                id: "root",
+                component: "Column",
+                children: ["destination", "confirm"],
+              },
+              {
+                id: "destination",
+                component: "TextField",
+                label: "Destination",
+                value: { path: "/destination" },
+              },
+              {
+                id: "confirm",
+                component: "Button",
+                child: "confirm-label",
+                action: {
+                  event: {
+                    name: "confirm_trip",
+                    context: { destination: { path: "/destination" } },
+                  },
+                },
+              },
+              { id: "confirm-label", component: "Text", text: "Confirm trip" },
+            ],
+          },
+        },
+        {
+          version: "v0.9",
+          updateDataModel: {
+            surfaceId: "trip",
+            path: "/",
+            value: { destination: "Paris" },
+          },
+        },
+      ],
+    },
+  } satisfies Message;
+  const view = mounting(async () => stored([activity]), [activity], null, true);
+  const user = userEvent.setup({ document: view.container.ownerDocument });
+  const destination = await view.findByRole("textbox", { name: "Destination" });
+  await user.clear(destination);
+  await user.type(destination, "Kyoto");
+  await user.click(view.getByRole("button", { name: "Confirm trip" }));
+  await waitFor(() => expect(runRequests).toHaveLength(1));
+  expect(runRequests[0]?.path).toBe("/api/copilotkit/agent/refresh-bot/run");
+  expect(runRequests[0]?.input.threadId).toBe(channel.threadId);
+  expect(runRequests[0]?.input.forwardedProps).toMatchObject({
+    a2uiAction: {
+      userAction: {
+        name: "confirm_trip",
+        surfaceId: "trip",
+        sourceComponentId: "confirm",
+        context: { destination: "Kyoto" },
+      },
+    },
+  });
+  await waitFor(() =>
+    expect(core?.properties).not.toHaveProperty("a2uiAction"),
+  );
+});
 function currentAgent(selected = channel) {
   const agent = core?.getAgent(`channel:${selected.id}`);
   if (!agent) throw new Error("Mounted channel agent is not registered");

--- a/app/tests/component-preview.test.tsx
+++ b/app/tests/component-preview.test.tsx
@@ -1,0 +1,161 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
+import * as ReactCoreV2 from "@copilotkit/react-core/v2";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render } from "@testing-library/react";
+import {
+  AdminComponentPreview,
+  ComponentPreview,
+} from "@/components/component-preview";
+import { GALLERY as TABLES } from "@/components/gallery/table";
+import * as gallery from "@/lib/copilot/gallery-registry";
+import type { SandboxedRecord } from "@/lib/sandboxed/queries";
+import { settleReactWork } from "./settle-react-work";
+
+beforeAll(() => {
+  GlobalRegistrator.register({ url: "http://localhost/" });
+  fetcher = createFetchSpy();
+});
+afterEach(cleanup);
+afterAll(async () => {
+  renderer.mockRestore();
+  fetcher.mockRestore();
+  compiled.mockRestore();
+  await settleReactWork();
+  GlobalRegistrator.unregister();
+});
+
+// The SDK owns iframe execution; this test checks which source reaches that boundary.
+const renderer = spyOn(ReactCoreV2, "OpenGenerativeUIActivityRenderer");
+function createFetchSpy() {
+  return spyOn(globalThis, "fetch");
+}
+let fetcher: ReturnType<typeof createFetchSpy>;
+const compiled = spyOn(gallery, "galleryComponent");
+beforeEach(() => {
+  renderer.mockClear();
+  renderer.mockImplementation(() => <div data-testid="sandbox-renderer" />);
+  fetcher.mockClear();
+  fetcher.mockResolvedValue(Response.json({ components: [PUBLISHED] }));
+  compiled.mockReturnValue(undefined);
+});
+
+const PUBLISHED: SandboxedRecord = {
+  name: "custom_preview_test",
+  title: "Preview test",
+  draftDescription: "An administrator-authored component",
+  draftHtml: "<p>Do not run this draft</p>",
+  draftCss: ".draft-only {}",
+  draftJsFunctions: 'throw new Error("Draft must not execute")',
+  draftArgumentSchema: {},
+  publishedHtml: '<p id="title">Published</p>',
+  publishedCss: "p { color: blue; }",
+  publishedJsFunctions:
+    'document.getElementById("title").textContent = window.__args.title;',
+  publishedArgumentSchema: {
+    type: "object",
+    properties: { title: { type: "string" } },
+  },
+  sampleArguments: { title: "Sample title" },
+  revision: 2,
+  published: true,
+  publishedAt: "2026-09-12T00:00:00Z",
+  authoredBy: null,
+  hasUnpublishedChanges: true,
+};
+
+test("admin previews asynchronously loaded published source with saved samples in the SDK sandbox", async () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const observe = spyOn(ResizeObserver.prototype, "observe");
+  try {
+    const view = render(
+      <QueryClientProvider client={queryClient}>
+        <AdminComponentPreview kind="sandboxed" name={PUBLISHED.name} />
+      </QueryClientProvider>,
+    );
+    expect(view.queryByTestId("sandbox-renderer")).toBeNull();
+    const sandbox = await view.findByTestId("sandbox-renderer");
+    expect(fetcher.mock.calls[0]?.[0]).toBe("/api/sandboxed");
+    expect(renderer.mock.calls.at(-1)?.[0]).toMatchObject({
+      activityType: "open-generative-ui",
+      agent: null,
+      message: null,
+      content: {
+        html: [PUBLISHED.publishedHtml],
+        css: PUBLISHED.publishedCss,
+        jsFunctions: `window.__args = {"title":"Sample title"};\n${PUBLISHED.publishedJsFunctions}`,
+        generating: false,
+      },
+    });
+    expect(sandbox.closest("[inert]")?.getAttribute("aria-hidden")).toBe(
+      "true",
+    );
+    // The sizing observer must mount after the source arrives, even though the first render was empty.
+    expect(observe.mock.calls).toHaveLength(2);
+    expect(view.queryByText("This build cannot draw this.")).toBeNull();
+  } finally {
+    observe.mockRestore();
+    queryClient.clear();
+  }
+});
+
+test("unpublished or never-published source does not reach the renderer", () => {
+  const view = render(
+    <ComponentPreview
+      kind="sandboxed"
+      name={PUBLISHED.name}
+      sandboxed={{ ...PUBLISHED, published: false }}
+    />,
+  );
+  expect(
+    view.getByText("Publish in the playground to see a preview."),
+  ).toBeTruthy();
+  view.rerender(
+    <ComponentPreview
+      kind="sandboxed"
+      name={PUBLISHED.name}
+      sandboxed={{ ...PUBLISHED, publishedHtml: null }}
+    />,
+  );
+  expect(renderer).not.toHaveBeenCalled();
+});
+
+test("read-only galleries identify playground components without fetching administrator drafts", () => {
+  const view = render(
+    <ComponentPreview kind="sandboxed" name={PUBLISHED.name} />,
+  );
+  expect(view.getByText("Published in the playground.")).toBeTruthy();
+  expect(view.queryByText("This build cannot draw this.")).toBeNull();
+  expect(fetcher).not.toHaveBeenCalled();
+  expect(renderer).not.toHaveBeenCalled();
+});
+
+test("compiled previews retain their real component and do not fetch sandboxed source", () => {
+  compiled.mockReturnValue(TABLES[0]);
+  const queryClient = new QueryClient();
+  try {
+    const view = render(
+      <QueryClientProvider client={queryClient}>
+        <AdminComponentPreview kind="card" name="showTable" />
+      </QueryClientProvider>,
+    );
+    expect(view.getByText("Team capacity")).toBeTruthy();
+    expect(
+      view.container.querySelector("table")?.closest("[inert]"),
+    ).toBeTruthy();
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(renderer).not.toHaveBeenCalled();
+  } finally {
+    queryClient.clear();
+  }
+});

--- a/app/tests/gallery-components.test.tsx
+++ b/app/tests/gallery-components.test.tsx
@@ -1,0 +1,284 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  test,
+} from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  GALLERY as FORMS,
+  FormCard,
+  FormCardArgs,
+} from "@/components/gallery/form";
+import {
+  DataTable,
+  DataTableProps,
+  GALLERY as TABLES,
+} from "@/components/gallery/table";
+import { settleReactWork } from "./settle-react-work";
+
+beforeAll(() => GlobalRegistrator.register({ url: "http://localhost/" }));
+let user: ReturnType<typeof userEvent.setup>;
+beforeEach(() => {
+  user = userEvent.setup({ document });
+});
+afterEach(cleanup);
+afterAll(async () => {
+  await settleReactWork();
+  GlobalRegistrator.unregister();
+});
+const TABLE = {
+  title: "Team capacity",
+  columns: ["Team", "Hours"],
+  rows: [
+    { cells: ["Design", 18] },
+    { cells: ["Product", 4] },
+    { cells: ["Engineering", 72] },
+  ],
+};
+const FORM = {
+  title: "Project brief",
+  fields: [
+    { id: "team", label: "Team", type: "text", required: true },
+    { id: "email", label: "Work email", type: "email", required: true },
+    {
+      id: "seats",
+      label: "Seats",
+      type: "number",
+      min: 1,
+      max: 20,
+      required: true,
+    },
+    {
+      id: "priority",
+      label: "Priority",
+      type: "select",
+      options: ["This week", "This month"],
+      required: true,
+    },
+    { id: "notes", label: "Notes", type: "textarea" },
+  ],
+};
+async function fillForm(view: ReturnType<typeof render>) {
+  await user.type(view.getByRole("textbox", { name: "Team" }), "  Design  ");
+  await user.type(
+    view.getByRole("textbox", { name: "Work email" }),
+    "designer@example.test",
+  );
+  await user.type(view.getByRole("spinbutton", { name: "Seats" }), "3");
+  await user.selectOptions(
+    view.getByRole("combobox", { name: "Priority" }),
+    "This month",
+  );
+}
+test("table sorts numeric cells in both directions with accessible headers", async () => {
+  const view = render(<DataTable {...TABLE} />);
+  const order = () =>
+    view
+      .getAllByRole("row")
+      .slice(1)
+      .map((row) => within(row).getAllByRole("cell")[0].textContent);
+  expect(order()).toEqual(["Design", "Product", "Engineering"]);
+  const header = view.getByRole("columnheader", { name: "Hours" });
+  await user.click(view.getByRole("button", { name: "Hours" }));
+  expect(order()).toEqual(["Product", "Design", "Engineering"]);
+  expect(header.getAttribute("aria-sort")).toBe("ascending");
+  await user.keyboard("{Enter}");
+  expect(order()).toEqual(["Engineering", "Design", "Product"]);
+  expect(header.getAttribute("aria-sort")).toBe("descending");
+  expect(view.getByRole("region").getAttribute("tabindex")).toBe("0");
+});
+test("empty tables stay explicit and mismatched cells are refused", () => {
+  const view = render(<DataTable {...TABLE} rows={[]} />);
+  expect(view.getByText("No rows to show.")).toBeTruthy();
+  expect(view.getAllByRole("columnheader")).toHaveLength(2);
+  expect(
+    DataTableProps.safeParse({ ...TABLE, rows: [{ cells: ["Only one"] }] })
+      .success,
+  ).toBe(false);
+  view.rerender(<DataTable {...TABLE} rows={[{ cells: ["Only one"] }]} />);
+  expect(view.queryByRole("table")).toBeNull();
+  expect(
+    DataTableProps.safeParse({ ...TABLE, columns: ["Same", "Same"] }).success,
+  ).toBe(false);
+});
+test("required and typed fields keep the form pending until corrected", async () => {
+  const answers: unknown[] = [];
+  const view = render(
+    <FormCard
+      status="executing"
+      args={FORM}
+      respond={async (answer: unknown) => {
+        answers.push(answer);
+      }}
+    />,
+  );
+  await user.click(view.getByRole("button", { name: "Submit answers" }));
+  expect(view.getAllByRole("alert")).toHaveLength(4);
+  expect(document.activeElement).toBe(
+    view.getByRole("textbox", { name: "Team" }),
+  );
+  expect(
+    view.getByRole("textbox", { name: "Team" }).getAttribute("aria-invalid"),
+  ).toBe("true");
+  await fillForm(view);
+  await user.clear(view.getByRole("textbox", { name: "Work email" }));
+  await user.type(view.getByRole("textbox", { name: "Work email" }), "invalid");
+  await user.clear(view.getByRole("spinbutton", { name: "Seats" }));
+  await user.type(view.getByRole("spinbutton", { name: "Seats" }), "21");
+  await user.click(view.getByRole("button", { name: "Submit answers" }));
+  expect(view.getByText("Enter a valid email address.")).toBeTruthy();
+  expect(view.getByText("Enter 20 or less.")).toBeTruthy();
+  expect(answers).toEqual([]);
+  await user.clear(view.getByRole("textbox", { name: "Work email" }));
+  await user.type(
+    view.getByRole("textbox", { name: "Work email" }),
+    "designer@example.test",
+  );
+  await user.clear(view.getByRole("spinbutton", { name: "Seats" }));
+  await user.type(view.getByRole("spinbutton", { name: "Seats" }), "3");
+  await user.click(view.getByRole("button", { name: "Submit answers" }));
+  await waitFor(() => expect(view.getByText("Submitted")).toBeTruthy());
+  expect(answers).toEqual([
+    {
+      status: "submitted",
+      values: {
+        team: "Design",
+        email: "designer@example.test",
+        seats: 3,
+        priority: "This month",
+      },
+    },
+  ]);
+  expect(view.queryByRole("form")).toBeNull();
+  expect(view.getByText("Not provided")).toBeTruthy();
+});
+test("a failed answer preserves values and retries without duplicate submissions", async () => {
+  let attempts = 0;
+  let release: (() => void) | undefined;
+  const view = render(
+    <FormCard
+      status="executing"
+      args={FORM}
+      respond={async () => {
+        attempts++;
+        if (attempts === 1) throw new Error("synthetic transport failure");
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+      }}
+    />,
+  );
+  await fillForm(view);
+  await user.click(view.getByRole("button", { name: "Submit answers" }));
+  await waitFor(() =>
+    expect(view.getByRole("alert").textContent).toContain("could not be sent"),
+  );
+  const team = view.getByRole("textbox", { name: "Team" });
+  expect(team instanceof HTMLInputElement).toBe(true);
+  if (team instanceof HTMLInputElement) expect(team.value).toBe("  Design  ");
+  await user.click(view.getByRole("button", { name: "Submit answers" }));
+  fireEvent.submit(view.getByRole("form"));
+  expect(attempts).toBe(2);
+  expect(
+    view.getByRole("button", { name: "Sending…" }).hasAttribute("disabled"),
+  ).toBe(true);
+  await act(async () => {
+    release?.();
+  });
+  await waitFor(() => expect(view.getByText("Submitted")).toBeTruthy());
+  expect(view.queryByRole("button")).toBeNull();
+});
+test("completed SDK results show saved values and never offer another submission", () => {
+  const view = render(
+    <FormCard
+      status="complete"
+      args={FORM}
+      result={JSON.stringify({
+        status: "submitted",
+        values: {
+          team: "Saved team",
+          email: "saved@example.test",
+          seats: 7,
+          priority: "This week",
+          notes: "First line\nSecond line",
+        },
+      })}
+    />,
+  );
+  expect(view.getByText("Saved team")).toBeTruthy();
+  expect(view.getByText("7")).toBeTruthy();
+  expect(view.queryByRole("textbox")).toBeNull();
+  expect(view.queryByRole("button")).toBeNull();
+  view.rerender(
+    <FormCard status="complete" args={FORM} result="unreadable result" />,
+  );
+  expect(view.getByText(/saved answers are unavailable/)).toBeTruthy();
+  expect(view.queryByRole("button")).toBeNull();
+});
+test("streaming or malformed form specifications expose no active fields", () => {
+  const view = render(
+    <FormCard status="inProgress" args={{ title: "Incoming" }} />,
+  );
+  expect(view.queryByRole("textbox")).toBeNull();
+  expect(
+    FormCardArgs.safeParse({
+      title: "Bad",
+      fields: [{ id: "team", label: "Team", type: "select" }],
+    }).success,
+  ).toBe(false);
+  expect(
+    FormCardArgs.safeParse({
+      ...FORM,
+      fields: [FORM.fields[0], FORM.fields[0]],
+    }).success,
+  ).toBe(false);
+  view.rerender(<FormCard status="executing" args={FORM} />);
+  expect(
+    view
+      .getByRole("button", { name: "Submit answers" })
+      .hasAttribute("disabled"),
+  ).toBe(true);
+});
+test("gallery exports have valid previews and existing card/decision kinds", () => {
+  expect(TABLES[0].name).toBe("showTable");
+  expect(TABLES[0].kind).toBe("card");
+  expect(DataTableProps.safeParse(TABLES[0].preview).success).toBe(true);
+  expect(FORMS[0].name).toBe("askForm");
+  expect(FORMS[0].kind).toBe("decision");
+  expect(FormCardArgs.safeParse(FORMS[0].preview?.args).success).toBe(true);
+});
+
+test("invalid form arguments release the suspended run once so the Bot can repair them", async () => {
+  const answers: unknown[] = [];
+  const card = (
+    <FormCard
+      status="executing"
+      args={{ title: "Bad form", fields: [] }}
+      respond={async (answer: unknown) => {
+        answers.push(answer);
+      }}
+    />
+  );
+  const view = render(card);
+  await waitFor(() => expect(answers).toHaveLength(1));
+  expect(answers[0]).toEqual({
+    status: "invalid",
+    message:
+      "The form could not be displayed because its questions were invalid. Send a corrected form with unique field IDs, valid types, and options for each select field.",
+  });
+  expect(view.queryByRole("form")).toBeNull();
+  view.rerender(card);
+  expect(answers).toHaveLength(1);
+});

--- a/app/tests/playground-json.test.ts
+++ b/app/tests/playground-json.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseJsonObject,
+  validatePlaygroundDraft,
+} from "../src/routes/_authed/admin/playground";
+
+const draft = {
+  slug: "s8_visual_check",
+  title: "S8 visual check",
+  description: "A draft with explicit JSON editor state.",
+  html: "<div></div>",
+  css: "",
+  jsFunctions: "",
+  argumentSchema: '{ "type": "object" }',
+  sampleArguments: '{ "title": "Saved exactly" }',
+};
+
+describe("playground JSON editors", () => {
+  test("reject malformed JSON instead of producing an empty object payload", () => {
+    const result = validatePlaygroundDraft({ ...draft, sampleArguments: "{" });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.fields.sampleArguments).toContain(
+        "Sample arguments must be valid JSON",
+      );
+    }
+  });
+
+  test.each(["[]", "null", '"text"'])(
+    "rejects %p because the editors must contain objects",
+    (raw) => {
+      const result = parseJsonObject(raw, "Sample arguments");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toContain("must be a JSON object");
+      }
+    },
+  );
+
+  test("preserves typed object JSON in the save payload", () => {
+    const result = validatePlaygroundDraft(draft);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.input.argumentSchema).toEqual({ type: "object" });
+      expect(result.input.sampleArguments).toEqual({ title: "Saved exactly" });
+    }
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@ag-ui/core": "0.0.59",
         "@base-ui/react": "^1.6.0",
         "@better-auth/sso": "^1.7.1",
+        "@copilotkit/a2ui-renderer": "1.70.1",
         "@copilotkit/react-core": "1.70.1",
         "@fontsource-variable/inter": "^5.3.0",
         "@shadcn/react": "^0.3.0",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,36 +58,23 @@ at `agent-langgraph` on a laptop.
 | `APP_DIST_DIR`       | unset                              | Where the built app is, when this process serves it. Set inside the container image; unset in development, where Vite serves the app. |
 | `AUDIT_RETENTION_DAYS` | unset                            | Whole number of days to keep audit rows; older ones are removed. Unset keeps the trail forever. |
 | `WORKER_SHARED_SECRET` | unset; `start.sh` uses a fixed local default | The secret the routines worker presents to fire a due routine. Without it the server refuses every handoff, whether or not a worker exists to send one. |
-| `OPENBOT_GENERATIVE_UI` | unset (capability off)              | `true` or `1` lets a Bot answer with an interface it wrote itself. |
+| `OPENBOT_GENERATIVE_UI` | unset (capability on)               | Set `false` or `0` to stop Bots from answering with generated interfaces. |
 
-**`OPENBOT_GENERATIVE_UI`** turns on generated interfaces. Set it, and a Bot may answer by writing
-the markup, styles and script for an interface and streaming it into the transcript, where it renders
-in a sandboxed iframe. Left unset, a Bot answers in prose and with the components this deployment
-holds, as before.
+**`OPENBOT_GENERATIVE_UI`** enables generated interfaces by default: streamed HTML/CSS/JavaScript
+in a sandboxed iframe, and A2UI interfaces built from the SDK's declarative components. A2UI buttons
+send their named action and selected values back to the current conversation's Bot.
+Set `OPENBOT_GENERATIVE_UI=false` or `0` to disable both. `true`, `1`, an empty value, or an unset
+value leave the capability on. The server configures both runtime renderers and reports the same
+setting through `/api/capabilities` to the browser.
 
-It is asked for rather than inherited, which is deliberate and unlike most switches here. This one
-decides whether a model may put code it wrote on somebody's screen and load libraries from a CDN to
-run it, so a deployment should choose it rather than acquire it by upgrading — including a deployment
-that builds its default branch automatically. Only `true` or `1` count as yes; anything else leaves it
-off.
+The component catalogue has separate per-Bot grants. Its sortable data table (`showTable`),
+interactive form (`askForm`), and other compiled or playground-authored components remain governed
+by those grants. In Admin → Playground, edit a draft and its sample arguments, preview it, then
+publish it for Bots to use. Only published code renders in conversations and the administrator's
+gallery; invalid JSON blocks saving and publishing.
 
-This is not the component catalogue. A component is something the deployment holds — compiled into
-the build or authored in the playground — and an administrator grants it per Bot. A generated
-interface has nothing to grant: it does not exist until the Bot writes it, and it is gone when the
-conversation moves on. That is also why this is one switch for the deployment rather than a grant per
-Bot. The interface is painted from activity events that only the runtime middleware emits, and the
-tool the model calls is registered by the browser for every Bot the moment that middleware runs, so
-enabling it for some Bots would leave the rest able to call the tool and draw nothing.
-
-The switch reaches both halves. The server passes `openGenerativeUI` to the runtime, and
-`/api/capabilities` reports the capability so the app offers the tool. The halves disagreeing is the
-one configuration worth avoiding: runtime-only means the tool is never offered, and browser-only
-means a Bot generates a whole interface that nothing renders.
-
-What a generated interface can reach is what the sandbox hands it, and this deployment hands it
-nothing — no session, no same-origin access to the app, no route into your data. It can load
-libraries from a CDN, which is the reason a deployment that must not reach the public internet from a
-browser tab should leave this unset.
+Generated HTML runs without the app's session or same-origin access to its data. It can load
+libraries from a CDN; deployments that prohibit that browser traffic can disable generated UI.
 
 **`AGENT_STALL_TIMEOUT_MS`** watches for the failure a Bot has that nothing else in the trail can
 show: a stream that stops producing anything. Every other audit row is something that happened, and

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -251,9 +251,8 @@ export type DeploymentConfig = {
    * Narrowing the middleware to some Bots would leave the rest able to call the tool and draw
    * nothing at all, which is a worse answer than never offering it.
    *
-   * Off until a deployment sets OPENBOT_GENERATIVE_UI. A capability that runs code a model wrote is
-   * one an operator should choose, not one they should discover after an upgrade — and a deployment
-   * that builds its default branch automatically would otherwise acquire it without a decision.
+   * On by default. A deployment that cannot allow generated interfaces can explicitly opt out with
+   * OPENBOT_GENERATIVE_UI=false or OPENBOT_GENERATIVE_UI=0.
    *
    * What it runs is sandboxed by the SDK, in an iframe with no same-origin access to this app, so a
    * generated interface reaches this deployment's data only through what the host hands it. This
@@ -900,16 +899,12 @@ function accessibilityEnabled(environment: Environment): boolean {
 /**
  * Whether a Bot may draw an interface it wrote itself.
  *
- * ASKED FOR, NOT INHERITED, which is the one place this deliberately breaks the symmetry with
- * OPENBOT_ACCESSIBILITY_DISABLED above it. That flag names a deployment out of an analytics label,
- * so defaulting it on costs a fork nothing it would mind. This one decides whether a model may put
- * code it wrote on somebody's screen and pull libraries from a CDN to run it. Written as a disable
- * switch, absence would be the permissive answer, and a deployment acquires the capability by
- * upgrading rather than by choosing it — which is exactly how a deployment that auto-deploys its
- * default branch would find out.
+ * Default-on, matching the product capability the browser can already render. Operators who cannot
+ * allow generated interfaces can explicitly opt out. `false` is the documented spelling and `0` is
+ * accepted alongside it as the conventional off value used by environment-driven switches.
  *
- * Only "true" or "1" turn it on. Anything else is not a way of saying yes, and a value nobody
- * intended should leave a capability off rather than on.
+ * Anything else leaves the capability on. A typo should not silently become an opt-out, and the
+ * capability must stay consistent between runtime and browser projection.
  *
  * The answer has to reach the browser as well as the runtime, which is why it ends up on
  * /api/capabilities rather than staying server-side. Enabling only the runtime half would leave the
@@ -917,8 +912,8 @@ function accessibilityEnabled(environment: Environment): boolean {
  * interface that nothing renders. See DeploymentConfig.generativeUi.
  */
 function generativeUiEnabled(environment: Environment): boolean {
-  const on = optional(environment, "OPENBOT_GENERATIVE_UI");
-  return on === "true" || on === "1";
+  const value = optional(environment, "OPENBOT_GENERATIVE_UI");
+  return value !== "false" && value !== "0";
 }
 
 /**

--- a/server/src/copilot.ts
+++ b/server/src/copilot.ts
@@ -2085,6 +2085,9 @@ export function mountCopilotRuntime(
      * has; see DeploymentConfig.generativeUi.
      */
     ...(config.generativeUi ? { openGenerativeUI: true } : {}),
+    // A browser catalog enables the public A2UI middleware/tool. Explicitly disable it on the
+    // server too, so stale clients cannot reactivate a deployment's generative UI opt-out.
+    a2ui: { enabled: config.generativeUi },
     // `identifyUser` is the Intelligence projection of the same person `identifyActor` returns:
     // one resolver decides both whose threads these are and whose coworkers exist.
     agents: createRequestAgents(

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -755,34 +755,31 @@ describe("accessibility", () => {
  * renders rather than merely leaving a capability on.
  */
 describe("generated interfaces", () => {
-  /*
-   * The default is the whole point of this block. Written as a disable switch, an upgrade would hand
-   * every existing deployment the ability to run code a model wrote, and a deployment that builds
-   * its default branch automatically would acquire it without anybody deciding to.
-   */
-  test("are off when nothing is set", () => {
-    expect(loadConfig(baseEnvironment).generativeUi).toBe(false);
+  test("are on when nothing is set", () => {
+    expect(loadConfig(baseEnvironment).generativeUi).toBe(true);
   });
 
-  test.each(["true", "1"])("are on for OPENBOT_GENERATIVE_UI=%p", (value) => {
+  test.each(["true", "1"])("stay on for OPENBOT_GENERATIVE_UI=%p", (value) => {
     expect(
       loadConfig({ ...baseEnvironment, OPENBOT_GENERATIVE_UI: value })
         .generativeUi,
     ).toBe(true);
   });
 
-  /*
-   * Anything else is not a way of saying yes. A value nobody intended — a stray "false", an empty
-   * variable left behind by a template — should leave the capability off, which is the direction
-   * that cannot surprise anybody.
-   */
-  test.each(["false", "no", "", "yes", "TRUE", "on"])(
-    "stay off for OPENBOT_GENERATIVE_UI=%p",
+  test.each(["false", "0"])("are off for OPENBOT_GENERATIVE_UI=%p", (value) => {
+    expect(
+      loadConfig({ ...baseEnvironment, OPENBOT_GENERATIVE_UI: value })
+        .generativeUi,
+    ).toBe(false);
+  });
+
+  test.each(["no", "", "yes", "TRUE", "on"])(
+    "stay on for OPENBOT_GENERATIVE_UI=%p",
     (value) => {
       expect(
         loadConfig({ ...baseEnvironment, OPENBOT_GENERATIVE_UI: value })
           .generativeUi,
-      ).toBe(false);
+      ).toBe(true);
     },
   );
 
@@ -794,7 +791,7 @@ describe("generated interfaces", () => {
         ...baseEnvironment,
         OPENBOT_GENERATIVE_UI_DISABLED: "false",
       }).generativeUi,
-    ).toBe(false);
+    ).toBe(true);
   });
 });
 

--- a/server/tests/health.test.ts
+++ b/server/tests/health.test.ts
@@ -26,9 +26,9 @@ describe("runtime capabilities", () => {
     await expect(response.json()).resolves.toEqual({
       mode: "intelligence",
       durableHistory: true,
-      // Off until a deployment asks for it. The browser reads this to decide whether to offer the
-      // tool that generates an interface, so it has to be here and not only in the runtime.
-      generativeUi: false,
+      // Default-on. The browser reads this to decide whether to offer the tool that generates an
+      // interface, so it has to be here and not only in the runtime.
+      generativeUi: true,
       // Names only. The sign-in screen reads this to know which buttons to draw.
       authProviders: ["google"],
       // A boolean, not a list: naming the registered providers would tell anybody who loads the
@@ -66,17 +66,17 @@ describe("runtime capabilities", () => {
    * to end up in: runtime-only means the tool is never offered, browser-only means a Bot writes a
    * whole interface that nothing renders.
    */
-  test("reports generated interfaces as on when the deployment asked for them", async () => {
-    const enabled = createApp(
-      loadConfig(testEnvironment({ OPENBOT_GENERATIVE_UI: "true" })),
+  test("reports generated interfaces as off when the deployment opts out", async () => {
+    const disabled = createApp(
+      loadConfig(testEnvironment({ OPENBOT_GENERATIVE_UI: "false" })),
     );
 
-    const response = await enabled.request(
+    const response = await disabled.request(
       "http://openbot.local/api/capabilities",
     );
 
     expect(response.status).toBe(200);
-    expect((await response.json()).generativeUi).toBe(true);
+    expect((await response.json()).generativeUi).toBe(false);
   });
 });
 

--- a/tests/compose.test.ts
+++ b/tests/compose.test.ts
@@ -52,6 +52,7 @@ function runLangGraphAguiModelProbe(
         "tools = ModuleType('src.tool_runtime')",
         "tools.ToolAwareAgent = LangGraphAgent",
         "tools.bind_tools = tools.execute_tools = tools.next_step = lambda *args: None",
+        "tools.model_messages = lambda messages: messages",
         "sys.modules['src.tool_runtime'] = tools",
         "from src import main",
         "chosen = main._model()",


### PR DESCRIPTION
## What this changes

Closes FOR-300.

S8 enables generated interfaces by default and carries graphical output through the selected Bot's AG-UI conversation. It adds sortable tables and validated forms, integrates the pinned public A2UI renderer (including actions back to the selected agent), and passes UI catalog context through the bundled Python/TypeScript harnesses.

The playground now rejects invalid JSON, confirms draft saves/publication, and renders published custom components in the admin gallery. Existing per-Bot component grants still apply. `OPENBOT_GENERATIVE_UI=false` or `0` disables generated HTML and A2UI.

## Where it runs

- No new durable store, port, listener, or schedule. Components use the existing database and publish mutations; conversations use existing Intelligence history and event fan-out.
- Harness catalog context is request-local and never enters checkpoints. Another replica receives the current run's context through AG-UI.
- A2UI actions use the channel's SDK agent instance and thread. They resume the selected Bot through the existing runtime ingress.

## Boundary and audit

- Existing gallery/custom-component grants and server decisions remain in place. Declarative A2UI actions resume the Bot; they do not gain a direct route to protected application operations.
- Published previews render sandboxed published source, never unpublished draft code. Draft/sample editing remains admin-only.

## Changelog

Added an Unreleased entry and updated configuration documentation.

## Proof

CI is green on `63b8eb38`, including 3,573 passing main-suite tests, Python harness regressions, build, types, lint, and final verification.

Visually exercised the candidate browser build and the installed Mac desktop shell against the real selected LangGraph agent and Intelligence service:

- Numeric table sorting; required form validation and submitted values acknowledged by the Bot.
- A2UI field edits and buttons: browser acknowledged Kyoto; native Mac acknowledged Oslo.
- Generated HTML counter clicked from 0 to 2 in both browser and Mac.
- Playground edit, preview, invalid-JSON rejection, save, publish, reopen, and agent invocation; published preview visible in the Mac admin gallery.
- Light/dark and narrower browser layouts; a new isolated browser context restored both A2UI cards and both generated HTML interfaces after later turns.

[Screenshots and validation evidence in FOR-300](https://linear.app/copilotkit/issue/FOR-300/openbot-s8-default-on-generative-ui-a2ui-gallery-tableform-and). The temporary authored fixture was deleted after validation.

Regression checks: 19 focused UI tests, 33 channel-history tests, 107 configuration/health tests, 14 TypeScript harness history tests, 13 Python AG-UI protocol tests, and 15 compose/provider probes passed. App/server/harness TypeScript checks, scoped Biome, frozen Bun lockfile verification, and the production app build passed. Existing native binary used; no OS-specific changes or native rebuild.

Companion [Intelligence #1233](https://github.com/CopilotKit/Intelligence/pull/1233) fixes the history API projection discrepancy tracked in FOR-301. AG-UI event replay restored the real app's graphical history in the fresh-session check; the companion fix makes the messages API retain those activities too.
