### PR TITLE
Read a message with a file attached as its words and the file, not as `[object Object]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Newest first. `Unreleased` is what is on `main` and not yet tagged.
 
 ## Unreleased
 
+### The Bot in the box and the LangGraph Bot read a message that has a file attached
+
+A message with a file attached reached both Bots as `[object Object],[object Object]`, in place of
+what the person typed and the file both: they read a message as a string, and one carrying a file is
+a list of parts. Each part now reaches the model as what it is — the words, the text of an attached
+file, an attached image — and a part neither can read is named rather than dropped.
+
 ### A malformed page size is refused instead of silently coerced
 
 `GET /channels` and `GET /api/admin/people` read `?limit=` with `Number.parseInt`, which

--- a/agent-bot/src/history.ts
+++ b/agent-bot/src/history.ts
@@ -8,6 +8,7 @@
 import type { RunAgentInput } from "@ag-ui/core";
 import type OpenAI from "openai";
 import { COMPUTER_GUIDANCE, NO_ANSWER_CAME } from "../../shared/bot-prompt";
+import { userContent } from "../../shared/user-content";
 
 export { NO_ANSWER_CAME };
 
@@ -58,7 +59,7 @@ export function toProviderMessages(
     // Placed with the call they answer, below, rather than wherever they arrived.
     if (message.role === "tool") continue;
     if (message.role === "user") {
-      messages.push({ role: "user", content: String(message.content ?? "") });
+      messages.push({ role: "user", content: userContent(message.content) });
       continue;
     }
     if (message.role === "system" || message.role === "developer") {

--- a/agent-bot/tests/history.test.ts
+++ b/agent-bot/tests/history.test.ts
@@ -279,3 +279,66 @@ describe("a tool call restored from the thread store", () => {
     expect(fn?.arguments).toBe('{"url":"https://news.ycombinator.com"}');
   });
 });
+
+/**
+ * A message somebody attached a file to.
+ *
+ * The composer sends it as a list of parts rather than a string: what the person typed, then the
+ * file. `copilot.ts` resolves the file before the run leaves the server, so a text file arrives here
+ * as a text part and an image as an `image` part carrying its bytes. `String()` of that list is
+ * `[object Object],[object Object]`, and that is what the model was sent in place of the question and
+ * the file both.
+ */
+describe("a message with a file attached", () => {
+  const typed = { type: "text", text: "How many rows say failed?" };
+  const csv = 'Attached file "runs.csv":\n\nid,status\n1,failed\n2,ok';
+
+  function userContent(content: unknown) {
+    const [user] = withoutGuidance(
+      toProviderMessages(
+        input([{ id: "1", role: "user", content } as unknown as Message]),
+      ),
+    );
+    return user?.content;
+  }
+
+  test("keeps what the person typed and the text of the file", () => {
+    expect(userContent([typed, { type: "text", text: csv }])).toEqual([
+      { type: "text", text: "How many rows say failed?" },
+      { type: "text", text: csv },
+    ]);
+  });
+
+  test("puts an attached image in front of the model", () => {
+    const image = {
+      type: "image",
+      source: { type: "data", value: "iVBORw0KGgo=", mimeType: "image/png" },
+      metadata: { attachmentId: "a1", filename: "chart.png" },
+    };
+    expect(userContent([typed, image])).toEqual([
+      { type: "text", text: "How many rows say failed?" },
+      {
+        type: "image_url",
+        image_url: { url: "data:image/png;base64,iVBORw0KGgo=" },
+      },
+    ]);
+  });
+
+  test("names a part it cannot read rather than dropping it", () => {
+    // A model told "[audio]" can say something was attached that it cannot hear. A model handed
+    // nothing answers as though nothing was attached.
+    const audio = {
+      type: "audio",
+      source: { type: "data", value: "UklGRg==", mimeType: "audio/wav" },
+    };
+    expect(userContent([typed, audio])).toEqual([
+      { type: "text", text: "How many rows say failed?" },
+      { type: "text", text: "[audio]" },
+    ]);
+  });
+
+  test("sends a message that is only text exactly as it was typed", () => {
+    // Nearly every message. Unchanged by this, and pinned so it stays that way.
+    expect(userContent("What is 17 times 3?")).toBe("What is 17 times 3?");
+  });
+});

--- a/agent-langgraph/src/history.ts
+++ b/agent-langgraph/src/history.ts
@@ -14,6 +14,7 @@ import {
   ToolMessage,
 } from "@langchain/core/messages";
 import { COMPUTER_GUIDANCE, NO_ANSWER_CAME } from "../../shared/bot-prompt";
+import { userContent } from "../../shared/user-content";
 
 /*
  * Re-exported so this module's own tests and callers keep reading it from here, while the wording
@@ -57,7 +58,9 @@ export function toLangChainMessages(input: RunAgentInput): BaseMessage[] {
 
   for (const message of input.messages) {
     if (message.role === "user") {
-      messages.push(new HumanMessage(String(message.content ?? "")));
+      messages.push(
+        new HumanMessage({ content: userContent(message.content) }),
+      );
       continue;
     }
     if (message.role === "system" || message.role === "developer") {

--- a/agent-langgraph/tests/history.test.ts
+++ b/agent-langgraph/tests/history.test.ts
@@ -139,3 +139,62 @@ describe("history with a tool call nobody answered", () => {
     expect(byId.get("orphan")).toBe(NO_ANSWER_CAME);
   });
 });
+
+/**
+ * A message somebody attached a file to.
+ *
+ * The composer sends it as a list of parts rather than a string: what the person typed, then the
+ * file. `copilot.ts` resolves the file before the run leaves the server, so a text file arrives here
+ * as a text part and an image as an `image` part carrying its bytes. `String()` of that list is
+ * `[object Object],[object Object]`, and that is what the model was sent in place of the question and
+ * the file both.
+ */
+describe("a message with a file attached", () => {
+  const typed = { type: "text", text: "How many rows say failed?" };
+  const csv = 'Attached file "runs.csv":\n\nid,status\n1,failed\n2,ok';
+
+  function userContent(content: unknown) {
+    return toLangChainMessages(input([{ role: "user", content }])).at(-1)
+      ?.content;
+  }
+
+  test("keeps what the person typed and the text of the file", () => {
+    expect(userContent([typed, { type: "text", text: csv }])).toEqual([
+      { type: "text", text: "How many rows say failed?" },
+      { type: "text", text: csv },
+    ]);
+  });
+
+  test("puts an attached image in front of the model", () => {
+    const image = {
+      type: "image",
+      source: { type: "data", value: "iVBORw0KGgo=", mimeType: "image/png" },
+      metadata: { attachmentId: "a1", filename: "chart.png" },
+    };
+    expect(userContent([typed, image])).toEqual([
+      { type: "text", text: "How many rows say failed?" },
+      {
+        type: "image_url",
+        image_url: { url: "data:image/png;base64,iVBORw0KGgo=" },
+      },
+    ]);
+  });
+
+  test("names a part it cannot read rather than dropping it", () => {
+    // A model told "[audio]" can say something was attached that it cannot hear. A model handed
+    // nothing answers as though nothing was attached.
+    const audio = {
+      type: "audio",
+      source: { type: "data", value: "UklGRg==", mimeType: "audio/wav" },
+    };
+    expect(userContent([typed, audio])).toEqual([
+      { type: "text", text: "How many rows say failed?" },
+      { type: "text", text: "[audio]" },
+    ]);
+  });
+
+  test("sends a message that is only text exactly as it was typed", () => {
+    // Nearly every message. Unchanged by this, and pinned so it stays that way.
+    expect(userContent("What is 17 times 3?")).toBe("What is 17 times 3?");
+  });
+});

--- a/shared/user-content.ts
+++ b/shared/user-content.ts
@@ -1,0 +1,51 @@
+/**
+ * What a person said, in the shape a chat model reads. Read by both Bots.
+ *
+ * A message is a string until somebody attaches a file. Then the composer sends a list of parts —
+ * what the person typed, then the file — and `copilot.ts` resolves each file before the run leaves
+ * the server: a text file becomes a text part carrying its contents, an image an `image` part
+ * carrying its bytes. Both Bots read `content` with `String()`, which for that list is
+ * `[object Object],[object Object]`, so that is what the model was sent in place of the question and
+ * the file both.
+ *
+ * ONE DECLARATION FOR BOTH BOTS, for the reason `bot-prompt.ts` gives for `NO_ANSWER_CAME`. The two
+ * shapes returned are the ones OpenAI's chat completions take, and LangChain's OpenAI, Anthropic and
+ * Google converters read the same two blocks, so one answer serves `agent-bot` and `agent-langgraph`
+ * alike and the two cannot drift.
+ *
+ * A part neither shape can carry is NAMED, not dropped, which is the rule `resultText` in
+ * `server/src/plugins/mcp.ts` follows for a tool result: a model told "[audio]" can say something was
+ * attached that it cannot hear, and a model handed nothing answers as though nothing was attached.
+ */
+export type UserContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } };
+
+export function userContent(content: unknown): string | UserContentPart[] {
+  if (!Array.isArray(content)) return String(content ?? "");
+  return content.map((part): UserContentPart => {
+    const item = (part ?? {}) as {
+      type?: unknown;
+      text?: unknown;
+      source?: { type?: unknown; value?: unknown; mimeType?: unknown } | null;
+    };
+    if (item.type === "text" && typeof item.text === "string") {
+      return { type: "text", text: item.text };
+    }
+    const source = item.source;
+    if (
+      item.type === "image" &&
+      source?.type === "data" &&
+      typeof source.value === "string" &&
+      typeof source.mimeType === "string"
+    ) {
+      return {
+        type: "image_url",
+        image_url: { url: `data:${source.mimeType};base64,${source.value}` },
+      };
+    }
+    const name =
+      typeof item.type === "string" && item.type ? item.type : "unknown";
+    return { type: "text", text: `[${name}]` };
+  });
+}


### PR DESCRIPTION
## What happens

Attach a file to a message in a channel whose coworker is the Bot in the box (`agent-bot`) or the LangGraph Bot (`agent-langgraph`), and ask about it:

> How many rows say failed? *(runs.csv attached)*

The Bot answers as though it was asked nothing, because what its model was sent is:

```
[object Object],[object Object]
```

That string is in place of the question **and** the file. An image goes the same way.

## Why

With no file attached, the composer sends a message as a string. With one attached, it sends a list of parts: what the person typed, then the file (`channel-chat.tsx`). The server resolves each file before the run leaves it. `inlineAttachments` in `copilot.ts` turns a text file into a text part carrying its contents, and an image into an `image` part with a `data` source. That comment says the reason it is done in the remote Bot's middleware is so a file does not reach the endpoint as a URL it cannot fetch.

Both Bots then read the message like this:

```ts
// agent-bot/src/history.ts
messages.push({ role: "user", content: String(message.content ?? "") });

// agent-langgraph/src/history.ts
messages.push(new HumanMessage(String(message.content ?? "")));
```

`String()` of an array of objects is `[object Object],[object Object]`. So the file arrives intact at the Bot, and the Bot's last step throws it away along with the words beside it.

Run against `main`, with the exact content shape `inlineAttachments` produces (typed text, a CSV's text, a PNG):

```
agent-bot user message content: "[object Object],[object Object],[object Object]"
agent-langgraph user message content: "[object Object],[object Object],[object Object]"
```

Built-in Bots are not affected. The runtime converts their content itself.

## The change

One function, `shared/user-content.ts`, read by both Bots, for the reason `NO_ANSWER_CAME` lives in `shared/`: two copies of this would drift. It maps each part to the two content blocks both providers read:

- a text part → `{ type: "text", text }`, verbatim;
- an image with a `data` source → `{ type: "image_url", image_url: { url: "data:<mime>;base64,<bytes>" } }`;
- anything else → a text part naming it, e.g. `[audio]`. It is named rather than dropped, for the reason `resultText` in `plugins/mcp.ts` names a tool part it cannot read. A model told something was attached can say it cannot see it. A model handed nothing answers as though nothing was attached.

Those two block shapes are what OpenAI chat completions take. They are also what `@langchain/openai`, `@langchain/anthropic` and `@langchain/google-genai` each convert (each has an `image_url` branch that accepts a base64 data URL), so the LangGraph Bot works on all three of its providers.

A message that is a string, which is nearly every message, is returned exactly as before.

## Where it runs

- **New state that outlives a request?** None. A pure function of the message.
- **Second replica?** No difference. Nothing is held.
- **Serialised / fanned out / new listener?** None.

## Boundary and audit

Untouched. No acting call, refusal or audit row is involved. This is the last step of turning a run's input into the model's prompt.

## Changelog

A line under `Unreleased`, because a Bot that could not read an attached file now can.

## Proof

`bun test tests/history.test.ts` in each Bot, on `main` with only this PR's tests applied (absolute paths shortened to the repository root, nothing else edited):

<details><summary><code>agent-bot</code>: 10 pass, 3 fail</summary>

```
bun test v1.3.14 (0d9b296a)

tests\history.test.ts:
301 |     );
302 |     return user?.content;
303 |   }
304 | 
305 |   test("keeps what the person typed and the text of the file", () => {
306 |     expect(userContent([typed, { type: "text", text: csv }])).toEqual([
                                                                    ^
error: expect(received).toEqual(expected)

- [
-   {
-     "text": "How many rows say failed?",
-     "type": "text",
-   },
-   {
-     "text": 
- "Attached file "runs.csv":
- 
- id,status
- 1,failed
- 2,ok"
- ,
-     "type": "text",
-   },
- ]
+ "[object Object],[object Object]"

- Expected  - 16
+ Received  + 1

      at <anonymous> (agent-bot\tests\history.test.ts:306:63)
(fail) a message with a file attached > keeps what the person typed and the text of the file [1.38ms]
313 |     const image = {
314 |       type: "image",
315 |       source: { type: "data", value: "iVBORw0KGgo=", mimeType: "image/png" },
316 |       metadata: { attachmentId: "a1", filename: "chart.png" },
317 |     };
318 |     expect(userContent([typed, image])).toEqual([
                                              ^
error: expect(received).toEqual(expected)

- [
-   {
-     "text": "How many rows say failed?",
-     "type": "text",
-   },
-   {
-     "image_url": {
-       "url": "data:image/png;base64,iVBORw0KGgo=",
-     },
-     "type": "image_url",
-   },
- ]
+ "[object Object],[object Object]"

- Expected  - 12
+ Received  + 1

      at <anonymous> (agent-bot\tests\history.test.ts:318:41)
(fail) a message with a file attached > puts an attached image in front of the model [0.36ms]
329 |     // nothing answers as though nothing was attached.
330 |     const audio = {
331 |       type: "audio",
332 |       source: { type: "data", value: "UklGRg==", mimeType: "audio/wav" },
333 |     };
334 |     expect(userContent([typed, audio])).toEqual([
                                              ^
error: expect(received).toEqual(expected)

- [
-   {
-     "text": "How many rows say failed?",
-     "type": "text",
-   },
-   {
-     "text": "[audio]",
-     "type": "text",
-   },
- ]
+ "[object Object],[object Object]"

- Expected  - 10
+ Received  + 1

      at <anonymous> (agent-bot\tests\history.test.ts:334:41)
(fail) a message with a file attached > names a part it cannot read rather than dropping it [0.23ms]

 10 pass
 3 fail
 22 expect() calls
Ran 13 tests across 1 file. [33.00ms]
```

</details>

<details><summary><code>agent-langgraph</code>: 6 pass, 3 fail (the same three, against LangChain's message)</summary>

```
(fail) a message with a file attached > keeps what the person typed and the text of the file [1.38ms]
(fail) a message with a file attached > puts an attached image in front of the model [0.50ms]
(fail) a message with a file attached > names a part it cannot read rather than dropping it [0.25ms]

 6 pass
 3 fail
 14 expect() calls
Ran 9 tests across 1 file.
```

Each failure's received value is `"[object Object],[object Object]"`, identical to the `agent-bot` output above.

</details>

With the change: **`agent-bot` 13 pass, 0 fail**, **`agent-langgraph` 9 pass, 0 fail**.

**Not a widening.** In each file the fourth test, `sends a message that is only text exactly as it was typed`, passes both before and after. It pins that a string message is returned verbatim, so the only messages this changes are the ones carrying parts. Every test that was already in both files (tool-call pairing, out-of-order results, restored calls, A2UI context) passes before and after.

Whole packages (`bun test` in each Bot directory):

| | `main` | this PR |
|---|---|---|
| `agent-bot` | 12 pass, 0 fail | 16 pass, 0 fail |
| `agent-langgraph` | 29 pass, 0 fail | 33 pass, 0 fail |

The delta is exactly the four tests added to each.

`bunx @biomejs/biome check` and `bunx prettier --check` are clean on the five TypeScript files. `prettier --check CHANGELOG.md` reports style issues, but it does on `main` too: every suggestion is a missing blank line further down the file, none in the lines added here, so I have left that file's existing formatting alone.

## Note on the CHANGELOG

The entry goes at the top of `## Unreleased`, the one line every entry goes at, so it will conflict with any other PR open against that anchor. Happy to rebase whenever it suits you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
